### PR TITLE
Exposing prefetchCount through clients

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpSubscriptionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpSubscriptionClient.cs
@@ -56,6 +56,23 @@ namespace Microsoft.Azure.ServiceBus.Amqp
             }
         }
 
+        /// <summary>
+        /// Gets or sets the number of messages that the queue client can simultaneously request.
+        /// </summary>
+        /// <value>The number of messages that the queue client can simultaneously request.</value>
+        public int PrefetchCount
+        {
+            get => this.ServiceBusConnection.PrefetchCount;
+            set
+            {
+                this.ServiceBusConnection.PrefetchCount = value;
+                if (this.innerReceiver != null)
+                {
+                    this.innerReceiver.PrefetchCount = value;
+                }
+            }
+        }
+
         ServiceBusConnection ServiceBusConnection { get; set; }
 
         RetryPolicy RetryPolicy { get; set; }

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpSubscriptionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpSubscriptionClient.cs
@@ -57,12 +57,13 @@ namespace Microsoft.Azure.ServiceBus.Amqp
         }
 
         /// <summary>
-        /// Gets or sets the number of messages that the queue client can simultaneously request.
+        /// Gets or sets the number of messages that the subscription client can simultaneously request.
         /// </summary>
-        /// <value>The number of messages that the queue client can simultaneously request.</value>
+        /// <value>The number of messages that the subscription client can simultaneously request.</value>
         public int PrefetchCount
         {
             get => this.ServiceBusConnection.PrefetchCount;
+
             set
             {
                 this.ServiceBusConnection.PrefetchCount = value;

--- a/src/Microsoft.Azure.ServiceBus/Core/IInnerSubscriptionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/IInnerSubscriptionClient.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Azure.ServiceBus.Core
     {
         MessageReceiver InnerReceiver { get; }
 
+        int PrefetchCount { get; set; }
+
         Task OnAddRuleAsync(RuleDescription description);
 
         Task OnRemoveRuleAsync(string ruleName);

--- a/src/Microsoft.Azure.ServiceBus/QueueClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/QueueClient.cs
@@ -49,6 +49,23 @@ namespace Microsoft.Azure.ServiceBus
 
         public string Path => this.QueueName;
 
+        /// <summary>
+        /// Gets or sets the number of messages that the queue client can simultaneously request.
+        /// </summary>
+        /// <value>The number of messages that the queue client can simultaneously request.</value>
+        public int PrefetchCount
+        {
+            get => this.ServiceBusConnection.PrefetchCount;
+            set
+            {
+                this.ServiceBusConnection.PrefetchCount = value;
+                if (this.innerReceiver != null)
+                {
+                    this.innerReceiver.PrefetchCount = value;
+                }
+            }
+        }
+
         internal MessageSender InnerSender
         {
             get
@@ -148,7 +165,7 @@ namespace Microsoft.Azure.ServiceBus
             }
         }
 
-        ServiceBusConnection ServiceBusConnection { get; set; }
+        internal ServiceBusConnection ServiceBusConnection { get; set; }
 
         ICbsTokenProvider CbsTokenProvider { get; }
 

--- a/src/Microsoft.Azure.ServiceBus/QueueClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/QueueClient.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Azure.ServiceBus
         public int PrefetchCount
         {
             get => this.ServiceBusConnection.PrefetchCount;
+
             set
             {
                 this.ServiceBusConnection.PrefetchCount = value;

--- a/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Azure.ServiceBus
         public int PrefetchCount
         {
             get => this.ServiceBusConnection.PrefetchCount;
+
             set
             {
                 this.ServiceBusConnection.PrefetchCount = value;

--- a/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
@@ -50,6 +50,23 @@ namespace Microsoft.Azure.ServiceBus
 
         public ReceiveMode ReceiveMode { get; }
 
+        /// <summary>
+        /// Gets or sets the number of messages that the subscription client can simultaneously request.
+        /// </summary>
+        /// <value>The number of messages that the subscription client can simultaneously request.</value>
+        public int PrefetchCount
+        {
+            get => this.ServiceBusConnection.PrefetchCount;
+            set
+            {
+                this.ServiceBusConnection.PrefetchCount = value;
+                if (this.innerSubscriptionClient != null)
+                {
+                    this.innerSubscriptionClient.PrefetchCount = value;
+                }
+            }
+        }
+
         internal IInnerSubscriptionClient InnerSubscriptionClient
         {
             get
@@ -120,7 +137,7 @@ namespace Microsoft.Azure.ServiceBus
             }
         }
 
-        ServiceBusNamespaceConnection ServiceBusConnection { get; }
+        internal ServiceBusNamespaceConnection ServiceBusConnection { get; }
 
         ICbsTokenProvider CbsTokenProvider { get; }
 

--- a/src/Microsoft.Azure.ServiceBus/TopicClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/TopicClient.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.ServiceBus
             }
         }
 
-        ServiceBusNamespaceConnection ServiceBusConnection { get; set; }
+        internal ServiceBusNamespaceConnection ServiceBusConnection { get; set; }
 
         ICbsTokenProvider CbsTokenProvider { get; }
 

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/QueueClientTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/QueueClientTests.cs
@@ -136,5 +136,36 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 await queueClient.CloseAsync();
             }
         }
+
+        [Fact]
+        [DisplayTestMethodName]
+        void UpdatingPrefetchCountOnQueueClientUpdatesTheReceiverPrefetchCount()
+        {
+            string queueName = TestConstants.NonPartitionedQueueName;
+            var queueClient = new QueueClient(TestUtility.NamespaceConnectionString, queueName, ReceiveMode.ReceiveAndDelete);
+
+            try
+            {
+                Assert.Equal(0, queueClient.PrefetchCount);
+
+                queueClient.PrefetchCount = 2;
+                Assert.Equal(2, queueClient.PrefetchCount);
+                Assert.Equal(2, queueClient.ServiceBusConnection.PrefetchCount);
+
+                // Message receiver should be created with latest prefetch count (lazy load).
+                Assert.Equal(2, queueClient.InnerReceiver.PrefetchCount);
+
+                queueClient.PrefetchCount = 3;
+                Assert.Equal(3, queueClient.PrefetchCount);
+                Assert.Equal(3, queueClient.ServiceBusConnection.PrefetchCount);
+
+                // Already created message receiver should have its prefetch value updated.
+                Assert.Equal(3, queueClient.InnerReceiver.PrefetchCount);
+            }
+            finally
+            {
+                queueClient.CloseAsync().Wait();
+            }
+        }
     }
 }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/QueueClientTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/QueueClientTests.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
 
         [Fact]
         [DisplayTestMethodName]
-        void UpdatingPrefetchCountOnQueueClientUpdatesTheReceiverPrefetchCount()
+        async Task UpdatingPrefetchCountOnQueueClientUpdatesTheReceiverPrefetchCount()
         {
             string queueName = TestConstants.NonPartitionedQueueName;
             var queueClient = new QueueClient(TestUtility.NamespaceConnectionString, queueName, ReceiveMode.ReceiveAndDelete);
@@ -164,7 +164,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             }
             finally
             {
-                queueClient.CloseAsync().Wait();
+                await queueClient.CloseAsync();
             }
         }
     }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/SubscriptionClientTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/SubscriptionClientTests.cs
@@ -194,5 +194,39 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 await topicClient.CloseAsync();
             }
         }
+
+        [Fact]
+        [DisplayTestMethodName]
+        void UpdatingPrefetchCountOnSubscriptionClientUpdatesTheReceiverPrefetchCount()
+        {
+            var subscriptionClient = new SubscriptionClient(
+                TestUtility.NamespaceConnectionString,
+                TestConstants.NonPartitionedTopicName,
+                TestConstants.SubscriptionName,
+                ReceiveMode.ReceiveAndDelete);
+
+            try
+            {
+                Assert.Equal(0, subscriptionClient.PrefetchCount);
+
+                subscriptionClient.PrefetchCount = 2;
+                Assert.Equal(2, subscriptionClient.PrefetchCount);
+                Assert.Equal(2, subscriptionClient.ServiceBusConnection.PrefetchCount);
+
+                // Message receiver should be created with latest prefetch count (lazy load).
+                Assert.Equal(2, subscriptionClient.InnerSubscriptionClient.InnerReceiver.PrefetchCount);
+
+                subscriptionClient.PrefetchCount = 3;
+                Assert.Equal(3, subscriptionClient.PrefetchCount);
+                Assert.Equal(3, subscriptionClient.ServiceBusConnection.PrefetchCount);
+
+                // Already created message receiver should have its prefetch value updated.
+                Assert.Equal(3, subscriptionClient.InnerSubscriptionClient.InnerReceiver.PrefetchCount);
+            }
+            finally
+            {
+                subscriptionClient.CloseAsync().Wait();
+            }
+        }
     }
 }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/SubscriptionClientTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/SubscriptionClientTests.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
 
         [Fact]
         [DisplayTestMethodName]
-        void UpdatingPrefetchCountOnSubscriptionClientUpdatesTheReceiverPrefetchCount()
+        async Task UpdatingPrefetchCountOnSubscriptionClientUpdatesTheReceiverPrefetchCount()
         {
             var subscriptionClient = new SubscriptionClient(
                 TestUtility.NamespaceConnectionString,
@@ -225,7 +225,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             }
             finally
             {
-                subscriptionClient.CloseAsync().Wait();
+                await subscriptionClient.CloseAsync();
             }
         }
     }


### PR DESCRIPTION
## Description
Exposing PrefetchCount through clients.
Added tests for prefetch.
Fix for #135 

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.