### PR TITLE
RegisterMessageHandler should not block for 1 minute if there are no messages

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Constants.cs
+++ b/src/Microsoft.Azure.ServiceBus/Constants.cs
@@ -40,5 +40,7 @@ namespace Microsoft.Azure.ServiceBus
         public static readonly int DefaultClientPumpPrefetchCount = 5;
 
         public static readonly TimeSpan NoMessageBackoffTimeSpan = TimeSpan.FromSeconds(5);
+
+        public static readonly TimeSpan MessageReceiverStartPumpInitialReceiveTimeout = TimeSpan.Zero;
     }
 }

--- a/src/Microsoft.Azure.ServiceBus/Constants.cs
+++ b/src/Microsoft.Azure.ServiceBus/Constants.cs
@@ -41,6 +41,6 @@ namespace Microsoft.Azure.ServiceBus
 
         public static readonly TimeSpan NoMessageBackoffTimeSpan = TimeSpan.FromSeconds(5);
 
-        public static readonly TimeSpan MessageReceiverStartPumpInitialReceiveTimeout = TimeSpan.Zero;
+        public static readonly TimeSpan MessageReceiverStartPumpInitialReceiveTimeout = TimeSpan.FromSeconds(1);
     }
 }

--- a/src/Microsoft.Azure.ServiceBus/MessageReceivePump.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageReceivePump.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.ServiceBus
 
         public async Task StartPumpAsync()
         {
-            var initialMessage = await this.messageReceiver.ReceiveAsync().ConfigureAwait(false);
+            var initialMessage = await this.messageReceiver.ReceiveAsync(Constants.MessageReceiverStartPumpInitialReceiveTimeout).ConfigureAwait(false);
             if (initialMessage != null)
             {
                 MessagingEventSource.Log.MessageReceiverPumpInitialMessageReceived(this.messageReceiver.ClientId, initialMessage);
@@ -138,7 +138,7 @@ namespace Microsoft.Azure.ServiceBus
 
         void CancelAutoRenewlock(object state)
         {
-            CancellationTokenSource renewLockCancellationTokenSource = (CancellationTokenSource)state;
+            var renewLockCancellationTokenSource = (CancellationTokenSource)state;
             try
             {
                 renewLockCancellationTokenSource.Cancel();

--- a/src/Microsoft.Azure.ServiceBus/Primitives/TaskExtensionHelper.cs
+++ b/src/Microsoft.Azure.ServiceBus/Primitives/TaskExtensionHelper.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.ServiceBus.Primitives
     using System;
     using System.Threading.Tasks;
 
-    class TaskExtensionHelper
+    static class TaskExtensionHelper
     {
         public static void Schedule(Func<Task> func)
         {

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/OnMessageQueueTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/OnMessageQueueTests.cs
@@ -41,6 +41,15 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             await this.OnMessageTestAsync(queueName, maxConcurrentCalls, ReceiveMode.ReceiveAndDelete, false);
         }
 
+        [Theory]
+        [MemberData(nameof(TestPermutations))]
+        [DisplayTestMethodName]
+        void OnMessageRegistrationWithoutPendingMessagesReceiveAndDelete(string queueName, int maxConcurrentCalls)
+        {
+            var queueClient = new QueueClient(TestUtility.NamespaceConnectionString, queueName, ReceiveMode.ReceiveAndDelete);
+            this.OnMessageRegistrationWithoutPendingMessagesTestCase(queueClient.InnerReceiver, maxConcurrentCalls, true);
+        }
+
         async Task OnMessageTestAsync(string queueName, int maxConcurrentCalls, ReceiveMode mode, bool autoComplete)
         {
             const int messageCount = 10;

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/SenderReceiverClientTestBase.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/SenderReceiverClientTestBase.cs
@@ -268,5 +268,20 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             }
             Assert.True(count == messageCount);
         }
+
+        internal void OnMessageRegistrationWithoutPendingMessagesTestCase(
+            IMessageReceiver messageReceiver,
+            int maxConcurrentCalls,
+            bool autoComplete)
+        {
+            var stopwatch = Stopwatch.StartNew();
+
+            messageReceiver.RegisterMessageHandler(
+                (message, token) => throw new Exception("Was not supposed to receive any messages"),
+                new MessageHandlerOptions { MaxConcurrentCalls = maxConcurrentCalls, AutoComplete = autoComplete });
+
+            stopwatch.Stop();
+            Assert.True(stopwatch.Elapsed.TotalSeconds < 10, "OnMessage handler registration took longer than 10 seconds.");
+        }
     }
 }


### PR DESCRIPTION
Address #154 / #177 by reducing initial message receive wait time in the `MessageReceivePump` from 60 seconds to 1 second.