### PR TITLE
[Temporary]: Disable running of tests for .NetFramework temporarily

### DIFF
--- a/test/Microsoft.Azure.ServiceBus.UnitTests/project.json
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/project.json
@@ -36,8 +36,6 @@
         "dnxcore50",
         "portable-net46+win8"
       ]
-    },
-    "net451": {
     }
   }
 }


### PR DESCRIPTION
## Description
[Temporary]: Disable running of tests for .NetFramework until AppVeyor build account issues are fixed. Today we are running tests with both .NetCore and .NetFramework clients. But it looks like with a general Appveyor account, running both is not finishing within 1 hour's time and is timing out. So disabling running .NetFramework client for now. We are working to get the build process fixed and will reinstate this once that is completed.
-->

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [X] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [X] If applicable, the public code is properly documented.
- [X] Pull request includes test coverage for the included changes.
- [X] The code builds without any errors.