### PR TITLE
nameof operator instead of hard-coded names

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageReceiver.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.ServiceBus
         {
             if (lockTokens == null || !lockTokens.Any())
             {
-                throw Fx.Exception.ArgumentNull("lockTokens");
+                throw Fx.Exception.ArgumentNull(nameof(lockTokens));
             }
         }
 

--- a/src/Microsoft.Azure.ServiceBus/MessageSender.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageSender.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.ServiceBus
         {
             if (brokeredMessages == null || !brokeredMessages.Any())
             {
-                throw Fx.Exception.ArgumentNull("brokeredMessages");
+                throw Fx.Exception.ArgumentNull(nameof(brokeredMessages));
             }
 
             if (brokeredMessages.Any(brokeredMessage => brokeredMessage.IsLockTokenSet))

--- a/src/Microsoft.Azure.ServiceBus/Primitives/DataContractBinarySerializer.cs
+++ b/src/Microsoft.Azure.ServiceBus/Primitives/DataContractBinarySerializer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.ServiceBus.Primitives
         {
             if (stream == null)
             {
-                throw Fx.Exception.ArgumentNull("stream");
+                throw Fx.Exception.ArgumentNull(nameof(stream));
             }
 
             return this.ReadObject(XmlDictionaryReader.CreateBinaryReader(stream, XmlDictionaryReaderQuotas.Max));
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.ServiceBus.Primitives
         {
             if (stream == null)
             {
-                throw Fx.Exception.ArgumentNull("stream");
+                throw Fx.Exception.ArgumentNull(nameof(stream));
             }
 
             XmlDictionaryWriter writer = XmlDictionaryWriter.CreateBinaryWriter(stream, null, null, false);
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.ServiceBus.Primitives
         {
             if (writer == null)
             {
-                throw Fx.Exception.ArgumentNull("writer");
+                throw Fx.Exception.ArgumentNull(nameof(writer));
             }
 
             this.dataContractSerializer.WriteObject(writer, graph);

--- a/src/Microsoft.Azure.ServiceBus/Primitives/Fx.cs
+++ b/src/Microsoft.Azure.ServiceBus/Primitives/Fx.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.ServiceBus
 
                     if (elementType == null)
                     {
-                        throw Fx.Exception.ArgumentNull("elementType");
+                        throw Fx.Exception.ArgumentNull(nameof(elementType));
                     }
 
                     this.elementType = elementType;
@@ -193,7 +193,7 @@ namespace Microsoft.Azure.ServiceBus
 
                     if (elementType == null)
                     {
-                        throw Fx.Exception.ArgumentNull("elementType");
+                        throw Fx.Exception.ArgumentNull(nameof(elementType));
                     }
 
                     this.elementType = elementType;
@@ -311,7 +311,7 @@ namespace Microsoft.Azure.ServiceBus
                     {
                         if (exceptionType == null)
                         {
-                            throw Fx.Exception.ArgumentNull("exceptionType");
+                            throw Fx.Exception.ArgumentNull(nameof(exceptionType));
                         }
                         if (string.IsNullOrEmpty(diagnosis))
                         {

--- a/src/Microsoft.Azure.ServiceBus/Primitives/TimeoutHelper.cs
+++ b/src/Microsoft.Azure.ServiceBus/Primitives/TimeoutHelper.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.ServiceBus
 
         public static void ThrowIfNegativeArgument(TimeSpan timeout)
         {
-            ThrowIfNegativeArgument(timeout, "timeout");
+            ThrowIfNegativeArgument(timeout, nameof(timeout));
         }
 
         public static void ThrowIfNegativeArgument(TimeSpan timeout, string argumentName)
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.ServiceBus
 
         public static void ThrowIfNonPositiveArgument(TimeSpan timeout)
         {
-            ThrowIfNonPositiveArgument(timeout, "timeout");
+            ThrowIfNonPositiveArgument(timeout, nameof(timeout));
         }
 
         public static void ThrowIfNonPositiveArgument(TimeSpan timeout, string argumentName)


### PR DESCRIPTION
Fixed a few places where argument names were hard-coded

@azure/azure-service-bus-write please review