### PR TITLE
Removed Sender/Receiver constructor for ServiceBusNamespaceConnection

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -46,6 +46,10 @@ namespace Microsoft.Azure.ServiceBus.Core
             int prefetchCount = DefaultPrefetchCount)
             : this(entityPath, null, receiveMode, new ServiceBusNamespaceConnection(connectionString), null, retryPolicy, prefetchCount)
         {
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw Fx.Exception.ArgumentNullOrWhiteSpace(connectionString);
+            }
             if (string.IsNullOrWhiteSpace(entityPath))
             {
                 throw Fx.Exception.ArgumentNullOrWhiteSpace(entityPath);

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             ReceiveMode receiveMode = ReceiveMode.PeekLock,
             RetryPolicy retryPolicy = null,
             int prefetchCount = DefaultPrefetchCount)
-            : this(connectionStringBuilder.GetNamespaceConnectionString(), connectionStringBuilder.EntityPath, receiveMode, retryPolicy, prefetchCount)
+            : this(connectionStringBuilder?.GetNamespaceConnectionString(), connectionStringBuilder.EntityPath, receiveMode, retryPolicy, prefetchCount)
         {
         }
 

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             ReceiveMode receiveMode = ReceiveMode.PeekLock,
             RetryPolicy retryPolicy = null,
             int prefetchCount = DefaultPrefetchCount)
-            : this(entityPath, new ServiceBusNamespaceConnection(connectionString), receiveMode, retryPolicy, prefetchCount)
+            : this(entityPath, null, receiveMode, new ServiceBusNamespaceConnection(connectionString), null, retryPolicy, prefetchCount)
         {
             if (string.IsNullOrWhiteSpace(entityPath))
             {
@@ -52,18 +52,8 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
 
             this.ownsConnection = true;
-        }
-
-        public MessageReceiver(
-            string entityPath,
-            ServiceBusConnection serviceBusConnection,
-            ReceiveMode receiveMode = ReceiveMode.PeekLock,
-            RetryPolicy retryPolicy = null,
-            int prefetchCount = DefaultPrefetchCount)
-            : this(entityPath, null, receiveMode, serviceBusConnection, null, retryPolicy, prefetchCount)
-        {
-            var tokenProvider = TokenProvider.CreateSharedAccessSignatureTokenProvider(serviceBusConnection.SasKeyName, serviceBusConnection.SasKey);
-            this.CbsTokenProvider = new TokenProviderAdapter(tokenProvider, serviceBusConnection.OperationTimeout);
+            var tokenProvider = TokenProvider.CreateSharedAccessSignatureTokenProvider(this.ServiceBusConnection.SasKeyName, this.ServiceBusConnection.SasKey);
+            this.CbsTokenProvider = new TokenProviderAdapter(tokenProvider, this.ServiceBusConnection.OperationTimeout);
         }
 
         internal MessageReceiver(

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         public MessageSender(
             ServiceBusConnectionStringBuilder connectionStringBuilder,
             RetryPolicy retryPolicy = null)
-            : this(connectionStringBuilder.GetNamespaceConnectionString(), connectionStringBuilder.EntityPath, retryPolicy)
+            : this(connectionStringBuilder?.GetNamespaceConnectionString(), connectionStringBuilder.EntityPath, retryPolicy)
         {
         }
 

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             string connectionString, 
             string entityPath, 
             RetryPolicy retryPolicy = null)
-            : this(entityPath, new ServiceBusNamespaceConnection(connectionString), retryPolicy)
+            : this(entityPath, null, new ServiceBusNamespaceConnection(connectionString), null, retryPolicy)
         {
             if (string.IsNullOrWhiteSpace(connectionString))
             {
@@ -42,18 +42,10 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
 
             this.ownsConnection = true;
-        }
-
-        public MessageSender(
-            string entityPath,
-            ServiceBusConnection serviceBusConnection,
-            RetryPolicy retryPolicy = null)
-            : this(entityPath, null, serviceBusConnection, null, retryPolicy)
-        {
             var tokenProvider = TokenProvider.CreateSharedAccessSignatureTokenProvider(
-                serviceBusConnection.SasKeyName,
-                serviceBusConnection.SasKey);
-            this.CbsTokenProvider = new TokenProviderAdapter(tokenProvider, serviceBusConnection.OperationTimeout);
+                this.ServiceBusConnection.SasKeyName,
+                this.ServiceBusConnection.SasKey);
+            this.CbsTokenProvider = new TokenProviderAdapter(tokenProvider, this.ServiceBusConnection.OperationTimeout);
         }
 
         internal MessageSender(

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/ExpectedMessagingExceptionTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/ExpectedMessagingExceptionTests.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.Azure.ServiceBus.Core;
-    using Microsoft.Azure.ServiceBus.Primitives;
     using Xunit;
 
     public class ExpectedMessagingExceptionTests
@@ -16,10 +15,9 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         async Task MessageLockLostExceptionTest()
         {
             const int messageCount = 2;
-            var connection = new ServiceBusNamespaceConnection(TestUtility.NamespaceConnectionString);
 
-            var sender = new MessageSender(TestConstants.NonPartitionedQueueName, connection);
-            var receiver = new MessageReceiver(TestConstants.NonPartitionedQueueName, connection, receiveMode: ReceiveMode.PeekLock);
+            var sender = new MessageSender(TestUtility.NamespaceConnectionString, TestConstants.NonPartitionedQueueName);
+            var receiver = new MessageReceiver(TestUtility.NamespaceConnectionString, TestConstants.NonPartitionedQueueName, receiveMode: ReceiveMode.PeekLock);
 
             try
             {
@@ -48,66 +46,11 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             }
         }
 
-        // TODO: Update this when Session is implemented
-        /*
-        [Fact]
-        async Task SessionLockLostExceptionTest()
-        {
-            var messagingFactory = new ServiceBusClientFactory();
-            var queueClient =
-                (QueueClient)messagingFactory.CreateQueueClientFromConnectionString(
-                    TestUtility.GetEntityConnectionString(TestConstants.SessionNonPartitionedQueueName));
-
-            try
-            {
-                var messageId = "test-message1";
-                var sessionId = Guid.NewGuid().ToString();
-            await queueClient.SendAsync(new Message
-                { MessageId = messageId, SessionId = sessionId });
-                TestUtility.Log($"Sent Message: {messageId} to Session: {sessionId}");
-
-                MessageSession messageSession = await queueClient.AcceptMessageSessionAsync(sessionId);
-            Assert.NotNull(messageSession);
-
-                var message = await messageSession.ReceiveAsync();
-                Assert.True(message.MessageId == messageId);
-                TestUtility.Log($"Received Message: SessionId: {messageSession.SessionId}");
-
-                // Let the Session expire
-                await Task.Delay(TimeSpan.FromMinutes(1));
-
-                // Complete should throw
-                await Assert.ThrowsAsync<SessionLockLostException>(async () => await message.CompleteAsync());
-                try
-                {
-                    await messageSession.CloseAsync();
-                }
-                catch (Exception e)
-                {
-                    TestUtility.Log($"Got Exception on Session Close(): SessionId: {messageSession.SessionId}, Exception: {e.Message}");
-                }
-
-                messageSession = await queueClient.AcceptMessageSessionAsync(sessionId);
-            Assert.NotNull(messageSession);
-
-                message = await messageSession.ReceiveAsync();
-                TestUtility.Log($"Received Message: SessionId: {messageSession.SessionId}");
-
-                await message.CompleteAsync();
-            }
-            finally
-            {
-                await queueClient.CloseAsync();
-            }
-        }
-        */
-
         [Fact]
         async Task CompleteOnPeekedMessagesShouldThrowTest()
         {
-            var connection = new ServiceBusNamespaceConnection(TestUtility.NamespaceConnectionString);
-            var sender = new MessageSender(TestConstants.NonPartitionedQueueName, connection);
-            var receiver = new MessageReceiver(TestConstants.NonPartitionedQueueName, connection, receiveMode: ReceiveMode.ReceiveAndDelete);
+            var sender = new MessageSender(TestUtility.NamespaceConnectionString, TestConstants.NonPartitionedQueueName);
+            var receiver = new MessageReceiver(TestUtility.NamespaceConnectionString, TestConstants.NonPartitionedQueueName, receiveMode: ReceiveMode.ReceiveAndDelete);
 
             try
             {

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/ExpectedMessagingExceptionTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/ExpectedMessagingExceptionTests.cs
@@ -70,5 +70,59 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 await receiver.CloseAsync().ConfigureAwait(false);
             }
         }
+
+        // TODO: Update this when Session is implemented
+        /*
+        [Fact]
+        async Task SessionLockLostExceptionTest()
+        {
+            var messagingFactory = new ServiceBusClientFactory();
+            var queueClient =
+                (QueueClient)messagingFactory.CreateQueueClientFromConnectionString(
+                    TestUtility.GetEntityConnectionString(TestConstants.SessionNonPartitionedQueueName));
+
+            try
+            {
+                var messageId = "test-message1";
+                var sessionId = Guid.NewGuid().ToString();
+            await queueClient.SendAsync(new Message
+                { MessageId = messageId, SessionId = sessionId });
+                TestUtility.Log($"Sent Message: {messageId} to Session: {sessionId}");
+
+                MessageSession messageSession = await queueClient.AcceptMessageSessionAsync(sessionId);
+            Assert.NotNull(messageSession);
+
+                var message = await messageSession.ReceiveAsync();
+                Assert.True(message.MessageId == messageId);
+                TestUtility.Log($"Received Message: SessionId: {messageSession.SessionId}");
+
+                // Let the Session expire
+                await Task.Delay(TimeSpan.FromMinutes(1));
+
+                // Complete should throw
+                await Assert.ThrowsAsync<SessionLockLostException>(async () => await message.CompleteAsync());
+                try
+                {
+                    await messageSession.CloseAsync();
+                }
+                catch (Exception e)
+                {
+                    TestUtility.Log($"Got Exception on Session Close(): SessionId: {messageSession.SessionId}, Exception: {e.Message}");
+                }
+
+                messageSession = await queueClient.AcceptMessageSessionAsync(sessionId);
+            Assert.NotNull(messageSession);
+
+                message = await messageSession.ReceiveAsync();
+                TestUtility.Log($"Received Message: SessionId: {messageSession.SessionId}");
+
+                await message.CompleteAsync();
+            }
+            finally
+            {
+                await queueClient.CloseAsync();
+            }
+        }
+        */
     }
 }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/SenderReceiverTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/SenderReceiverTests.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Microsoft.Azure.ServiceBus.Core;
-    using Microsoft.Azure.ServiceBus.Primitives;
     using Xunit;
 
     public class SenderReceiverTests : SenderReceiverClientTestBase
@@ -26,9 +25,8 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         [DisplayTestMethodName]
         async Task MessageReceiverAndMessageSenderCreationWorksAsExpected(string queueName, int messageCount = 10)
         {
-            var connection = new ServiceBusNamespaceConnection(TestUtility.NamespaceConnectionString);
-            var sender = new MessageSender(queueName, connection);
-            var receiver = new MessageReceiver(queueName, connection, receiveMode: ReceiveMode.PeekLock);
+            var sender = new MessageSender(TestUtility.NamespaceConnectionString, queueName);
+            var receiver = new MessageReceiver(TestUtility.NamespaceConnectionString, queueName, receiveMode: ReceiveMode.PeekLock);
 
             try
             {
@@ -46,9 +44,8 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         [DisplayTestMethodName]
         async Task TopicClientPeekLockDeferTestCase(string queueName, int messageCount = 10)
         {
-            var connection = new ServiceBusNamespaceConnection(TestUtility.NamespaceConnectionString);
-            var sender = new MessageSender(queueName, connection);
-            var receiver = new MessageReceiver(queueName, connection, receiveMode: ReceiveMode.PeekLock);
+            var sender = new MessageSender(TestUtility.NamespaceConnectionString, queueName);
+            var receiver = new MessageReceiver(TestUtility.NamespaceConnectionString, queueName, receiveMode: ReceiveMode.PeekLock);
 
             try
             {
@@ -67,9 +64,8 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         [DisplayTestMethodName]
         async Task PeekAsyncTest(string queueName, int messageCount = 10)
         {
-            var connection = new ServiceBusNamespaceConnection(TestUtility.NamespaceConnectionString);
-            var sender = new MessageSender(queueName, connection);
-            var receiver = new MessageReceiver(queueName, connection, receiveMode: ReceiveMode.ReceiveAndDelete);
+            var sender = new MessageSender(TestUtility.NamespaceConnectionString, queueName);
+            var receiver = new MessageReceiver(TestUtility.NamespaceConnectionString, queueName, receiveMode: ReceiveMode.ReceiveAndDelete);
 
             try
             {
@@ -87,9 +83,8 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         [DisplayTestMethodName]
         async Task ReceiveShouldReturnNoLaterThanServerWaitTimeTest(string queueName, int messageCount = 1)
         {
-            var connection = new ServiceBusNamespaceConnection(TestUtility.NamespaceConnectionString);
-            var sender = new MessageSender(queueName, connection);
-            var receiver = new MessageReceiver(queueName, connection, receiveMode: ReceiveMode.ReceiveAndDelete);
+            var sender = new MessageSender(TestUtility.NamespaceConnectionString, queueName);
+            var receiver = new MessageReceiver(TestUtility.NamespaceConnectionString, queueName, receiveMode: ReceiveMode.ReceiveAndDelete);
 
             try
             {
@@ -107,13 +102,11 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         async Task ReceiverShouldUseTheLatestPrefetchCount()
         {
             var queueName = TestConstants.NonPartitionedQueueName;
-            var connection1 = new ServiceBusNamespaceConnection(TestUtility.NamespaceConnectionString);
-            var connection2 = new ServiceBusNamespaceConnection(TestUtility.NamespaceConnectionString);
 
-            var sender = new MessageSender(queueName, connection1);
+            var sender = new MessageSender(TestUtility.NamespaceConnectionString, queueName);
 
-            var receiver1 = new MessageReceiver(queueName, connection1, receiveMode: ReceiveMode.ReceiveAndDelete);
-            var receiver2 = new MessageReceiver(queueName, connection2, receiveMode: ReceiveMode.ReceiveAndDelete, prefetchCount: 1);
+            var receiver1 = new MessageReceiver(TestUtility.NamespaceConnectionString, queueName, receiveMode: ReceiveMode.ReceiveAndDelete);
+            var receiver2 = new MessageReceiver(TestUtility.NamespaceConnectionString, queueName, receiveMode: ReceiveMode.ReceiveAndDelete, prefetchCount: 1);
 
             Assert.Equal(0, receiver1.PrefetchCount);
             Assert.Equal(1, receiver2.PrefetchCount);


### PR DESCRIPTION
## Description
Removing constructor that accepts `ServiceBusNamespaceConnection` for `MessageSender` and `MessageReceiver`. We don't want to expose functionality like this until we have connection pooling ironed out. See #134 for details.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.