### PR TITLE
API approver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,4 @@ Buildx86retail.dat
 #OpenCover
 /build/OpenCoverReport/*
 /build/coverage.xml
+test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.received.txt

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-MIT License
+﻿MIT License
 
 Copyright © Microsoft Corporation 2016
 
@@ -19,3 +19,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+Third Party Programs: The software may include third party programs that Microsoft, not the third party,
+licenses to you under this agreement. Notices, if any, for the third party programs are included for your
+information only.

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/APIApprovals.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/APIApprovals.cs
@@ -1,0 +1,23 @@
+﻿#if NET46
+namespace Microsoft.Azure.ServiceBus.UnitTests.API
+{
+    using System.Runtime.CompilerServices;
+    using ApprovalTests;
+    using ApprovalTests.Reporters;
+    using PublicApiGenerator;
+    using Xunit;
+
+    public class ApiApprovals
+    {
+        [Fact]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [UseReporter(typeof(DiffReporter))]
+        public void ApproveAzureServiceBus()
+        {
+            //Directory.SetCurrentDirectory(TestContext.CurrentContext.TestDirectory);
+            var publicApi = ApiGenerator.GeneratePublicApi(typeof(Message).Assembly);
+            Approvals.Verify(publicApi);
+        }
+    }
+}
+#endif

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -1,0 +1,82 @@
+﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute(@"Microsoft.Azure.ServiceBus.UnitTests,PublicKey=0024000004800000940000000602000000240000525341310004000001000100fdf4acac3b2244dd8a96737e5385b31414369dc3e42f371172127252856a0650793e1f5673a16d5d78e2ac852a104bc51e6f018dca44fdd26a219c27cb2b263956a80620223c8e9c2f8913c3c903e1e453e9e4e84098afdad5f4badb8c1ebe0a7b0a4b57a08454646a65886afe3e290a791ff3260099ce0edf0bdbccafadfeb6")]
+[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
+[assembly: System.Runtime.InteropServices.GuidAttribute("a042adf0-ef65-4f87-b634-322a409f3d61")]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.5.1", FrameworkDisplayName=".NET Framework 4.5.1")]
+
+namespace Microsoft.Azure.ServiceBus
+{
+    
+    public abstract class ClientEntity : Microsoft.Azure.ServiceBus.IClientEntity { }
+    public class static EntityNameHelper { }
+    public interface IClientEntity { }
+    public interface IMessageSession : Microsoft.Azure.ServiceBus.Core.IMessageReceiver, Microsoft.Azure.ServiceBus.Core.IReceiverClient, Microsoft.Azure.ServiceBus.IClientEntity { }
+    public interface IQueueClient : Microsoft.Azure.ServiceBus.Core.IReceiverClient, Microsoft.Azure.ServiceBus.Core.ISenderClient, Microsoft.Azure.ServiceBus.IClientEntity { }
+    public interface ISubscriptionClient : Microsoft.Azure.ServiceBus.Core.IReceiverClient, Microsoft.Azure.ServiceBus.IClientEntity { }
+    public interface ITopicClient : Microsoft.Azure.ServiceBus.Core.ISenderClient, Microsoft.Azure.ServiceBus.IClientEntity { }
+    public class Message
+    {
+        public sealed class SystemPropertiesCollection { }
+    }
+    public sealed class MessageHandlerOptions { }
+    public sealed class MessageLockLostException : Microsoft.Azure.ServiceBus.ServiceBusException { }
+    public sealed class MessagingEntityDisabledException : Microsoft.Azure.ServiceBus.ServiceBusException { }
+    public sealed class MessagingEntityNotFoundException : Microsoft.Azure.ServiceBus.ServiceBusException { }
+    public sealed class NoRetry : Microsoft.Azure.ServiceBus.RetryPolicy { }
+    public class QueueClient : Microsoft.Azure.ServiceBus.ClientEntity, Microsoft.Azure.ServiceBus.Core.IReceiverClient, Microsoft.Azure.ServiceBus.Core.ISenderClient, Microsoft.Azure.ServiceBus.IClientEntity, Microsoft.Azure.ServiceBus.IQueueClient { }
+    public sealed class QuotaExceededException : Microsoft.Azure.ServiceBus.ServiceBusException { }
+    public enum ReceiveMode
+    {
+        PeekLock = 0,
+        ReceiveAndDelete = 1,
+    }
+    public sealed class RetryExponential : Microsoft.Azure.ServiceBus.RetryPolicy { }
+    public abstract class RetryPolicy { }
+    public class SecurityToken { }
+    public sealed class ServerBusyException : Microsoft.Azure.ServiceBus.ServiceBusException { }
+    public class ServiceBusCommunicationException : Microsoft.Azure.ServiceBus.ServiceBusException { }
+    public class ServiceBusConnectionStringBuilder { }
+    public class ServiceBusException : System.Exception { }
+    public sealed class SessionHandlerOptions { }
+    public sealed class SessionLockLostException : Microsoft.Azure.ServiceBus.ServiceBusException { }
+    public class SharedAccessSignatureTokenProvider : Microsoft.Azure.ServiceBus.TokenProvider
+    {
+        public static readonly System.DateTime EpochTime;
+    }
+    public class SubscriptionClient : Microsoft.Azure.ServiceBus.ClientEntity, Microsoft.Azure.ServiceBus.Core.IReceiverClient, Microsoft.Azure.ServiceBus.IClientEntity, Microsoft.Azure.ServiceBus.ISubscriptionClient
+    {
+        public const string DefaultRule = "$Default";
+    }
+    public abstract class TokenProvider { }
+    public enum TokenScope
+    {
+        Namespace = 0,
+        Entity = 1,
+    }
+    public class TopicClient : Microsoft.Azure.ServiceBus.ClientEntity, Microsoft.Azure.ServiceBus.Core.ISenderClient, Microsoft.Azure.ServiceBus.IClientEntity, Microsoft.Azure.ServiceBus.ITopicClient { }
+}
+namespace Microsoft.Azure.ServiceBus.Core
+{
+    
+    public interface IMessageReceiver : Microsoft.Azure.ServiceBus.Core.IReceiverClient, Microsoft.Azure.ServiceBus.IClientEntity { }
+    public interface IReceiverClient : Microsoft.Azure.ServiceBus.IClientEntity { }
+    public interface ISenderClient : Microsoft.Azure.ServiceBus.IClientEntity { }
+    public class MessageReceiver : Microsoft.Azure.ServiceBus.ClientEntity, Microsoft.Azure.ServiceBus.Core.IMessageReceiver, Microsoft.Azure.ServiceBus.Core.IReceiverClient, Microsoft.Azure.ServiceBus.IClientEntity { }
+    public class MessageSender : Microsoft.Azure.ServiceBus.ClientEntity, Microsoft.Azure.ServiceBus.Core.ISenderClient, Microsoft.Azure.ServiceBus.IClientEntity { }
+}
+namespace Microsoft.Azure.ServiceBus.Filters
+{
+    
+    public sealed class CorrelationFilter : Microsoft.Azure.ServiceBus.Filters.Filter { }
+    public sealed class FalseFilter : Microsoft.Azure.ServiceBus.Filters.SqlFilter { }
+    public abstract class Filter { }
+    public abstract class RuleAction { }
+    public sealed class RuleDescription { }
+    public class SqlFilter : Microsoft.Azure.ServiceBus.Filters.Filter { }
+    public sealed class SqlRuleAction : Microsoft.Azure.ServiceBus.Filters.RuleAction { }
+    public sealed class TrueFilter : Microsoft.Azure.ServiceBus.Filters.SqlFilter { }
+}
+namespace Microsoft.Azure.ServiceBus.Primitives
+{
+    
+    public sealed class ExceptionReceivedEventArgs : System.EventArgs { }
+}

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprover.6.0.0/PublicApiApprover.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprover.6.0.0/PublicApiApprover.cs
@@ -1,0 +1,37 @@
+﻿#if NET46
+
+using System.IO;
+using System.Reflection;
+using ApprovalTests;
+using ApprovalTests.Namers;
+
+namespace ApiApprover
+{
+    public static class PublicApiApprover
+    {
+        public static void ApprovePublicApi(Assembly assembly)
+        {
+            var publicApi = PublicApiGenerator.ApiGenerator.GeneratePublicApi(assembly);
+            var writer = new ApprovalTextWriter(publicApi, "cs");
+            var approvalNamer = new AssemblyPathNamer(assembly.Location);
+            Approvals.Verify(writer, approvalNamer, Approvals.GetReporter());
+        }
+
+        private class AssemblyPathNamer : UnitTestFrameworkNamer
+        {
+            private readonly string name;
+
+            public AssemblyPathNamer(string assemblyPath)
+            {
+                name = Path.GetFileNameWithoutExtension(assemblyPath);
+            }
+
+            public override string Name
+            {
+                get { return name; }
+            }
+        }
+    }
+}
+
+#endif

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/PublicApiGenerator.6.0.0/ApiGenerator.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/PublicApiGenerator.6.0.0/ApiGenerator.cs
@@ -1,0 +1,800 @@
+﻿#if NET46
+
+using System;
+using System.CodeDom;
+using System.CodeDom.Compiler;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.CSharp;
+using Mono.Cecil;
+using Mono.Cecil.Rocks;
+using ICustomAttributeProvider = Mono.Cecil.ICustomAttributeProvider;
+using TypeAttributes = System.Reflection.TypeAttributes;
+using System.Globalization;
+
+// ReSharper disable BitwiseOperatorOnEnumWithoutFlags
+namespace PublicApiGenerator
+{
+    public static class ApiGenerator
+    {
+        public static string GeneratePublicApi(Assembly assemby, Type[] includeTypes = null, bool shouldIncludeAssemblyAttributes = true)
+        {
+            var assemblyResolver = new DefaultAssemblyResolver();
+            var assemblyPath = assemby.Location;
+            assemblyResolver.AddSearchDirectory(Path.GetDirectoryName(assemblyPath));
+
+            var readSymbols = File.Exists(Path.ChangeExtension(assemblyPath, ".pdb"));
+            var asm = AssemblyDefinition.ReadAssembly(assemblyPath, new ReaderParameters(ReadingMode.Deferred)
+            {
+                ReadSymbols = readSymbols,
+                AssemblyResolver = assemblyResolver,
+            });
+
+            return CreatePublicApiForAssembly(asm, tr => includeTypes == null || includeTypes.Any(t => t.FullName == tr.FullName && t.Assembly.FullName == tr.Module.Assembly.FullName), shouldIncludeAssemblyAttributes);
+        }
+
+        // TODO: Assembly references?
+        // TODO: Better handle namespaces - using statements? - requires non-qualified type names
+        static string CreatePublicApiForAssembly(AssemblyDefinition assembly, Func<TypeDefinition, bool> shouldIncludeType, bool shouldIncludeAssemblyAttributes)
+        {
+            var publicApiBuilder = new StringBuilder();
+            var cgo = new CodeGeneratorOptions
+            {
+                BracingStyle = "C",
+                BlankLinesBetweenMembers = false,
+                VerbatimOrder = false
+            };
+
+            using (var provider = new CSharpCodeProvider())
+            {
+                var compileUnit = new CodeCompileUnit();
+                if (shouldIncludeAssemblyAttributes && assembly.HasCustomAttributes)
+                {
+                    PopulateCustomAttributes(assembly, compileUnit.AssemblyCustomAttributes);
+                }
+
+                var publicTypes = assembly.Modules.SelectMany(m => m.GetTypes())
+                    .Where(t => !t.IsNested && ShouldIncludeType(t) && shouldIncludeType(t))
+                    .OrderBy(t => t.FullName);
+                foreach (var publicType in publicTypes)
+                {
+                    var @namespace = compileUnit.Namespaces.Cast<CodeNamespace>()
+                        .FirstOrDefault(n => n.Name == publicType.Namespace);
+                    if (@namespace == null)
+                    {
+                        @namespace = new CodeNamespace(publicType.Namespace);
+                        compileUnit.Namespaces.Add(@namespace);
+                    }
+
+                    var typeDeclaration = CreateTypeDeclaration(publicType);
+                    @namespace.Types.Add(typeDeclaration);
+                }
+
+                using (var writer = new StringWriter())
+                {
+                    provider.GenerateCodeFromCompileUnit(compileUnit, writer, cgo);
+                    var typeDeclarationText = NormaliseGeneratedCode(writer);
+                    publicApiBuilder.AppendLine(typeDeclarationText);
+                }
+            }
+            return NormaliseLineEndings(publicApiBuilder.ToString().Trim());
+        }
+
+        static string NormaliseLineEndings(string value)
+        {
+            return Regex.Replace(value, @"\r\n|\n\r|\r|\n", Environment.NewLine);
+        }
+
+        static bool IsDelegate(TypeDefinition publicType)
+        {
+            return publicType.BaseType != null && publicType.BaseType.FullName == "System.MulticastDelegate";
+        }
+
+        static bool ShouldIncludeType(TypeDefinition t)
+        {
+            return (t.IsPublic || t.IsNestedPublic || t.IsNestedFamily) && !IsCompilerGenerated(t);
+        }
+
+        static bool ShouldIncludeMember(IMemberDefinition m)
+        {
+            return !IsCompilerGenerated(m) && !IsDotNetTypeMember(m) && !(m is FieldDefinition);
+        }
+
+        static bool IsCompilerGenerated(IMemberDefinition m)
+        {
+            return m.CustomAttributes.Any(a => a.AttributeType.FullName == "System.Runtime.CompilerServices.CompilerGeneratedAttribute");
+        }
+
+        static bool IsDotNetTypeMember(IMemberDefinition m)
+        {
+            if (m.DeclaringType == null || m.DeclaringType.FullName == null)
+                return false;
+            return m.DeclaringType.FullName.StartsWith("System") || m.DeclaringType.FullName.StartsWith("Microsoft");
+        }
+
+        static void AddMemberToTypeDeclaration(CodeTypeDeclaration typeDeclaration, IMemberDefinition memberInfo)
+        {
+            var methodDefinition = memberInfo as MethodDefinition;
+            if (methodDefinition != null)
+            {
+                if (methodDefinition.IsConstructor)
+                    AddCtorToTypeDeclaration(typeDeclaration, methodDefinition);
+                else
+                    AddMethodToTypeDeclaration(typeDeclaration, methodDefinition);
+            }
+            else if (memberInfo is PropertyDefinition)
+            {
+                AddPropertyToTypeDeclaration(typeDeclaration, (PropertyDefinition) memberInfo);
+            }
+            else if (memberInfo is EventDefinition)
+            {
+                typeDeclaration.Members.Add(GenerateEvent((EventDefinition)memberInfo));
+            }
+            else if (memberInfo is FieldDefinition)
+            {
+                AddFieldToTypeDeclaration(typeDeclaration, (FieldDefinition) memberInfo);
+            }
+        }
+
+        static string NormaliseGeneratedCode(StringWriter writer)
+        {
+            var gennedClass = writer.ToString();
+            const string autoGeneratedHeader = @"^//-+\s*$.*^//-+\s*$";
+            const string emptyGetSet = @"\s+{\s+get\s+{\s+}\s+set\s+{\s+}\s+}";
+            const string emptyGet = @"\s+{\s+get\s+{\s+}\s+}";
+            const string emptySet = @"\s+{\s+set\s+{\s+}\s+}";
+            const string getSet = @"\s+{\s+get;\s+set;\s+}";
+            const string get = @"\s+{\s+get;\s+}";
+            const string set = @"\s+{\s+set;\s+}";
+            gennedClass = Regex.Replace(gennedClass, autoGeneratedHeader, string.Empty,
+                RegexOptions.IgnorePatternWhitespace | RegexOptions.Multiline | RegexOptions.Singleline);
+            gennedClass = Regex.Replace(gennedClass, emptyGetSet, " { get; set; }", RegexOptions.IgnorePatternWhitespace);
+            gennedClass = Regex.Replace(gennedClass, getSet, " { get; set; }", RegexOptions.IgnorePatternWhitespace);
+            gennedClass = Regex.Replace(gennedClass, emptyGet, " { get; }", RegexOptions.IgnorePatternWhitespace);
+            gennedClass = Regex.Replace(gennedClass, emptySet, " { set; }", RegexOptions.IgnorePatternWhitespace);
+            gennedClass = Regex.Replace(gennedClass, get, " { get; }", RegexOptions.IgnorePatternWhitespace);
+            gennedClass = Regex.Replace(gennedClass, set, " { set; }", RegexOptions.IgnorePatternWhitespace);
+            gennedClass = Regex.Replace(gennedClass, @"\s+{\s+}", " { }", RegexOptions.IgnorePatternWhitespace);
+            gennedClass = Regex.Replace(gennedClass, @"\)\s+;", ");", RegexOptions.IgnorePatternWhitespace);
+            return gennedClass;
+        }
+
+        static CodeTypeDeclaration CreateTypeDeclaration(TypeDefinition publicType)
+        {
+            if (IsDelegate(publicType))
+                return CreateDelegateDeclaration(publicType);
+
+            bool @static = false;
+            TypeAttributes attributes = 0;
+            if (publicType.IsPublic || publicType.IsNestedPublic)
+                attributes |= TypeAttributes.Public;
+            if (publicType.IsNestedFamily)
+                attributes |= TypeAttributes.NestedFamily;
+            if (publicType.IsSealed && !publicType.IsAbstract)
+                attributes |= TypeAttributes.Sealed;
+            else if (!publicType.IsSealed && publicType.IsAbstract && !publicType.IsInterface)
+                attributes |= TypeAttributes.Abstract;
+            else if (publicType.IsSealed && publicType.IsAbstract)
+                @static = true;
+
+            // Static support is a hack. CodeDOM does support it, and this isn't
+            // correct C#, but it's good enough for our API outline
+            var name = publicType.Name;
+
+            var index = name.IndexOf('`');
+            if (index != -1)
+                name = name.Substring(0, index);
+            var declaration = new CodeTypeDeclaration(@static ? "static " + name : name)
+            {
+                CustomAttributes = CreateCustomAttributes(publicType),
+                // TypeAttributes must be specified before the IsXXX as they manipulate TypeAttributes!
+                TypeAttributes = attributes,
+                IsClass = publicType.IsClass,
+                IsEnum = publicType.IsEnum,
+                IsInterface = publicType.IsInterface,
+                IsStruct = publicType.IsValueType && !publicType.IsPrimitive && !publicType.IsEnum,
+            };
+
+            if (declaration.IsInterface && publicType.BaseType != null)
+                throw new NotImplementedException("Base types for interfaces needs testing");
+
+            PopulateGenericParameters(publicType, declaration.TypeParameters);
+
+            if (publicType.BaseType != null && ShouldOutputBaseType(publicType))
+            {
+                if (publicType.BaseType.FullName == "System.Enum")
+                {
+                    var underlyingType = publicType.GetEnumUnderlyingType();
+                    if (underlyingType.FullName != "System.Int32")
+                        declaration.BaseTypes.Add(CreateCodeTypeReference(underlyingType));
+                }
+                else
+                    declaration.BaseTypes.Add(CreateCodeTypeReference(publicType.BaseType));
+            }
+            foreach(var @interface in publicType.Interfaces.OrderBy(i => i.FullName)
+                .Select(t => new { Reference = t, Definition = t.Resolve() })
+                .Where(t => ShouldIncludeType(t.Definition))
+                .Select(t => t.Reference))
+                declaration.BaseTypes.Add(CreateCodeTypeReference(@interface));
+
+            foreach (var memberInfo in publicType.GetMembers().Where(ShouldIncludeMember).OrderBy(m => m.Name))
+                AddMemberToTypeDeclaration(declaration, memberInfo);
+
+            // Fields should be in defined order for an enum
+            var fields = !publicType.IsEnum
+                ? publicType.Fields.OrderBy(f => f.Name)
+                : (IEnumerable<FieldDefinition>)publicType.Fields;
+            foreach (var field in fields)
+                AddMemberToTypeDeclaration(declaration, field);
+
+            foreach (var nestedType in publicType.NestedTypes.Where(ShouldIncludeType).OrderBy(t => t.FullName))
+            {
+                var nestedTypeDeclaration = CreateTypeDeclaration(nestedType);
+                declaration.Members.Add(nestedTypeDeclaration);
+            }
+
+            return declaration;
+        }
+
+        static CodeTypeDeclaration CreateDelegateDeclaration(TypeDefinition publicType)
+        {
+            var invokeMethod = publicType.Methods.Single(m => m.Name == "Invoke");
+            var name = publicType.Name;
+            var index = name.IndexOf('`');
+            if (index != -1)
+                name = name.Substring(0, index);
+            var declaration = new CodeTypeDelegate(name)
+            {
+                Attributes = MemberAttributes.Public,
+                CustomAttributes = CreateCustomAttributes(publicType),
+                ReturnType = CreateCodeTypeReference(invokeMethod.ReturnType),
+            };
+
+            // CodeDOM. No support. Return type attributes.
+            PopulateCustomAttributes(invokeMethod.MethodReturnType, declaration.CustomAttributes, type => ModifyCodeTypeReference(type, "return:"));
+            PopulateGenericParameters(publicType, declaration.TypeParameters);
+            PopulateMethodParameters(invokeMethod, declaration.Parameters);
+
+            // Of course, CodeDOM doesn't support generic type parameters for delegates. Of course.
+            if (declaration.TypeParameters.Count > 0)
+            {
+                var parameterNames = from parameterType in declaration.TypeParameters.Cast<CodeTypeParameter>()
+                    select parameterType.Name;
+                declaration.Name = string.Format(CultureInfo.InvariantCulture, "{0}<{1}>", declaration.Name, string.Join(", ", parameterNames));
+            }
+
+            return declaration;
+        }
+
+        static bool ShouldOutputBaseType(TypeDefinition publicType)
+        {
+            return publicType.BaseType.FullName != "System.Object" && publicType.BaseType.FullName != "System.ValueType";
+        }
+
+        static void PopulateGenericParameters(IGenericParameterProvider publicType, CodeTypeParameterCollection parameters)
+        {
+            foreach (var parameter in publicType.GenericParameters)
+            {
+                if (parameter.HasCustomAttributes)
+                    throw new NotImplementedException("Attributes on type parameters is not supported. And weird");
+
+                // A little hacky. Means we get "in" and "out" prefixed on any constraints, but it's either that
+                // or add it as a custom attribute, which looks even weirder
+                var name = parameter.Name;
+                if (parameter.IsCovariant)
+                    name = "out " + name;
+                if (parameter.IsContravariant)
+                    name = "in " + name;
+
+                var typeParameter = new CodeTypeParameter(name)
+                {
+                    HasConstructorConstraint =
+                        parameter.HasDefaultConstructorConstraint && !parameter.HasNotNullableValueTypeConstraint
+                };
+                if (parameter.HasNotNullableValueTypeConstraint)
+                    typeParameter.Constraints.Add(" struct"); // Extra space is a hack!
+                if (parameter.HasReferenceTypeConstraint)
+                    typeParameter.Constraints.Add(" class");
+                foreach (var constraint in parameter.Constraints.Where(t => t.FullName != "System.ValueType"))
+                {
+                    typeParameter.Constraints.Add(CreateCodeTypeReference(constraint.GetElementType()));
+                }
+                parameters.Add(typeParameter);
+            }
+        }
+
+        static CodeAttributeDeclarationCollection CreateCustomAttributes(ICustomAttributeProvider type)
+        {
+            var attributes = new CodeAttributeDeclarationCollection();
+            PopulateCustomAttributes(type, attributes);
+            return attributes;
+        }
+
+        static void PopulateCustomAttributes(ICustomAttributeProvider type,
+            CodeAttributeDeclarationCollection attributes)
+        {
+            PopulateCustomAttributes(type, attributes, ctr => ctr);
+        }
+
+        static void PopulateCustomAttributes(ICustomAttributeProvider type,
+            CodeAttributeDeclarationCollection attributes, Func<CodeTypeReference, CodeTypeReference> codeTypeModifier)
+        {
+            foreach (var customAttribute in type.CustomAttributes.Where(ShouldIncludeAttribute).OrderBy(a => a.AttributeType.FullName).ThenBy(a => ConvertAttrbuteToCode(codeTypeModifier, a)))
+            {
+                var attribute = GenerateCodeAttributeDeclaration(codeTypeModifier, customAttribute);
+                attributes.Add(attribute);
+            }
+        }
+
+        static CodeAttributeDeclaration GenerateCodeAttributeDeclaration(Func<CodeTypeReference, CodeTypeReference> codeTypeModifier, CustomAttribute customAttribute)
+        {
+            var attribute = new CodeAttributeDeclaration(codeTypeModifier(CreateCodeTypeReference(customAttribute.AttributeType)));
+            foreach (var arg in customAttribute.ConstructorArguments)
+            {
+                attribute.Arguments.Add(new CodeAttributeArgument(CreateInitialiserExpression(arg)));
+            }
+            foreach (var field in customAttribute.Fields.OrderBy(f => f.Name))
+            {
+                attribute.Arguments.Add(new CodeAttributeArgument(field.Name, CreateInitialiserExpression(field.Argument)));
+            }
+            foreach (var property in customAttribute.Properties.OrderBy(p => p.Name))
+            {
+                attribute.Arguments.Add(new CodeAttributeArgument(property.Name, CreateInitialiserExpression(property.Argument)));
+            }
+            return attribute;
+        }
+
+        // Litee: This method is used for additional sorting of custom attributes when multiple values are allowed
+        static object ConvertAttrbuteToCode(Func<CodeTypeReference, CodeTypeReference> codeTypeModifier, CustomAttribute customAttribute)
+        {
+            using (var provider = new CSharpCodeProvider())
+            {
+                var cgo = new CodeGeneratorOptions
+                {
+                    BracingStyle = "C",
+                    BlankLinesBetweenMembers = false,
+                    VerbatimOrder = false
+                };
+                var attribute = GenerateCodeAttributeDeclaration(codeTypeModifier, customAttribute);
+                var declaration = new CodeTypeDeclaration("DummyClass")
+                {
+                    CustomAttributes = new CodeAttributeDeclarationCollection(new[] { attribute }),
+                };
+                using (var writer = new StringWriter())
+                {
+                    provider.GenerateCodeFromType(declaration, writer, cgo);
+                    return writer.ToString();
+                }
+            }
+        }
+
+        static readonly HashSet<string> SkipAttributeNames = new HashSet<string>
+        {
+            "System.CodeDom.Compiler.GeneratedCodeAttribute",
+            "System.ComponentModel.EditorBrowsableAttribute",
+            "System.Runtime.CompilerServices.AsyncStateMachineAttribute",
+            "System.Runtime.CompilerServices.CompilerGeneratedAttribute",
+            "System.Runtime.CompilerServices.CompilationRelaxationsAttribute",
+            "System.Runtime.CompilerServices.ExtensionAttribute",
+            "System.Runtime.CompilerServices.RuntimeCompatibilityAttribute",
+            "System.Reflection.DefaultMemberAttribute",
+            "System.Diagnostics.DebuggableAttribute",
+            "System.Diagnostics.DebuggerNonUserCodeAttribute",
+            "System.Diagnostics.DebuggerStepThroughAttribute",
+            "System.Reflection.AssemblyCompanyAttribute",
+            "System.Reflection.AssemblyConfigurationAttribute",
+            "System.Reflection.AssemblyCopyrightAttribute",
+            "System.Reflection.AssemblyDescriptionAttribute",
+            "System.Reflection.AssemblyFileVersionAttribute",
+            "System.Reflection.AssemblyInformationalVersionAttribute",
+            "System.Reflection.AssemblyProductAttribute",
+            "System.Reflection.AssemblyTitleAttribute",
+            "System.Reflection.AssemblyTrademarkAttribute"
+        };
+
+        static bool ShouldIncludeAttribute(CustomAttribute attribute)
+        {
+            var attributeTypeDefinition = attribute.AttributeType.Resolve();
+            return !SkipAttributeNames.Contains(attribute.AttributeType.FullName) && attributeTypeDefinition.IsPublic;
+        }
+
+        static CodeExpression CreateInitialiserExpression(CustomAttributeArgument attributeArgument)
+        {
+            if (attributeArgument.Value is CustomAttributeArgument)
+            {
+                return CreateInitialiserExpression((CustomAttributeArgument) attributeArgument.Value);
+            }
+
+            if (attributeArgument.Value is CustomAttributeArgument[])
+            {
+                var initialisers = from argument in (CustomAttributeArgument[]) attributeArgument.Value
+                    select CreateInitialiserExpression(argument);
+                return new CodeArrayCreateExpression(CreateCodeTypeReference(attributeArgument.Type), initialisers.ToArray());
+            }
+
+            var type = attributeArgument.Type.Resolve();
+            var value = attributeArgument.Value;
+            if (type.BaseType != null && type.BaseType.FullName == "System.Enum")
+            {
+                var originalValue = Convert.ToInt64(value);
+                if (type.CustomAttributes.Any(a => a.AttributeType.FullName == "System.FlagsAttribute"))
+                {
+                    //var allFlags = from f in type.Fields
+                    //    where f.Constant != null
+                    //    let v = Convert.ToInt64(f.Constant)
+                    //    where v == 0 || (originalValue & v) != 0
+                    //    select (CodeExpression)new CodeFieldReferenceExpression(typeExpression, f.Name);
+                    //return allFlags.Aggregate((current, next) => new CodeBinaryOperatorExpression(current, CodeBinaryOperatorType.BitwiseOr, next));
+
+                    // I'd rather use the above, as it's just using the CodeDOM, but it puts
+                    // brackets around each CodeBinaryOperatorExpression
+                    var flags = from f in type.Fields
+                                where f.Constant != null
+                                let v = Convert.ToInt64(f.Constant)
+                                where v == 0 || (originalValue & v) != 0
+                                select type.FullName + "." + f.Name;
+                    return new CodeSnippetExpression(flags.Aggregate((current, next) => current + " | " + next));
+                }
+
+                var allFlags = from f in type.Fields
+                               where f.Constant != null
+                               let v = Convert.ToInt64(f.Constant)
+                               where v == originalValue
+                               select new CodeFieldReferenceExpression(new CodeTypeReferenceExpression(CreateCodeTypeReference(type)), f.Name);
+                return allFlags.FirstOrDefault();
+            }
+
+            if (type.FullName == "System.Type" && value is TypeReference)
+            {
+                return new CodeTypeOfExpression(CreateCodeTypeReference((TypeReference)value));
+            }
+
+            if (value is string)
+            {
+                // CodeDOM outputs a verbatim string. Any string with \n is treated as such, so normalise
+                // it to make it easier for comparisons
+                value = Regex.Replace((string)value, @"\n", "\\n");
+                value = Regex.Replace((string)value, @"\r\n|\r\\n", "\\r\\n");
+            }
+
+            return new CodePrimitiveExpression(value);
+        }
+
+        static void AddCtorToTypeDeclaration(CodeTypeDeclaration typeDeclaration, MethodDefinition member)
+        {
+            if (member.IsAssembly || member.IsPrivate)
+                return;
+
+            var method = new CodeConstructor
+            {
+                CustomAttributes = CreateCustomAttributes(member),
+                Name = member.Name,
+                Attributes = GetMethodAttributes(member)
+            };
+            PopulateMethodParameters(member, method.Parameters);
+
+            typeDeclaration.Members.Add(method);
+        }
+
+        static void AddMethodToTypeDeclaration(CodeTypeDeclaration typeDeclaration, MethodDefinition member)
+        {
+            if (member.IsAssembly || member.IsPrivate || member.IsSpecialName)
+                return;
+
+            var returnType = CreateCodeTypeReference(member.ReturnType);
+
+            var method = new CodeMemberMethod
+            {
+                Name = member.Name,
+                Attributes = GetMethodAttributes(member),
+                CustomAttributes = CreateCustomAttributes(member),
+                ReturnType = returnType,
+            };
+            PopulateCustomAttributes(member.MethodReturnType, method.ReturnTypeCustomAttributes);
+            PopulateGenericParameters(member, method.TypeParameters);
+            PopulateMethodParameters(member, method.Parameters, IsExtensionMethod(member));
+
+            typeDeclaration.Members.Add(method);
+        }
+
+        static bool IsExtensionMethod(ICustomAttributeProvider method)
+        {
+            return method.CustomAttributes.Any(a => a.AttributeType.FullName == "System.Runtime.CompilerServices.ExtensionAttribute");
+        }
+
+        static void PopulateMethodParameters(IMethodSignature member,
+            CodeParameterDeclarationExpressionCollection parameters, bool isExtension = false)
+        {
+            foreach (var parameter in member.Parameters)
+            {
+                FieldDirection direction = 0;
+                if (parameter.IsOut)
+                    direction |= FieldDirection.Out;
+                else if (parameter.ParameterType.IsByReference)
+                    direction |= FieldDirection.Ref;
+
+                var parameterType = parameter.ParameterType.IsByReference
+                    ? parameter.ParameterType.GetElementType()
+                    : parameter.ParameterType;
+
+                var type = CreateCodeTypeReference(parameterType);
+
+                if (isExtension)
+                {
+                    type = ModifyCodeTypeReference(type, "this");
+                    isExtension = false;
+                }
+
+                var name = parameter.HasConstant
+                    ? string.Format(CultureInfo.InvariantCulture, "{0} = {1}", parameter.Name, FormatParameterConstant(parameter))
+                    : parameter.Name;
+                var expression = new CodeParameterDeclarationExpression(type, name)
+                {
+                    Direction = direction,
+                    CustomAttributes = CreateCustomAttributes(parameter)
+                };
+                parameters.Add(expression);
+            }
+        }
+
+        static object FormatParameterConstant(IConstantProvider parameter)
+        {
+            return parameter.Constant is string ? string.Format(CultureInfo.InvariantCulture, "\"{0}\"", parameter.Constant) : (parameter.Constant ?? "null");
+        }
+
+        static MemberAttributes GetMethodAttributes(MethodDefinition method)
+        {
+            MemberAttributes access = 0;
+            if (method.IsFamily)
+                access = MemberAttributes.Family;
+            if (method.IsPublic)
+                access = MemberAttributes.Public;
+            if (method.IsAssembly)
+                access = MemberAttributes.Assembly;
+            if (method.IsFamilyAndAssembly)
+                access = MemberAttributes.FamilyAndAssembly;
+            if (method.IsFamilyOrAssembly)
+                access = MemberAttributes.FamilyOrAssembly;
+
+            MemberAttributes scope = 0;
+            if (method.IsStatic)
+                scope |= MemberAttributes.Static;
+            if (method.IsFinal || !method.IsVirtual)
+                scope |= MemberAttributes.Final;
+            if (method.IsAbstract)
+                scope |= MemberAttributes.Abstract;
+            if (method.IsVirtual && !method.IsNewSlot)
+                scope |= MemberAttributes.Override;
+
+            MemberAttributes vtable = 0;
+            if (IsHidingMethod(method))
+                vtable = MemberAttributes.New;
+
+            return access | scope | vtable;
+        }
+
+        static bool IsHidingMethod(MethodDefinition method)
+        {
+            var typeDefinition = method.DeclaringType;
+
+            // If we're an interface, just try and find any method with the same signature
+            // in any of the interfaces that we implement
+            if (typeDefinition.IsInterface)
+            {
+                var interfaceMethods = from @interfaceReference in typeDefinition.Interfaces
+                    let interfaceDefinition = @interfaceReference.Resolve()
+                    where interfaceDefinition != null
+                    select interfaceDefinition.Methods;
+
+                return interfaceMethods.Any(ms => MetadataResolver.GetMethod(ms, method) != null);
+            }
+
+            // If we're not an interface, find a base method that isn't virtual
+            return !method.IsVirtual && GetBaseTypes(typeDefinition).Any(d => MetadataResolver.GetMethod(d.Methods, method) != null);
+        }
+
+        static IEnumerable<TypeDefinition> GetBaseTypes(TypeDefinition type)
+        {
+            var baseType = type.BaseType;
+            while (baseType != null)
+            {
+                var definition = baseType.Resolve();
+                if (definition == null)
+                    yield break;
+                yield return definition;
+
+                baseType = baseType.DeclaringType;
+            }
+        }
+
+        static void AddPropertyToTypeDeclaration(CodeTypeDeclaration typeDeclaration, PropertyDefinition member)
+        {
+            var getterAttributes = member.GetMethod != null ? GetMethodAttributes(member.GetMethod) : 0;
+            var setterAttributes = member.SetMethod != null ? GetMethodAttributes(member.SetMethod) : 0;
+
+            if (!HasVisiblePropertyMethod(getterAttributes) && !HasVisiblePropertyMethod(setterAttributes))
+                return;
+
+            var propertyAttributes = GetPropertyAttributes(getterAttributes, setterAttributes);
+
+            var propertyType = member.PropertyType.IsGenericParameter
+                ? new CodeTypeReference(member.PropertyType.Name)
+                : CreateCodeTypeReference(member.PropertyType);
+
+            var property = new CodeMemberProperty
+            {
+                Name = member.Name,
+                Type = propertyType,
+                Attributes = propertyAttributes,
+                CustomAttributes = CreateCustomAttributes(member),
+                HasGet = member.GetMethod != null && HasVisiblePropertyMethod(getterAttributes),
+                HasSet = member.SetMethod != null && HasVisiblePropertyMethod(setterAttributes)
+            };
+
+            // Here's a nice hack, because hey, guess what, the CodeDOM doesn't support
+            // attributes on getters or setters
+            if (member.GetMethod != null && member.GetMethod.HasCustomAttributes)
+            {
+                PopulateCustomAttributes(member.GetMethod, property.CustomAttributes, type => ModifyCodeTypeReference(type, "get:"));
+            }
+            if (member.SetMethod != null && member.SetMethod.HasCustomAttributes)
+            {
+                PopulateCustomAttributes(member.SetMethod, property.CustomAttributes, type => ModifyCodeTypeReference(type, "set:"));
+            }
+
+            foreach (var parameter in member.Parameters)
+            {
+                property.Parameters.Add(
+                    new CodeParameterDeclarationExpression(CreateCodeTypeReference(parameter.ParameterType),
+                        parameter.Name));
+            }
+
+            // TODO: CodeDOM has no support for different access modifiers for getters and setters
+            // TODO: CodeDOM has no support for attributes on setters or getters - promote to property?
+
+            typeDeclaration.Members.Add(property);
+        }
+
+        static MemberAttributes GetPropertyAttributes(MemberAttributes getterAttributes, MemberAttributes setterAttributes)
+        {
+            MemberAttributes access = 0;
+            var getterAccess = getterAttributes & MemberAttributes.AccessMask;
+            var setterAccess = setterAttributes & MemberAttributes.AccessMask;
+            if (getterAccess == MemberAttributes.Public || setterAccess == MemberAttributes.Public)
+                access = MemberAttributes.Public;
+            else if (getterAccess == MemberAttributes.Family || setterAccess == MemberAttributes.Family)
+                access = MemberAttributes.Family;
+            else if (getterAccess == MemberAttributes.FamilyAndAssembly || setterAccess == MemberAttributes.FamilyAndAssembly)
+                access = MemberAttributes.FamilyAndAssembly;
+            else if (getterAccess == MemberAttributes.FamilyOrAssembly || setterAccess == MemberAttributes.FamilyOrAssembly)
+                access = MemberAttributes.FamilyOrAssembly;
+            else if (getterAccess == MemberAttributes.Assembly || setterAccess == MemberAttributes.Assembly)
+                access = MemberAttributes.Assembly;
+            else if (getterAccess == MemberAttributes.Private || setterAccess == MemberAttributes.Private)
+                access = MemberAttributes.Private;
+
+            // Scope should be the same for getter and setter. If one isn't specified, it'll be 0
+            var getterScope = getterAttributes & MemberAttributes.ScopeMask;
+            var setterScope = setterAttributes & MemberAttributes.ScopeMask;
+            var scope = (MemberAttributes) Math.Max((int) getterScope, (int) setterScope);
+
+            // Vtable should be the same for getter and setter. If one isn't specified, it'll be 0
+            var getterVtable = getterAttributes & MemberAttributes.VTableMask;
+            var setterVtable = setterAttributes & MemberAttributes.VTableMask;
+            var vtable = (MemberAttributes) Math.Max((int) getterVtable, (int) setterVtable);
+
+            return access | scope | vtable;
+        }
+
+        static bool HasVisiblePropertyMethod(MemberAttributes attributes)
+        {
+            var access = attributes & MemberAttributes.AccessMask;
+            return access == MemberAttributes.Public || access == MemberAttributes.Family ||
+                   access == MemberAttributes.FamilyOrAssembly;
+        }
+
+        static CodeTypeMember GenerateEvent(EventDefinition eventDefinition)
+        {
+            var @event = new CodeMemberEvent
+            {
+                Name = eventDefinition.Name,
+                Attributes = MemberAttributes.Public | MemberAttributes.Final,
+                CustomAttributes = CreateCustomAttributes(eventDefinition),
+                Type = CreateCodeTypeReference(eventDefinition.EventType)
+            };
+
+            return @event;
+        }
+
+        static void AddFieldToTypeDeclaration(CodeTypeDeclaration typeDeclaration, FieldDefinition memberInfo)
+        {
+            if (memberInfo.IsPrivate || memberInfo.IsAssembly || memberInfo.IsSpecialName)
+                return;
+
+            MemberAttributes attributes = 0;
+            if (memberInfo.HasConstant)
+                attributes |= MemberAttributes.Const;
+            if (memberInfo.IsFamily)
+                attributes |= MemberAttributes.Family;
+            if (memberInfo.IsPublic)
+                attributes |= MemberAttributes.Public;
+            if (memberInfo.IsStatic && !memberInfo.HasConstant)
+                attributes |= MemberAttributes.Static;
+
+            // TODO: Values for readonly fields are set in the ctor
+            var codeTypeReference = CreateCodeTypeReference(memberInfo.FieldType);
+            if (memberInfo.IsInitOnly)
+                codeTypeReference = MakeReadonly(codeTypeReference);
+            var field = new CodeMemberField(codeTypeReference, memberInfo.Name)
+            {
+                Attributes = attributes,
+                CustomAttributes = CreateCustomAttributes(memberInfo)
+            };
+
+            if (memberInfo.HasConstant)
+                field.InitExpression = new CodePrimitiveExpression(memberInfo.Constant);
+
+            typeDeclaration.Members.Add(field);
+        }
+
+        static CodeTypeReference MakeReadonly(CodeTypeReference typeReference)
+        {
+            return ModifyCodeTypeReference(typeReference, "readonly");
+        }
+
+        static CodeTypeReference ModifyCodeTypeReference(CodeTypeReference typeReference, string modifier)
+        {
+            using (var provider = new CSharpCodeProvider())
+                return new CodeTypeReference(modifier + " " + provider.GetTypeOutput(typeReference));
+        }
+
+        static CodeTypeReference CreateCodeTypeReference(TypeReference type)
+        {
+            var typeName = GetTypeName(type);
+            return new CodeTypeReference(typeName, CreateGenericArguments(type));
+        }
+
+        static string GetTypeName(TypeReference type)
+        {
+            if (type.IsGenericParameter)
+                return type.Name;
+
+            if (!type.IsNested)
+            {
+                return (!string.IsNullOrEmpty(type.Namespace) ? (type.Namespace + ".") : "") + type.Name;
+            }
+
+            return GetTypeName(type.DeclaringType) + "." + type.Name;
+        }
+
+        static CodeTypeReference[] CreateGenericArguments(TypeReference type)
+        {
+            var genericInstance = type as IGenericInstance;
+            if (genericInstance == null) return null;
+
+            var genericArguments = new List<CodeTypeReference>();
+            foreach (var argument in genericInstance.GenericArguments)
+            {
+                genericArguments.Add(CreateCodeTypeReference(argument));
+            }
+            return genericArguments.ToArray();
+        }
+    }
+
+    static class CecilEx
+    {
+        public static IEnumerable<IMemberDefinition> GetMembers(this TypeDefinition type)
+        {
+            return type.Fields.Cast<IMemberDefinition>()
+                .Concat(type.Methods)
+                .Concat(type.Properties)
+                .Concat(type.Events);
+        }
+    }
+}
+
+#endif

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Microsoft.Azure.ServiceBus.UnitTests.csproj
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Microsoft.Azure.ServiceBus.UnitTests.csproj
@@ -18,6 +18,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="API\ApiApprovals.ApproveAzureServiceBus.approved.txt" />
+    <None Remove="API\ApiApprovals.ApproveAzureServiceBus.received.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Azure.ServiceBus\Microsoft.Azure.ServiceBus.csproj" />
   </ItemGroup>
 
@@ -35,6 +40,18 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
     <PackageReference Include="ApiApprover">
+      <Version>6.0.0</Version>
+    </PackageReference>
+    <PackageReference Include="ApprovalTests">
+      <Version>3.0.13</Version>
+    </PackageReference>
+    <PackageReference Include="ApprovalUtilities">
+      <Version>3.0.13</Version>
+    </PackageReference>
+    <PackageReference Include="Mono.Cecil">
+      <Version>0.9.6.4</Version>
+    </PackageReference>
+    <PackageReference Include="PublicApiGenerator">
       <Version>6.0.0</Version>
     </PackageReference>
   </ItemGroup>

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Microsoft.Azure.ServiceBus.UnitTests.csproj
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Microsoft.Azure.ServiceBus.UnitTests.csproj
@@ -33,4 +33,10 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
+    <PackageReference Include="ApiApprover">
+      <Version>6.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/thirdpartynotice.txt
+++ b/thirdpartynotice.txt
@@ -1,0 +1,134 @@
+This file is based on or incorporates material from the projects listed below (Third Party IP).
+The original copyright notice and the license under which Microsoft received such Third Party IP, are set forth below.
+Such licenses and notices are provided for informational purposes only. Microsoft licenses the Third Party IP to you
+under the licensing terms for the Microsoft product. Microsoft reserves all other rights not expressly granted under
+this agreement, whether by implication, estoppel or otherwise.
+
+     ApiApprover
+
+/*
+The MIT License (MIT)
+
+Copyright (c) 2015 Jake Ginnivan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+     ApprovalTests
+/*
+Copyright (c) Llewellyn Falco.  All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License. You may
+obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions
+and limitations under the License.
+*/
+
+      ApprovalUtilities
+/*
+Copyright (c) Llewellyn Falco.  All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License. You may
+obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions
+and limitations under the License.
+*/
+
+     Mono.Cecil
+/*
+Copyright (c) 2008 - 2015 Jb Evain
+Copyright (c) 2008 - 2011 Novell, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+     PublicApiGenerator
+/*
+The MIT License (MIT)
+
+Copyright (c) 2015 Jake Ginnivan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+
+Provided for Informational Purposes Only
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the Software), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Apache 2.0 License
+
+Licensed under the Apache License, Version 2.0 (the License); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+
+See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.


### PR DESCRIPTION
Fixes #40 
This PR allows better control over public API surface.
API approval keeps public API changes from creeping in when those should not be made.

## How does it work?

`ApiApprovals` class contains a test named `ApproveAzureServiceBus`. This test is responsible to perform **public** API surface scan and compare the result with an already approved API (stored in `ApiApprovals.ApproveAzureServiceBus.approved.txt` file that is checked in).

When no public API changes are detected, the test will be green. When a public API is detected, one of the two has to take place:

1. API change should **not** be public. Rectify the issue and re-run the test. If it's green, the issue was addressed properly and API is internalized.
1. API change should be public. The `ApiApprovals.ApproveAzureServiceBus.approved.txt` file needs to be updated with the contents of a temporary generated `ApiApprovals.ApproveAzureServiceBus.received.txt` (this file contains API with all the recent changes). By virtue of updating the `ApiApprovals.ApproveAzureServiceBus.approved.txt` file, API is _approved_.

Example of API change caught by the test:
![image](https://cloud.githubusercontent.com/assets/1309622/26537156/2f4854b2-43fa-11e7-93c9-d1b164df4160.png)

<details>
<summary>Failing test error message</summary>
ApprovalTests.Core.Exceptions.ApprovalMismatchException : Failed Approval: Received file C:\github\SeanFeldman\azure-service-bus-dotnet\test\Microsoft.Azure.ServiceBus.UnitTests\API\ApiApprovals.ApproveAzureServiceBus.received.txt does not match approved file C:\github\SeanFeldman\azure-service-bus-dotnet\test\Microsoft.Azure.ServiceBus.UnitTests\API\ApiApprovals.ApproveAzureServiceBus.approved.txt.
   at ApprovalTests.Approvers.FileApprover.Fail()
   at ApprovalTests.Core.Approver.Verify(IApprovalApprover approver, IApprovalFailureReporter reporter)
   at ApprovalTests.Approvals.Verify(IApprovalWriter writer, IApprovalNamer namer, IApprovalFailureReporter reporter)
   at ApprovalTests.Approvals.Verify(IApprovalWriter writer)
   at ApprovalTests.Approvals.Verify(String text)
   at Microsoft.Azure.ServiceBus.UnitTests.API.ApiApprovals.ApproveAzureServiceBus() in C:\github\SeanFeldman\azure-service-bus-dotnet\test\Microsoft.Azure.ServiceBus.UnitTests\API\APIApprovals.cs:line 19
</details>

## Known limitations

Only works with .NET Framework. 
Since API is target independent, this should not be an issue.