### PR TITLE
Updating debug type for opencover

### DIFF
--- a/build/AppveyorBuildFunctions.ps1
+++ b/build/AppveyorBuildFunctions.ps1
@@ -93,12 +93,12 @@ function Run-UnitTests
     {
         Write-Host "Running unit tests."
 
-        Invoke-WebRequest -Uri "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" -OutFile nuget.exe
+        Invoke-WebRequest -Uri "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" -OutFile ".\build\nuget.exe"
         $openCoverVersion = '4.6.684'
         # Using a temporary version of OpenCover until a NuGet is published. https://github.com/OpenCover/opencover/issues/669
-        Invoke-WebRequest -Uri "https://ci.appveyor.com/api/buildjobs/v896p89ur5qpd4he/artifacts/main%2Fbin%2Fpackages%2Fnuget%2Fopencover%2FOpenCover.4.6.684.nupkg" -OutFile "OpenCover.4.6.684.nupkg"
-        & .\nuget.exe install opencover -version $openCoverVersion -source $ENV:APPVEYOR_BUILD_FOLDER\
-        $openCoverConsole = $ENV:APPVEYOR_BUILD_FOLDER + '\OpenCover.' + $openCoverVersion + '\tools\OpenCover.Console.exe'
+        Invoke-WebRequest -Uri "https://ci.appveyor.com/api/buildjobs/v896p89ur5qpd4he/artifacts/main%2Fbin%2Fpackages%2Fnuget%2Fopencover%2FOpenCover.4.6.684.nupkg" -OutFile ".\build\OpenCover.4.6.684.nupkg"
+        & .\build\nuget.exe install opencover -version $openCoverVersion -source $ENV:APPVEYOR_BUILD_FOLDER\ -OutputDirectory .\build\
+        $openCoverConsole = $ENV:APPVEYOR_BUILD_FOLDER + '.\build\OpenCover.' + $openCoverVersion + '\tools\OpenCover.Console.exe'
         $coverageFile = $ENV:APPVEYOR_BUILD_FOLDER + '\coverage.xml'
         $target = '-target:C:\Program Files\dotnet\dotnet.exe'
         $testProject = $ENV:APPVEYOR_BUILD_FOLDER + '\test\Microsoft.Azure.ServiceBus.UnitTests\Microsoft.Azure.ServiceBus.UnitTests.csproj'

--- a/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
+++ b/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
@@ -23,6 +23,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <DebugType>full</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Microsoft.Azure.ServiceBus.UnitTests.csproj
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Microsoft.Azure.ServiceBus.UnitTests.csproj
@@ -15,6 +15,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <DebugType>full</DebugType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
Fixing the below error in the OpenCover test results, by adding `<DebugType>full</DebugType>` to the .csproj files. This was lost in the VS2017 migration.
```
Committing...
No results, this could be for a number of reasons. The most common reasons are:
    1) missing PDBs for the assemblies that match the filter please review the
    output file and refer to the Usage guide (Usage.rtf) about filters.
    2) the profiler may not be registered correctly, please refer to the Usage
    guide and the -register switch.
Requirement already up-to-date: pip in c:\python34\lib\site-packages
Collecting git+git://github.com/codecov/codecov-python.git
  Cloning git://github.com/codecov/code
```
Also changed package downloads in the build to the download folder.