### PR TITLE
Cleanups

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpConnectionHelper.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpConnectionHelper.cs
@@ -26,11 +26,13 @@ namespace Microsoft.Azure.ServiceBus.Amqp
             AmqpSettings settings = new AmqpSettings();
             if (useSslStreamSecurity && !useWebSockets && sslStreamUpgrade)
             {
-                TlsTransportSettings tlsSettings = new TlsTransportSettings();
-                tlsSettings.CertificateValidationCallback = certificateValidationCallback;
-                tlsSettings.TargetHost = sslHostName;
+                var tlsSettings = new TlsTransportSettings
+                {
+                    CertificateValidationCallback = certificateValidationCallback,
+                    TargetHost = sslHostName
+                };
 
-                TlsTransportProvider tlsProvider = new TlsTransportProvider(tlsSettings);
+                var tlsProvider = new TlsTransportProvider(tlsSettings);
                 tlsProvider.Versions.Add(new AmqpVersion(amqpVersion));
                 settings.TransportProviders.Add(tlsProvider);
             }
@@ -47,9 +49,11 @@ namespace Microsoft.Azure.ServiceBus.Amqp
                 }
                 else if (networkCredential != null)
                 {
-                    SaslPlainHandler plainHandler = new SaslPlainHandler();
-                    plainHandler.AuthenticationIdentity = networkCredential.UserName;
-                    plainHandler.Password = networkCredential.Password;
+                    var plainHandler = new SaslPlainHandler
+                    {
+                        AuthenticationIdentity = networkCredential.UserName,
+                        Password = networkCredential.Password
+                    };
                     saslProvider.AddHandler(plainHandler);
                 }
                 else

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
@@ -20,13 +20,10 @@ namespace Microsoft.Azure.ServiceBus.Amqp
         const string ScheduledEnqueueTimeUtcName = "x-opt-scheduled-enqueue-time";
         const string SequenceNumberName = "x-opt-sequence-number";
         const string OffsetName = "x-opt-offset";
-        const string LockTokenName = "x-opt-lock-token";
         const string LockedUntilName = "x-opt-locked-until";
         const string PublisherName = "x-opt-publisher";
         const string PartitionKeyName = "x-opt-partition-key";
         const string PartitionIdName = "x-opt-partition-id";
-        const string PrefilteredMessageHeadersName = "x-opt-prefiltered-headers";
-        const string PrefilteredMessagePropertiesName = "x-opt-prefiltered-properties";
         const string DeadLetterSourceName = "x-opt-deadletter-source";
         const string TimeSpanName = AmqpConstants.Vendor + ":timespan";
         const string UriName = AmqpConstants.Vendor + ":uri";

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
@@ -16,21 +16,21 @@ namespace Microsoft.Azure.ServiceBus.Amqp
 
     static class AmqpMessageConverter
     {
-        private const string EnqueuedTimeUtcName = "x-opt-enqueued-time";
-        private const string ScheduledEnqueueTimeUtcName = "x-opt-scheduled-enqueue-time";
-        private const string SequenceNumberName = "x-opt-sequence-number";
-        private const string OffsetName = "x-opt-offset";
-        private const string LockTokenName = "x-opt-lock-token";
-        private const string LockedUntilName = "x-opt-locked-until";
-        private const string PublisherName = "x-opt-publisher";
-        private const string PartitionKeyName = "x-opt-partition-key";
-        private const string PartitionIdName = "x-opt-partition-id";
-        private const string PrefilteredMessageHeadersName = "x-opt-prefiltered-headers";
-        private const string PrefilteredMessagePropertiesName = "x-opt-prefiltered-properties";
-        private const string DeadLetterSourceName = "x-opt-deadletter-source";
-        private const string TimeSpanName = AmqpConstants.Vendor + ":timespan";
-        private const string UriName = AmqpConstants.Vendor + ":uri";
-        private const string DateTimeOffsetName = AmqpConstants.Vendor + ":datetime-offset";
+        const string EnqueuedTimeUtcName = "x-opt-enqueued-time";
+        const string ScheduledEnqueueTimeUtcName = "x-opt-scheduled-enqueue-time";
+        const string SequenceNumberName = "x-opt-sequence-number";
+        const string OffsetName = "x-opt-offset";
+        const string LockTokenName = "x-opt-lock-token";
+        const string LockedUntilName = "x-opt-locked-until";
+        const string PublisherName = "x-opt-publisher";
+        const string PartitionKeyName = "x-opt-partition-key";
+        const string PartitionIdName = "x-opt-partition-id";
+        const string PrefilteredMessageHeadersName = "x-opt-prefiltered-headers";
+        const string PrefilteredMessagePropertiesName = "x-opt-prefiltered-properties";
+        const string DeadLetterSourceName = "x-opt-deadletter-source";
+        const string TimeSpanName = AmqpConstants.Vendor + ":timespan";
+        const string UriName = AmqpConstants.Vendor + ":uri";
+        const string DateTimeOffsetName = AmqpConstants.Vendor + ":datetime-offset";
         const int GuidSize = 16;
 
         public static AmqpMessage BrokeredMessagesToAmqpMessage(IEnumerable<BrokeredMessage> brokeredMessages, bool batchable)

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
@@ -16,26 +16,26 @@ namespace Microsoft.Azure.ServiceBus.Amqp
 
     static class AmqpMessageConverter
     {
-        public const string EnqueuedTimeUtcName = "x-opt-enqueued-time";
-        public const string ScheduledEnqueueTimeUtcName = "x-opt-scheduled-enqueue-time";
-        public const string SequenceNumberName = "x-opt-sequence-number";
-        public const string OffsetName = "x-opt-offset";
-        public const string LockTokenName = "x-opt-lock-token";
-        public const string LockedUntilName = "x-opt-locked-until";
-        public const string PublisherName = "x-opt-publisher";
-        public const string PartitionKeyName = "x-opt-partition-key";
-        public const string PartitionIdName = "x-opt-partition-id";
-        public const string PrefilteredMessageHeadersName = "x-opt-prefiltered-headers";
-        public const string PrefilteredMessagePropertiesName = "x-opt-prefiltered-properties";
-        public const string DeadLetterSourceName = "x-opt-deadletter-source";
-        public const string TimeSpanName = AmqpConstants.Vendor + ":timespan";
-        public const string UriName = AmqpConstants.Vendor + ":uri";
-        public const string DateTimeOffsetName = AmqpConstants.Vendor + ":datetime-offset";
+        private const string EnqueuedTimeUtcName = "x-opt-enqueued-time";
+        private const string ScheduledEnqueueTimeUtcName = "x-opt-scheduled-enqueue-time";
+        private const string SequenceNumberName = "x-opt-sequence-number";
+        private const string OffsetName = "x-opt-offset";
+        private const string LockTokenName = "x-opt-lock-token";
+        private const string LockedUntilName = "x-opt-locked-until";
+        private const string PublisherName = "x-opt-publisher";
+        private const string PartitionKeyName = "x-opt-partition-key";
+        private const string PartitionIdName = "x-opt-partition-id";
+        private const string PrefilteredMessageHeadersName = "x-opt-prefiltered-headers";
+        private const string PrefilteredMessagePropertiesName = "x-opt-prefiltered-properties";
+        private const string DeadLetterSourceName = "x-opt-deadletter-source";
+        private const string TimeSpanName = AmqpConstants.Vendor + ":timespan";
+        private const string UriName = AmqpConstants.Vendor + ":uri";
+        private const string DateTimeOffsetName = AmqpConstants.Vendor + ":datetime-offset";
         const int GuidSize = 16;
 
         public static AmqpMessage BrokeredMessagesToAmqpMessage(IEnumerable<BrokeredMessage> brokeredMessages, bool batchable)
         {
-            AmqpMessage amqpMessage = null;
+            AmqpMessage amqpMessage;
             AmqpMessage firstAmqpMessage = null;
             BrokeredMessage firstBrokeredMessage = null;
             List<Data> dataList = null;

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageReceiver.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
             TimeoutHelper timeoutHelper = new TimeoutHelper(serverWaitTime, true);
             ReceivingAmqpLink receivingAmqpLink = await this.ReceiveLinkManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             Source source = (Source)receivingAmqpLink.Settings.Source;
-            if (!source.FilterSet.TryGetValue<string>(AmqpClientConstants.SessionFilterName, out this.sessionId))
+            if (!source.FilterSet.TryGetValue(AmqpClientConstants.SessionFilterName, out this.sessionId))
             {
                 receivingAmqpLink.Session.SafeClose();
                 throw new ServiceBusException(false, Resources.AmqpFieldSessionId);
@@ -280,7 +280,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
 
         protected override async Task OnCompleteAsync(IEnumerable<Guid> lockTokens)
         {
-            if (lockTokens.Any((lt) => this.requestResponseLockedMessages.Contains(lt)))
+                if (lockTokens.Any(lt => this.requestResponseLockedMessages.Contains(lt)))
             {
                 await this.DisposeMessageRequestResponseAsync(lockTokens, DispositionStatus.Completed).ConfigureAwait(false);
             }
@@ -292,7 +292,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
 
         protected override async Task OnAbandonAsync(IEnumerable<Guid> lockTokens)
         {
-            if (lockTokens.Any((lt) => this.requestResponseLockedMessages.Contains(lt)))
+                if (lockTokens.Any(lt => this.requestResponseLockedMessages.Contains(lt)))
             {
                 await this.DisposeMessageRequestResponseAsync(lockTokens, DispositionStatus.Abandoned).ConfigureAwait(false);
             }
@@ -304,7 +304,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
 
         protected override async Task OnDeferAsync(IEnumerable<Guid> lockTokens)
         {
-            if (lockTokens.Any((lt) => this.requestResponseLockedMessages.Contains(lt)))
+                if (lockTokens.Any(lt => this.requestResponseLockedMessages.Contains(lt)))
             {
                 await this.DisposeMessageRequestResponseAsync(lockTokens, DispositionStatus.Defered).ConfigureAwait(false);
             }
@@ -316,7 +316,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
 
         protected override async Task OnDeadLetterAsync(IEnumerable<Guid> lockTokens)
         {
-            if (lockTokens.Any((lt) => this.requestResponseLockedMessages.Contains(lt)))
+                if (lockTokens.Any(lt => this.requestResponseLockedMessages.Contains(lt)))
             {
                 await this.DisposeMessageRequestResponseAsync(lockTokens, DispositionStatus.Suspended).ConfigureAwait(false);
             }
@@ -333,7 +333,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
             {
                 // Create an AmqpRequest Message to renew  lock
                 AmqpRequestMessage requestMessage = AmqpRequestMessage.CreateRequest(ManagementConstants.Operations.RenewLockOperation, this.OperationTimeout, null);
-                requestMessage.Map[ManagementConstants.Properties.LockTokens] = new Guid[] { lockToken };
+                requestMessage.Map[ManagementConstants.Properties.LockTokens] = new[] { lockToken };
 
                 AmqpResponseMessage response = await this.ExecuteRequestResponseAsync(requestMessage).ConfigureAwait(false);
 

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageSender.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageSender.cs
@@ -147,7 +147,13 @@ namespace Microsoft.Azure.ServiceBus.Amqp
                     null);
             request.Map[ManagementConstants.Properties.SequenceNumbers] = new[] { sequenceNumber };
 
-            await this.ExecuteRequestResponseAsync(request);
+            var response = await this.ExecuteRequestResponseAsync(request);
+
+            // TODO: no idea what code and exception should be thrown, but the should be
+            if (response.StatusCode != AmqpResponseStatusCode.OK)
+            {
+                // throw
+            }
         }
 
         ArraySegment<byte> GetNextDeliveryTag()

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageSender.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageSender.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
                     null);
             request.Map[ManagementConstants.Properties.SequenceNumbers] = new[] { sequenceNumber };
 
-            var response = await this.ExecuteRequestResponseAsync(request);
+            await this.ExecuteRequestResponseAsync(request);
         }
 
         ArraySegment<byte> GetNextDeliveryTag()

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageSender.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageSender.cs
@@ -147,12 +147,11 @@ namespace Microsoft.Azure.ServiceBus.Amqp
                     null);
             request.Map[ManagementConstants.Properties.SequenceNumbers] = new[] { sequenceNumber };
 
-            var response = await this.ExecuteRequestResponseAsync(request);
+            var response = await this.ExecuteRequestResponseAsync(request).ConfigureAwait(false);
 
-            // TODO: no idea what code and exception should be thrown, but the should be
             if (response.StatusCode != AmqpResponseStatusCode.OK)
             {
-                // throw
+                throw response.ToMessagingContractException();
             }
         }
 

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpSubscriptionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpSubscriptionClient.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
                 amqpRequestMessage.Map[ManagementConstants.Properties.RuleName] = ruleName;
 
                 var response = await ((AmqpMessageReceiver)this.InnerReceiver).ExecuteRequestResponseAsync(amqpRequestMessage).ConfigureAwait(false);
-                
+
                 if (response.StatusCode != AmqpResponseStatusCode.OK)
                 {
                     throw response.ToMessagingContractException();

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpSubscriptionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpSubscriptionClient.cs
@@ -108,11 +108,8 @@ namespace Microsoft.Azure.ServiceBus.Amqp
                         null);
                 amqpRequestMessage.Map[ManagementConstants.Properties.RuleName] = ruleName;
 
-                AmqpResponseMessage response =
-                    await
-                        ((AmqpMessageReceiver)this.InnerReceiver).ExecuteRequestResponseAsync(amqpRequestMessage)
-                            .ConfigureAwait(false);
-
+                var response = await ((AmqpMessageReceiver)this.InnerReceiver).ExecuteRequestResponseAsync(amqpRequestMessage).ConfigureAwait(false);
+                
                 if (response.StatusCode != AmqpResponseStatusCode.OK)
                 {
                     throw response.ToMessagingContractException();

--- a/src/Microsoft.Azure.ServiceBus/BrokeredMessage.cs
+++ b/src/Microsoft.Azure.ServiceBus/BrokeredMessage.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Azure.ServiceBus
         }
 
         [Flags]
-        internal enum MessageMembers : int
+        internal enum MessageMembers
         {
             // public get/set members
             MessageId = 1,
@@ -572,7 +572,7 @@ namespace Microsoft.Azure.ServiceBus
 
                 if (value == DateTime.MaxValue)
                 {
-                    throw Fx.Exception.AsError(new ArgumentOutOfRangeException("ScheduledEnqueueTimeUtc"));
+                    throw Fx.Exception.AsError(new ArgumentOutOfRangeException(nameof(this.ScheduledEnqueueTimeUtc)));
                 }
 
                 this.initializedMembers |= MessageMembers.ScheduledEnqueueTimeUtc;
@@ -718,7 +718,7 @@ namespace Microsoft.Azure.ServiceBus
             {
                 if (value < 0)
                 {
-                    throw Fx.Exception.AsError(new ArgumentOutOfRangeException("PartitionId"));
+                    throw Fx.Exception.AsError(new ArgumentOutOfRangeException(nameof(this.PartitionId)));
                 }
 
                 this.ThrowIfDisposed();
@@ -742,7 +742,7 @@ namespace Microsoft.Azure.ServiceBus
             set
             {
                 this.ThrowIfDisposed();
-                BrokeredMessage.ValidatePartitionKey("Publisher", value);
+                BrokeredMessage.ValidatePartitionKey(nameof(this.Publisher), value);
                 if (value != null)
                 {
                     this.ThrowIfDominatingPropertyIsNotEqualToNonNullDormantProperty(MessageMembers.Publisher, MessageMembers.PartitionKey, value, this.partitionKey);
@@ -828,13 +828,7 @@ namespace Microsoft.Azure.ServiceBus
 
         /// <summary> Gets a value indicating whether this object is lock token set. </summary>
         /// <value> true if this object is lock token set, false if not. </value>
-        internal bool IsLockTokenSet
-        {
-            get
-            {
-                return (this.initializedMembers & MessageMembers.LockToken) != 0;
-            }
-        }
+        internal bool IsLockTokenSet => (this.initializedMembers & MessageMembers.LockToken) != 0;
 
         /// <summary> Gets the identifier of the body. </summary>
         /// <value> The identifier of the body. </value>
@@ -1061,13 +1055,13 @@ namespace Microsoft.Azure.ServiceBus
                 return null;
             }
 
-            List<IDisposable> clonedDisposables = new List<IDisposable>();
+            var clonedDisposables = new List<IDisposable>();
             foreach (IDisposable obj in disposables)
             {
-                ICloneable cloneable = obj as ICloneable;
+                var cloneable = obj as ICloneable;
                 if (cloneable != null)
                 {
-                    object clone = cloneable.Clone();
+                    var clone = cloneable.Clone();
                     Fx.Assert(clone is IDisposable, "cloned object must also implement IDisposable");
                     clonedDisposables.Add((IDisposable)clone);
                 }
@@ -1077,7 +1071,7 @@ namespace Microsoft.Azure.ServiceBus
 
         internal object ClearBodyObject()
         {
-            object obj = this.bodyObject;
+            var obj = this.bodyObject;
             this.bodyObject = null;
             return obj;
         }

--- a/src/Microsoft.Azure.ServiceBus/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageReceiver.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.ServiceBus
         {
             MessagingEventSource.Log.MessageReceiveStart(this.ClientId, maxMessageCount);
 
-            IList<BrokeredMessage> messages = null;
+            IList<BrokeredMessage> messages;
             try
             {
                 messages = await this.OnReceiveAsync(maxMessageCount, serverWaitTime);
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.ServiceBus
 
             MessagingEventSource.Log.MessageReceiveBySequenceNumberStart(this.ClientId, count, sequenceNumbers);
 
-            IList<BrokeredMessage> messages = null;
+            IList<BrokeredMessage> messages;
             try
             {
                 messages = await this.OnReceiveBySequenceNumberAsync(sequenceNumbers).ConfigureAwait(false);
@@ -235,9 +235,9 @@ namespace Microsoft.Azure.ServiceBus
         {
             this.ThrowIfNotPeekLockMode();
 
-            MessagingEventSource.Log.MessageRenewLockStart(this.ClientId, 1, new Guid[] { lockToken });
+            MessagingEventSource.Log.MessageRenewLockStart(this.ClientId, 1, new[] { lockToken });
 
-            DateTime lockedUntilUtc = DateTime.MinValue;
+            DateTime lockedUntilUtc;
             try
             {
                 lockedUntilUtc = await this.OnRenewLockAsync(lockToken).ConfigureAwait(false);
@@ -288,7 +288,7 @@ namespace Microsoft.Azure.ServiceBus
         /// <returns>A batch of messages peeked.</returns>
         public async Task<IList<BrokeredMessage>> PeekBySequenceNumberAsync(long fromSequenceNumber, int messageCount)
         {
-            IList<BrokeredMessage> messages = null;
+            IList<BrokeredMessage> messages;
 
             MessagingEventSource.Log.MessagePeekStart(this.ClientId, fromSequenceNumber, messageCount);
             try

--- a/src/Microsoft.Azure.ServiceBus/MessageSender.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageSender.cs
@@ -5,8 +5,6 @@ namespace Microsoft.Azure.ServiceBus
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading;
     using System.Threading.Tasks;
 
     public abstract class MessageSender : ClientEntity
@@ -27,7 +25,7 @@ namespace Microsoft.Azure.ServiceBus
 
         public Task SendAsync(BrokeredMessage brokeredMessage)
         {
-            return this.SendAsync(new BrokeredMessage[] { brokeredMessage });
+            return this.SendAsync(new[] { brokeredMessage });
         }
 
         public async Task SendAsync(IEnumerable<BrokeredMessage> brokeredMessages)

--- a/src/Microsoft.Azure.ServiceBus/MessageSession.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageSession.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Azure.ServiceBus
     using System.Collections.Generic;
     using System.IO;
     using System.Threading.Tasks;
-    using Amqp;
 
     public abstract class MessageSession : MessageReceiver
     {

--- a/src/Microsoft.Azure.ServiceBus/MessagingEventSource.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessagingEventSource.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Azure.ServiceBus
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Diagnostics.Tracing;
-    using System.Linq;
 
     [SuppressMessage(
         "Microsoft.StyleCop.CSharp.OrderingRules",

--- a/src/Microsoft.Azure.ServiceBus/Primitives/Fx.cs
+++ b/src/Microsoft.Azure.ServiceBus/Primitives/Fx.cs
@@ -265,10 +265,6 @@ namespace Microsoft.Azure.ServiceBus
                 [Conditional("CODE_ANALYSIS")]
                 public sealed class BlockingAttribute : Attribute
                 {
-                    public BlockingAttribute()
-                    {
-                    }
-
                     public string CancelMethod { get; set; }
 
                     public Type CancelDeclaringType { get; set; }

--- a/src/Microsoft.Azure.ServiceBus/Primitives/MessagingEntityType.cs
+++ b/src/Microsoft.Azure.ServiceBus/Primitives/MessagingEntityType.cs
@@ -9,7 +9,5 @@ namespace Microsoft.Azure.ServiceBus
         Topic = 1,
         Subscriber = 2,
         Filter = 3,
-        Namespace = 4,
-        Unknown = 0x7FFFFFFE,
     }
 }

--- a/src/Microsoft.Azure.ServiceBus/Primitives/MessagingEntityType.cs
+++ b/src/Microsoft.Azure.ServiceBus/Primitives/MessagingEntityType.cs
@@ -10,6 +10,6 @@ namespace Microsoft.Azure.ServiceBus
         Subscriber = 2,
         Filter = 3,
         Namespace = 4,
-        Unknown = (int)0x7FFFFFFE,
+        Unknown = 0x7FFFFFFE,
     }
 }

--- a/src/Microsoft.Azure.ServiceBus/Primitives/ServiceBusConnection.cs
+++ b/src/Microsoft.Azure.ServiceBus/Primitives/ServiceBusConnection.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Azure.ServiceBus
     using Microsoft.Azure.Amqp;
     using Microsoft.Azure.Amqp.Transport;
     using Microsoft.Azure.ServiceBus.Amqp;
-    using Microsoft.Azure.ServiceBus.Primitives;
 
     public abstract class ServiceBusConnection
     {

--- a/src/Microsoft.Azure.ServiceBus/QueueClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/QueueClient.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.ServiceBus
         /// <returns>A Task that completes when the send operations is done.</returns>
         public Task SendAsync(BrokeredMessage brokeredMessage)
         {
-            return this.SendAsync(new BrokeredMessage[] { brokeredMessage });
+            return this.SendAsync(new[] { brokeredMessage });
         }
 
         public Task SendAsync(IEnumerable<BrokeredMessage> brokeredMessages)
@@ -199,7 +199,7 @@ namespace Microsoft.Azure.ServiceBus
 
         public async Task<BrokeredMessage> ReceiveBySequenceNumberAsync(long sequenceNumber)
         {
-            IList<BrokeredMessage> messages = await this.ReceiveBySequenceNumberAsync(new long[] { sequenceNumber });
+            IList<BrokeredMessage> messages = await this.ReceiveBySequenceNumberAsync(new[] { sequenceNumber });
             if (messages != null && messages.Count > 0)
             {
                 return messages[0];
@@ -253,7 +253,7 @@ namespace Microsoft.Azure.ServiceBus
 
         public Task CompleteAsync(Guid lockToken)
         {
-            return this.CompleteAsync(new Guid[] { lockToken });
+            return this.CompleteAsync(new[] { lockToken });
         }
 
         public Task CompleteAsync(IEnumerable<Guid> lockTokens)
@@ -263,7 +263,7 @@ namespace Microsoft.Azure.ServiceBus
 
         public Task AbandonAsync(Guid lockToken)
         {
-            return this.InnerReceiver.AbandonAsync(new Guid[] { lockToken });
+            return this.InnerReceiver.AbandonAsync(new[] { lockToken });
         }
 
         public Task<MessageSession> AcceptMessageSessionAsync()
@@ -283,7 +283,7 @@ namespace Microsoft.Azure.ServiceBus
 
         public async Task<MessageSession> AcceptMessageSessionAsync(string sessionId, TimeSpan serverWaitTime)
         {
-            MessageSession session = null;
+            MessageSession session;
 
             MessagingEventSource.Log.AcceptMessageSessionStart(this.ClientId, sessionId);
 
@@ -303,12 +303,12 @@ namespace Microsoft.Azure.ServiceBus
 
         public Task DeferAsync(Guid lockToken)
         {
-            return this.InnerReceiver.DeferAsync(new Guid[] { lockToken });
+            return this.InnerReceiver.DeferAsync(new[] { lockToken });
         }
 
         public Task DeadLetterAsync(Guid lockToken)
         {
-            return this.InnerReceiver.DeadLetterAsync(new Guid[] { lockToken });
+            return this.InnerReceiver.DeadLetterAsync(new[] { lockToken });
         }
 
         public Task<DateTime> RenewMessageLockAsync(Guid lockToken)

--- a/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.ServiceBus
 
         public async Task<BrokeredMessage> ReceiveBySequenceNumberAsync(long sequenceNumber)
         {
-            IList<BrokeredMessage> messages = await this.ReceiveBySequenceNumberAsync(new long[] { sequenceNumber });
+            IList<BrokeredMessage> messages = await this.ReceiveBySequenceNumberAsync(new[] { sequenceNumber });
             if (messages != null && messages.Count > 0)
             {
                 return messages[0];
@@ -220,7 +220,7 @@ namespace Microsoft.Azure.ServiceBus
 
         public Task CompleteAsync(Guid lockToken)
         {
-            return this.CompleteAsync(new Guid[] { lockToken });
+            return this.CompleteAsync(new[] { lockToken });
         }
 
         public Task CompleteAsync(IEnumerable<Guid> lockTokens)
@@ -230,7 +230,7 @@ namespace Microsoft.Azure.ServiceBus
 
         public Task AbandonAsync(Guid lockToken)
         {
-            return this.InnerReceiver.AbandonAsync(new Guid[] { lockToken });
+            return this.InnerReceiver.AbandonAsync(new[] { lockToken });
         }
 
         public Task<MessageSession> AcceptMessageSessionAsync()
@@ -250,7 +250,7 @@ namespace Microsoft.Azure.ServiceBus
 
         public async Task<MessageSession> AcceptMessageSessionAsync(string sessionId, TimeSpan serverWaitTime)
         {
-            MessageSession session = null;
+            MessageSession session;
 
             MessagingEventSource.Log.AcceptMessageSessionStart(this.ClientId, sessionId);
 
@@ -270,12 +270,12 @@ namespace Microsoft.Azure.ServiceBus
 
         public Task DeferAsync(Guid lockToken)
         {
-            return this.InnerReceiver.DeferAsync(new Guid[] { lockToken });
+            return this.InnerReceiver.DeferAsync(new[] { lockToken });
         }
 
         public Task DeadLetterAsync(Guid lockToken)
         {
-            return this.InnerReceiver.DeadLetterAsync(new Guid[] { lockToken });
+            return this.InnerReceiver.DeadLetterAsync(new[] { lockToken });
         }
 
         public Task<DateTime> RenewMessageLockAsync(Guid lockToken)

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/BrokeredMessageTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/BrokeredMessageTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
 
             await TestUtility.SendMessagesAsync(queueClient.InnerSender, 1);
             var message = await queueClient.ReceiveAsync();
-            Assert.NotNull((object)message);
+            Assert.NotNull(message);
 
             await Assert.ThrowsAsync<InvalidOperationException>(async () => await message.CompleteAsync());
             await Assert.ThrowsAsync<InvalidOperationException>(async () => await message.AbandonAsync());
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
 
             await TestUtility.SendMessagesAsync(queueClient.InnerSender, 1);
             message = await queueClient.ReceiveAsync();
-            Assert.NotNull((object)message);
+            Assert.NotNull(message);
             await message.AbandonAsync();
             await Task.Delay(TimeSpan.FromMilliseconds(100));
             message = await queueClient.ReceiveAsync();

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/DisplayTestMethodNameAttribute.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/DisplayTestMethodNameAttribute.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
     {
         public override void Before(MethodInfo methodUnderTest)
         {
-            TestUtility.Log($"Begin {methodUnderTest.DeclaringType}.{methodUnderTest.Name} on {PlatformServices.Default.Application.RuntimeFramework.ToString()}");
+            TestUtility.Log($"Begin {methodUnderTest.DeclaringType}.{methodUnderTest.Name} on {PlatformServices.Default.Application.RuntimeFramework}");
             base.Before(methodUnderTest);
         }
 

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/ExpectedMessagingExceptionTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/ExpectedMessagingExceptionTests.cs
@@ -51,11 +51,12 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             {
                 var messageId = "test-message1";
                 var sessionId = Guid.NewGuid().ToString();
-                await queueClient.SendAsync(new BrokeredMessage() { MessageId = messageId, SessionId = sessionId });
+            await queueClient.SendAsync(new BrokeredMessage
+                { MessageId = messageId, SessionId = sessionId });
                 TestUtility.Log($"Sent Message: {messageId} to Session: {sessionId}");
 
                 MessageSession messageSession = await queueClient.AcceptMessageSessionAsync(sessionId);
-                Assert.NotNull((object)messageSession);
+            Assert.NotNull(messageSession);
 
                 var message = await messageSession.ReceiveAsync();
                 Assert.True(message.MessageId == messageId);
@@ -76,7 +77,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 }
 
                 messageSession = await queueClient.AcceptMessageSessionAsync(sessionId);
-                Assert.NotNull((object)messageSession);
+            Assert.NotNull(messageSession);
 
                 message = await messageSession.ReceiveAsync();
                 TestUtility.Log($"Received Message: SessionId: {messageSession.SessionId}");

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/QueueSessionTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/QueueSessionTests.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
     using System.Diagnostics;
     using System.IO;
     using System.Text;
-    using System.Threading;
     using System.Threading.Tasks;
     using Xunit;
 
@@ -71,7 +70,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 TestUtility.Log($"Sent Message: {messageId} to Session: {sessionId}");
 
                 var sessionReceiver = await queueClient.AcceptMessageSessionAsync(sessionId);
-                Assert.NotNull((object)sessionReceiver);
+                Assert.NotNull(sessionReceiver);
                 var message = await sessionReceiver.ReceiveAsync();
                 TestUtility.Log($"Received Message: {message.MessageId} from Session: {sessionReceiver.SessionId}");
                 Assert.True(message.MessageId == messageId);
@@ -90,7 +89,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 }
 
                 // Complete message using Session Receiver
-                await sessionReceiver.CompleteAsync(new Guid[] { message.LockToken });
+                await sessionReceiver.CompleteAsync(new[] { message.LockToken });
                 TestUtility.Log($"Completed Message: {message.MessageId} for Session: {sessionReceiver.SessionId}");
 
                 sessionStateString = "Completed Message On Session!";
@@ -128,7 +127,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 TestUtility.Log($"Sent Message: {messageId} to Session: {sessionId}");
 
                 var sessionReceiver = await queueClient.AcceptMessageSessionAsync(sessionId);
-                Assert.NotNull((object)sessionReceiver);
+                Assert.NotNull(sessionReceiver);
                 DateTime initialSessionLockedUntilTime = sessionReceiver.LockedUntilUtc;
                 TestUtility.Log($"Session LockedUntilUTC: {initialSessionLockedUntilTime} for Session: {sessionReceiver.SessionId}");
                 BrokeredMessage message = await sessionReceiver.ReceiveAsync();

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/SenderReceiverClientTestBase.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/SenderReceiverClientTestBase.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
-    using System.Threading;
     using System.Threading.Tasks;
     using Xunit;
 
@@ -103,7 +102,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
 
             // Receive Again and Check delivery count
             receivedMessages = await messageReceiver.ReceiveBySequenceNumberAsync(sequenceNumbers);
-            int count = receivedMessages.Where((message) => message.DeliveryCount == 3).Count();
+            int count = receivedMessages.Count(message => message.DeliveryCount == 3);
             Assert.True(count == receivedMessages.Count());
 
             // Complete messages
@@ -157,7 +156,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 lastSequenceNumber = message.SequenceNumber;
             }
 
-            var receivedMessages = await TestUtility.ReceiveMessagesAsync(messageReceiver, messageCount);
+            await TestUtility.ReceiveMessagesAsync(messageReceiver, messageCount);
         }
 
         protected async Task ReceiveShouldReturnNoLaterThanServerWaitTimeTestCase(MessageSender messageSender, MessageReceiver messageReceiver, int messageCount)

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/TopicClientTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/TopicClientTests.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.Azure.ServiceBus.UnitTests
 {
-    using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Xunit;

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/TopicSessionTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/TopicSessionTests.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
     using System.Diagnostics;
     using System.IO;
     using System.Text;
-    using System.Threading;
     using System.Threading.Tasks;
     using Xunit;
 
@@ -57,8 +56,8 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             }
             finally
             {
-                subscriptionClient.Close();
-                topicClient.Close();
+                await subscriptionClient.CloseAsync();
+                await topicClient.CloseAsync();
             }
         }
 
@@ -78,7 +77,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 TestUtility.Log($"Sent Message: {messageId} to Session: {sessionId}");
 
                 var sessionReceiver = await subscriptionClient.AcceptMessageSessionAsync(sessionId);
-                Assert.NotNull((object)sessionReceiver);
+                Assert.NotNull(sessionReceiver);
                 var message = await sessionReceiver.ReceiveAsync();
                 TestUtility.Log($"Received Message: {message.MessageId} from Session: {sessionReceiver.SessionId}");
                 Assert.True(message.MessageId == messageId);
@@ -117,8 +116,8 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             }
             finally
             {
-                subscriptionClient.Close();
-                topicClient.Close();
+                await subscriptionClient.CloseAsync();
+                await topicClient.CloseAsync();
             }
         }
 
@@ -138,7 +137,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 TestUtility.Log($"Sent Message: {messageId} to Session: {sessionId}");
 
                 var sessionReceiver = await subscriptionClient.AcceptMessageSessionAsync(sessionId);
-                Assert.NotNull((object)sessionReceiver);
+                Assert.NotNull(sessionReceiver);
                 var initialSessionLockedUntilTime = sessionReceiver.LockedUntilUtc;
                 TestUtility.Log($"Session LockedUntilUTC: {initialSessionLockedUntilTime} for Session: {sessionReceiver.SessionId}");
                 var message = await sessionReceiver.ReceiveAsync();
@@ -165,8 +164,8 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             }
             finally
             {
-                subscriptionClient.Close();
-                topicClient.Close();
+                await subscriptionClient.CloseAsync();
+                await topicClient.CloseAsync();
             }
         }
 


### PR DESCRIPTION
- object initializers
- redundant type specifiers
- unnecessary public modifiers
- unnecessary null initialization for objects
- unnecessary parentheses
- unnecessary array type specifier
- unused variables
- nameof instead of hard-coded names
- unused namespace usings
- unneeded cast for enum values
- unnecessary boxing for nunit
- prefer async version of methods over sync

![image](https://cloud.githubusercontent.com/assets/1309622/22363497/fa1c03d8-e427-11e6-9f51-5dcdb6ea6c12.png)