### PR TITLE
Fix regression introduced in Sendpath because of an earlier checkin

### DIFF
--- a/test/Microsoft.Azure.ServiceBus.UnitTests/TestUtility.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/TestUtility.cs
@@ -75,6 +75,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 }
             }
 
+            VerifyUniqueMessages(messagesToReturn);
             Log($"Received {messagesToReturn.Count} messages");
             return messagesToReturn;
         }
@@ -100,6 +101,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 }
             }
 
+            VerifyUniqueMessages(peekedMessages);
             Log($"Peeked {peekedMessages.Count} messages");
             return peekedMessages;
         }
@@ -126,6 +128,21 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         {
             await messageReceiver.DeferAsync(messages.Select(message => message.LockToken));
             Log($"Deferred {messages.Count()} messages");
+        }
+
+        static void VerifyUniqueMessages(List<BrokeredMessage> messages)
+        {
+            if (messages != null && messages.Count > 1)
+            {
+                HashSet<long> sequenceNumbers = new HashSet<long>();
+                foreach (var message in messages)
+                {
+                    if (!sequenceNumbers.Add(message.SequenceNumber))
+                    {
+                        throw new Exception($"Sequence Number '{message.SequenceNumber}' was repeated");
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
<!--
Fix regression introduced in Sendpath because of an earlier checkin. Basically the regression was introduced with this commit, which caused a One-Off Error. 
https://github.com/Azure/azure-service-bus-dotnet/commit/333073a29a08e965ee008551a2dd25f207fac933

Fixed that and also made some small changes to flow to make it more easier to read. Also made changes in the test to catch those errors.
-->

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [X] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [X] If applicable, the public code is properly documented.
- [X] Pull request includes test coverage for the included changes.
- [X] The code builds without any errors.