### PR TITLE
Replacing System.TimeoutException with ServiceBusTimeoutException

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpExceptionHelper.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpExceptionHelper.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
                 case OperationCanceledException _:
                     return new ServiceBusException(true, message, exception);
 
-                case TimeoutException _ when referenceId != null:
+                case TimeoutException _:
                     return new ServiceBusTimeoutException(message, exception);
             }
 

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpExceptionHelper.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpExceptionHelper.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Azure.ServiceBus.Primitives;
+
 namespace Microsoft.Azure.ServiceBus.Amqp
 {
     using System;
@@ -192,7 +194,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
                     return new ServiceBusException(true, message, exception);
 
                 case TimeoutException _ when referenceId != null:
-                    return new TimeoutException(message, exception);
+                    return new ServiceBusTimeoutException(message, exception);
             }
 
             return exception;

--- a/src/Microsoft.Azure.ServiceBus/Primitives/ServiceBusTimeoutException.cs
+++ b/src/Microsoft.Azure.ServiceBus/Primitives/ServiceBusTimeoutException.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.ServiceBus.Primitives
+{
+    using System;
+
+    /// <summary>
+    /// The exception that is thrown when a time out is encountered.  Callers retry the operation.
+    /// </summary>
+    public class ServiceBusTimeoutException : ServiceBusException
+    {
+        internal ServiceBusTimeoutException(string message) : this(message, null)
+        {
+        }
+
+        internal ServiceBusTimeoutException(string message, Exception innerException) : base(true, message, innerException)
+        {
+        }
+    }
+}

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -449,4 +449,5 @@ namespace Microsoft.Azure.ServiceBus.Primitives
         public string Action { get; }
         public System.Exception Exception { get; }
     }
+    public class ServiceBusTimeoutException : Microsoft.Azure.ServiceBus.ServiceBusException { }
 }


### PR DESCRIPTION
Fixes #173 

Introduces `ServiceBusTimeoutException` to replace `System.TimeoutException` that cannot be marked as transient.