### PR TITLE
Added ability to read AMQP DataBody in AMQPConverter

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
@@ -177,9 +177,13 @@ namespace Microsoft.Azure.ServiceBus.Amqp
                 && amqpMessage.DataBody != null
                 && amqpMessage.DataBody.Count() > 0)
             {
-                var dataBody = amqpMessage.DataBody.FirstOrDefault().Value;
-                var dataBodyAsByteArray = (ArraySegment<byte>)dataBody;
-                sbMessage = new SBMessage(dataBodyAsByteArray.ToArray());
+                var dataSegments = new List<byte>();
+                foreach (Data data in amqpMessage.DataBody)
+                {
+                    var arraySegmentValue = (ArraySegment<byte>)data.Value;
+                    dataSegments.AddRange(arraySegmentValue.ToArray());
+                }
+                sbMessage = new SBMessage(dataSegments.ToArray());
             }
             else
             {

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
     using System.Collections;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using System.Runtime.Serialization;
     using Microsoft.Azure.Amqp;
     using Microsoft.Azure.Amqp.Encoding;
@@ -171,6 +172,14 @@ namespace Microsoft.Azure.ServiceBus.Amqp
             {
                 var byteArrayValue = (byte[])amqpMessage.ValueBody.Value;
                 sbMessage = new SBMessage(byteArrayValue);
+            }
+            else if (amqpMessage.BodyType == SectionFlag.Data
+                && amqpMessage.DataBody != null
+                && amqpMessage.DataBody.Count() > 0)
+            {
+                var dataBody = amqpMessage.DataBody.FirstOrDefault().Value;
+                var dataBodyAsByteArray = (ArraySegment<byte>)dataBody;
+                sbMessage = new SBMessage(dataBodyAsByteArray.ToArray());
             }
             else
             {

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
@@ -168,17 +168,18 @@ namespace Microsoft.Azure.ServiceBus.Amqp
             }
 
             SBMessage sbMessage;
-            if (amqpMessage.BodyType == SectionFlag.AmqpValue && amqpMessage.ValueBody.Value != null)
+
+            if ((amqpMessage.BodyType & SectionFlag.AmqpValue) != 0
+                && amqpMessage.ValueBody.Value != null)
             {
                 var byteArrayValue = (byte[])amqpMessage.ValueBody.Value;
                 sbMessage = new SBMessage(byteArrayValue);
             }
-            else if (amqpMessage.BodyType == SectionFlag.Data
-                && amqpMessage.DataBody != null
-                && amqpMessage.DataBody.Count() > 0)
+            else if ((amqpMessage.BodyType & SectionFlag.Data) != 0
+                && amqpMessage.DataBody?.Count() > 0)
             {
                 var dataSegments = new List<byte>();
-                foreach (Data data in amqpMessage.DataBody)
+                foreach (var data in amqpMessage.DataBody)
                 {
                     var arraySegmentValue = (ArraySegment<byte>)data.Value;
                     dataSegments.AddRange(arraySegmentValue.ToArray());

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Azure.ServiceBus.Amqp
     using System.Collections;
     using System.Collections.Generic;
     using System.IO;
-    using System.Linq;
     using System.Runtime.Serialization;
     using Microsoft.Azure.Amqp;
     using Microsoft.Azure.Amqp.Encoding;
@@ -180,13 +179,13 @@ namespace Microsoft.Azure.ServiceBus.Amqp
                 sbMessage = new SBMessage(byteArrayValue);
             }
             else if ((amqpMessage.BodyType & SectionFlag.Data) != 0
-                && amqpMessage.DataBody?.Count() > 0)
+                && amqpMessage.DataBody != null)
             {
                 var dataSegments = new List<byte>();
                 foreach (var data in amqpMessage.DataBody)
                 {
                     var arraySegmentValue = (ArraySegment<byte>)data.Value;
-                    dataSegments.AddRange(arraySegmentValue.ToArray());
+                    dataSegments.AddRange(arraySegmentValue);
                 }
                 sbMessage = new SBMessage(dataSegments.ToArray());
             }

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
@@ -154,6 +154,10 @@ namespace Microsoft.Azure.ServiceBus.Amqp
                     {
                         amqpMessage.ApplicationProperties.Map.Add(pair.Key, amqpObject);
                     }
+                    else
+                    {
+                        throw new NotSupportedException(Resources.InvalidAmqpMessageProperty.FormatForUser(pair.Key.GetType()));
+                    }
                 }
             }
 

--- a/src/Microsoft.Azure.ServiceBus/Resources.Designer.cs
+++ b/src/Microsoft.Azure.ServiceBus/Resources.Designer.cs
@@ -177,6 +177,15 @@ namespace Microsoft.Azure.ServiceBus {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to {0} is not a supported user property type..
+        /// </summary>
+        public static string InvalidAmqpMessageProperty {
+            get {
+                return ResourceManager.GetString("InvalidAmqpMessageProperty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to The entity name or path contains an invalid character &apos;{0}&apos;. The supplied value is &apos;{1}&apos;..
         /// </summary>
         public static string InvalidCharacterInEntityName {

--- a/src/Microsoft.Azure.ServiceBus/Resources.resx
+++ b/src/Microsoft.Azure.ServiceBus/Resources.resx
@@ -201,4 +201,7 @@
   <data name="ArgumentMustBePositive" xml:space="preserve">
     <value>The value of the argument {0} must be positive.</value>
   </data>
+  <data name="InvalidAmqpMessageProperty" xml:space="preserve">
+    <value>{0} is not a supported user property type.</value>
+  </data>
 </root>

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/AmqpConverterTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/AmqpConverterTests.cs
@@ -5,11 +5,27 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
 {
     using System;
     using System.Text;
+    using Azure.Amqp.Framing;
+    using Microsoft.Azure.Amqp;
     using Microsoft.Azure.ServiceBus.Amqp;
     using Xunit;
 
     public class AmqpConverterTests
     {
+        [Fact]
+        [DisplayTestMethodName]
+        void Convert_Amqp_message_with_data_value_to_SB_message()
+        {
+            var messageBody = Encoding.UTF8.GetBytes("message1");
+
+            var data = new Data();
+            data.Value = new ArraySegment<byte>(messageBody);
+            var amqpMessage = AmqpMessage.Create(data);
+
+            var sbMessage = AmqpMessageConverter.AmqpMessageToSBMessage(amqpMessage);
+            Assert.Equal(messageBody, sbMessage.Body);
+        }
+
         [Fact]
         [DisplayTestMethodName]
         void Convert_SB_message_to_Amqp_message_and_back()
@@ -44,21 +60,21 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             sbMessage.UserProperties.Add("UserProperty", "SomeUserProperty");
 
             var amqpMessage = AmqpMessageConverter.SBMessageToAmqpMessage(sbMessage);
-            var convertedBrokeredMessage = AmqpMessageConverter.AmqpMessageToSBMessage(amqpMessage);
+            var convertedSbMessage = AmqpMessageConverter.AmqpMessageToSBMessage(amqpMessage);
 
-            Assert.Equal("SomeUserProperty", convertedBrokeredMessage.UserProperties["UserProperty"]);
-            Assert.Equal(messageBody, convertedBrokeredMessage.Body);
-            Assert.Equal(messageId, convertedBrokeredMessage.MessageId);
-            Assert.Equal(partitionKey, convertedBrokeredMessage.PartitionKey);
-            Assert.Equal(sessionId, convertedBrokeredMessage.SessionId);
-            Assert.Equal(correlationId, convertedBrokeredMessage.CorrelationId);
-            Assert.Equal(label, convertedBrokeredMessage.Label);
-            Assert.Equal(to, convertedBrokeredMessage.To);
-            Assert.Equal(contentType, convertedBrokeredMessage.ContentType);
-            Assert.Equal(replyTo, convertedBrokeredMessage.ReplyTo);
-            Assert.Equal(replyToSessionId, convertedBrokeredMessage.ReplyToSessionId);
-            Assert.Equal(publisher, convertedBrokeredMessage.Publisher);
-            Assert.Equal(deadLetterSource, convertedBrokeredMessage.DeadLetterSource);
+            Assert.Equal("SomeUserProperty", convertedSbMessage.UserProperties["UserProperty"]);
+            Assert.Equal(messageBody, convertedSbMessage.Body);
+            Assert.Equal(messageId, convertedSbMessage.MessageId);
+            Assert.Equal(partitionKey, convertedSbMessage.PartitionKey);
+            Assert.Equal(sessionId, convertedSbMessage.SessionId);
+            Assert.Equal(correlationId, convertedSbMessage.CorrelationId);
+            Assert.Equal(label, convertedSbMessage.Label);
+            Assert.Equal(to, convertedSbMessage.To);
+            Assert.Equal(contentType, convertedSbMessage.ContentType);
+            Assert.Equal(replyTo, convertedSbMessage.ReplyTo);
+            Assert.Equal(replyToSessionId, convertedSbMessage.ReplyToSessionId);
+            Assert.Equal(publisher, convertedSbMessage.Publisher);
+            Assert.Equal(deadLetterSource, convertedSbMessage.DeadLetterSource);
         }
     }
 }


### PR DESCRIPTION
## Description
Replacing PR #116, and addresses #114.
Allows for receiving AMQP messages that have the AMQP Data Body set in addition to AMQP Value. This allows for the older Service Bus client to be used in conjunction with this library.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.