### PR TITLE
Fix on message registration delay issue

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Constants.cs
+++ b/src/Microsoft.Azure.ServiceBus/Constants.cs
@@ -40,7 +40,5 @@ namespace Microsoft.Azure.ServiceBus
         public static readonly int DefaultClientPumpPrefetchCount = 5;
 
         public static readonly TimeSpan NoMessageBackoffTimeSpan = TimeSpan.FromSeconds(5);
-
-        public static readonly TimeSpan MessageReceiverStartPumpInitialReceiveTimeout = TimeSpan.FromSeconds(1);
     }
 }

--- a/src/Microsoft.Azure.ServiceBus/Core/IReceiverClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/IReceiverClient.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.ServiceBus.Core
     using System;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.ServiceBus.Primitives;
 
     /// <summary>
     /// An interface used to describe common functionality for receiving messages from queues and subscriptions.
@@ -26,7 +27,8 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// Registers a message handler and begins a new thread to receive messages.
         /// </summary>
         /// <param name="handler">A <see cref="Func{T1, T2, TResult}"/> that processes messages.</param>
-        void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler);
+        /// <param name="exceptionReceivedHandler"></param>
+        void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, Action<object, ExceptionReceivedEventArgs> exceptionReceivedHandler);
 
         /// <summary>
         /// Registers a message handler and begins a new thread to receive messages.

--- a/src/Microsoft.Azure.ServiceBus/Core/IReceiverClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/IReceiverClient.cs
@@ -27,8 +27,8 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// Registers a message handler and begins a new thread to receive messages.
         /// </summary>
         /// <param name="handler">A <see cref="Func{T1, T2, TResult}"/> that processes messages.</param>
-        /// <param name="exceptionReceivedHandler"></param>
-        void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, Action<object, ExceptionReceivedEventArgs> exceptionReceivedHandler);
+        /// <param name="exceptionReceivedHandler">A <see cref="Func{T1, TResult}"/> that is used to notify exceptions.</param>
+        void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler);
 
         /// <summary>
         /// Registers a message handler and begins a new thread to receive messages.

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -584,8 +584,8 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// Registers a message handler and begins a new thread to receive messages.
         /// </summary>
         /// <param name="handler">A <see cref="Func{T1, T2, TResult}"/> that processes messages.</param>
-        /// <param name="exceptionReceivedHandler"></param>
-        public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, Action<object, ExceptionReceivedEventArgs> exceptionReceivedHandler)
+        /// <param name="exceptionReceivedHandler">A <see cref="Func{T1, TResult}"/> that is used to notify exceptions.</param>
+        public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler)
         {
             this.RegisterMessageHandler(handler, new MessageHandlerOptions(exceptionReceivedHandler));
         }
@@ -597,7 +597,6 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// <param name="messageHandlerOptions">The <see cref="MessageHandlerOptions"/> options used to register a message handler.</param>
         public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, MessageHandlerOptions messageHandlerOptions)
         {
-            messageHandlerOptions.MessageClientEntity = this;
             this.OnMessageHandler(messageHandlerOptions, handler);
         }
 

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -584,9 +584,10 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// Registers a message handler and begins a new thread to receive messages.
         /// </summary>
         /// <param name="handler">A <see cref="Func{T1, T2, TResult}"/> that processes messages.</param>
-        public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler)
+        /// <param name="exceptionReceivedHandler"></param>
+        public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, Action<object, ExceptionReceivedEventArgs> exceptionReceivedHandler)
         {
-            this.RegisterMessageHandler(handler, new MessageHandlerOptions());
+            this.RegisterMessageHandler(handler, new MessageHandlerOptions(exceptionReceivedHandler));
         }
 
         /// <summary>
@@ -597,7 +598,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, MessageHandlerOptions messageHandlerOptions)
         {
             messageHandlerOptions.MessageClientEntity = this;
-            this.OnMessageHandlerAsync(messageHandlerOptions, handler).GetAwaiter().GetResult();
+            this.OnMessageHandler(messageHandlerOptions, handler);
         }
 
         /// <summary></summary>
@@ -1087,7 +1088,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
         }
 
-        async Task OnMessageHandlerAsync(
+        void OnMessageHandler(
             MessageHandlerOptions registerHandlerOptions,
             Func<Message, CancellationToken, Task> callback)
         {
@@ -1106,7 +1107,7 @@ namespace Microsoft.Azure.ServiceBus.Core
 
             try
             {
-                await this.receivePump.StartPumpAsync().ConfigureAwait(false);
+                this.receivePump.StartPump();
             }
             catch (Exception exception)
             {

--- a/src/Microsoft.Azure.ServiceBus/MessageHandlerOptions.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageHandlerOptions.cs
@@ -85,7 +85,14 @@ namespace Microsoft.Azure.ServiceBus
 
         internal async Task RaiseExceptionReceived(ExceptionReceivedEventArgs eventArgs)
         {
-            await this.ExceptionReceivedHandler(eventArgs).ConfigureAwait(false);
+            try
+            {
+                await this.ExceptionReceivedHandler(eventArgs).ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                MessagingEventSource.Log.ExceptionReceivedHandlerThrewException(exception);
+            }
         }
     }
 }

--- a/src/Microsoft.Azure.ServiceBus/MessageHandlerOptions.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageHandlerOptions.cs
@@ -21,17 +21,18 @@ namespace Microsoft.Azure.ServiceBus
         ///     <see cref="ReceiveTimeOut"/> = 1 minute
         ///     <see cref="MaxAutoRenewDuration"/> = 5 minutes
         /// </summary>
-        public MessageHandlerOptions()
+        public MessageHandlerOptions(Action<object, ExceptionReceivedEventArgs> exceptionReceivedHandler)
         {
             this.MaxConcurrentCalls = 1;
             this.AutoComplete = true;
             this.ReceiveTimeOut = Constants.DefaultOperationTimeout;
             this.MaxAutoRenewDuration = Constants.ClientPumpRenewLockTimeout;
+            this.ExceptionReceivedHandler = exceptionReceivedHandler ?? throw new ArgumentNullException(nameof(exceptionReceivedHandler));
         }
 
         /// <summary>Occurs when an exception is received. Enables you to be notified of any errors encountered by the message pump.
         /// When errors are received calls will automatically be retried, so this is informational. </summary>
-        public event EventHandler<ExceptionReceivedEventArgs> ExceptionReceived;
+        public Action<object, ExceptionReceivedEventArgs> ExceptionReceivedHandler { get; set; }
 
         /// <summary>Gets or sets the maximum number of concurrent calls to the callback the message pump should initiate.</summary>
         /// <value>The maximum number of concurrent calls to the callback.</value>
@@ -84,7 +85,7 @@ namespace Microsoft.Azure.ServiceBus
 
         internal void RaiseExceptionReceived(ExceptionReceivedEventArgs e)
         {
-            this.ExceptionReceived?.Invoke(this.MessageClientEntity, e);
+            this.ExceptionReceivedHandler(this.MessageClientEntity, e);
         }
     }
 }

--- a/src/Microsoft.Azure.ServiceBus/MessageReceivePump.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageReceivePump.cs
@@ -44,10 +44,10 @@ namespace Microsoft.Azure.ServiceBus
                 this.registerHandlerOptions.AutoRenewLock;
         }
 
-        async Task RaiseExceptionReceived(Exception e, string action)
+        Task RaiseExceptionReceived(Exception e, string action)
         {
             var eventArgs = new ExceptionReceivedEventArgs(e, action, this.endpoint, this.messageReceiver.Path, this.messageReceiver.ClientId);
-            await this.registerHandlerOptions.RaiseExceptionReceived(eventArgs).ConfigureAwait(false);
+            return this.registerHandlerOptions.RaiseExceptionReceived(eventArgs);
         }
 
         async Task MessagePumpTaskAsync()

--- a/src/Microsoft.Azure.ServiceBus/MessagingEventSource.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessagingEventSource.cs
@@ -1165,5 +1165,20 @@ namespace Microsoft.Azure.ServiceBus
         {
             WriteEvent(98, funcTargetName, methodInfoName, exception);
         }
+
+        [NonEvent]
+        public void ExceptionReceivedHandlerThrewException(Exception exception)
+        {
+            if (this.IsEnabled())
+            {
+                this.ExceptionReceivedHandlerThrewException(exception.ToString());
+            }
+        }
+
+        [Event(99, Level = EventLevel.Error, Message = "ExceptionReceivedHandler threw exception. Exception:{0}")]
+        void ExceptionReceivedHandlerThrewException(string exception)
+        {
+            WriteEvent(99, exception);
+        }
     }
 }

--- a/src/Microsoft.Azure.ServiceBus/MessagingEventSource.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessagingEventSource.cs
@@ -720,36 +720,6 @@ namespace Microsoft.Azure.ServiceBus
         }
 
         [NonEvent]
-        public void MessageReceiverPumpInitialMessageReceived(string clientId, Message message)
-        {
-            if (this.IsEnabled())
-            {
-                this.MessageReceiverPumpInitialMessageReceived(clientId, message.SystemProperties.SequenceNumber);
-            }
-        }
-
-        [Event(64, Level = EventLevel.Informational, Message = "{0}: MessageReceiverPump Received Initial Message: SequenceNumber: {1}")]
-        void MessageReceiverPumpInitialMessageReceived(string clientId, long sequenceNumber)
-        {
-            this.WriteEvent(64, clientId, sequenceNumber);
-        }
-
-        [NonEvent]
-        public void MessageReceiverPumpInitialMessageReceiveException(string clientId, int retryCount, Exception exception)
-        {
-            if (this.IsEnabled())
-            {
-                this.MessageReceiverPumpInitialMessageReceiveException(clientId, retryCount, exception.ToString());
-            }
-        }
-
-        [Event(65, Level = EventLevel.Error, Message = "{0}: MessageReceiverPump Receive Initial Message Exception: RetryCount: {1}, Exception: {2}")]
-        void MessageReceiverPumpInitialMessageReceiveException(string clientId, int retryCount, string exception)
-        {
-            this.WriteEvent(65, clientId, retryCount, exception);
-        }
-
-        [NonEvent]
         public void MessageReceiverPumpTaskStart(string clientId, Message message, int currentSemaphoreCount)
         {
             if (this.IsEnabled())

--- a/src/Microsoft.Azure.ServiceBus/Primitives/ExceptionReceivedContext.cs
+++ b/src/Microsoft.Azure.ServiceBus/Primitives/ExceptionReceivedContext.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.ServiceBus.Primitives
         /// <param name="action">The action associated with the exception.</param>
         /// <param name="endpoint">The endpoint associated with the exception.</param>
         /// <param name="entityPath">The entity path associated with the exception.</param>
-        /// <param name="clientId">The Client Id associated with the sender, receiver or session when this exception occured.</param>
+        /// <param name="clientId">The Client Id can be used to associate with the Queueclient, SubscriptionClient, MessageSender or MessageReceiver that encountered the exception.</param>
         public ExceptionReceivedContext(string action, string endpoint, string entityPath, string clientId)
         {
             Action = action ?? throw new ArgumentNullException(nameof(action));

--- a/src/Microsoft.Azure.ServiceBus/Primitives/ExceptionReceivedContext.cs
+++ b/src/Microsoft.Azure.ServiceBus/Primitives/ExceptionReceivedContext.cs
@@ -12,11 +12,13 @@ namespace Microsoft.Azure.ServiceBus.Primitives
         /// <param name="action">The action associated with the exception.</param>
         /// <param name="endpoint">The endpoint associated with the exception.</param>
         /// <param name="entityPath">The entity path associated with the exception.</param>
-        public ExceptionReceivedContext(string action, string endpoint, string entityPath)
+        /// <param name="clientId">The Client Id associated with the sender, receiver or session when this exception occured.</param>
+        public ExceptionReceivedContext(string action, string endpoint, string entityPath, string clientId)
         {
             Action = action ?? throw new ArgumentNullException(nameof(action));
             Endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
             EntityPath = entityPath ?? throw new ArgumentNullException(nameof(entityPath));
+            ClientId = clientId ?? throw new ArgumentNullException(nameof(clientId));
         }
 
         /// <summary>Gets the action associated with the event.</summary>
@@ -28,5 +30,8 @@ namespace Microsoft.Azure.ServiceBus.Primitives
 
         /// <summary>The entity path used when this exception occured.</summary>
         public string EntityPath { get; private set; }
+
+        /// <summary>The Client Id associated with the sender, receiver or session when this exception occured.</summary>
+        public string ClientId { get; private set; }
     }
 }

--- a/src/Microsoft.Azure.ServiceBus/Primitives/ExceptionReceivedEventArgs.cs
+++ b/src/Microsoft.Azure.ServiceBus/Primitives/ExceptionReceivedEventArgs.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Azure.ServiceBus.Primitives
 {
     using System;
 
-    /// <summary>Provides data for the <see cref="MessageHandlerOptions.ExceptionReceived" /> event.</summary>
+    /// <summary>Provides data for the <see cref="MessageHandlerOptions.ExceptionReceivedHandler" /> event.</summary>
     public sealed class ExceptionReceivedEventArgs : EventArgs
     {
         /// <summary>Initializes a new instance of the <see cref="ExceptionReceivedEventArgs" /> class.</summary>

--- a/src/Microsoft.Azure.ServiceBus/Primitives/ExceptionReceivedEventArgs.cs
+++ b/src/Microsoft.Azure.ServiceBus/Primitives/ExceptionReceivedEventArgs.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.ServiceBus.Primitives
         /// <param name="action">The action associated with the event.</param>
         /// <param name="endpoint">The endpoint used when this exception occurred.</param>
         /// <param name="entityName">The entity path used when this exception occurred.</param>
-        /// <param name="clientId">The Client Id associated with the sender, receiver or session when this exception occured.</param>
+        /// <param name="clientId">The Client Id can be used to associate with the Queueclient, SubscriptionClient, MessageSender or MessageReceiver that encountered the exception.</param>
         public ExceptionReceivedEventArgs(Exception exception, string action, string endpoint, string entityName, string clientId)
         {
             this.Exception = exception;

--- a/src/Microsoft.Azure.ServiceBus/Primitives/ExceptionReceivedEventArgs.cs
+++ b/src/Microsoft.Azure.ServiceBus/Primitives/ExceptionReceivedEventArgs.cs
@@ -13,10 +13,11 @@ namespace Microsoft.Azure.ServiceBus.Primitives
         /// <param name="action">The action associated with the event.</param>
         /// <param name="endpoint">The endpoint used when this exception occurred.</param>
         /// <param name="entityName">The entity path used when this exception occurred.</param>
-        public ExceptionReceivedEventArgs(Exception exception, string action, string endpoint, string entityName)
+        /// <param name="clientId">The Client Id associated with the sender, receiver or session when this exception occured.</param>
+        public ExceptionReceivedEventArgs(Exception exception, string action, string endpoint, string entityName, string clientId)
         {
             this.Exception = exception;
-            this.ExceptionReceivedContext = new ExceptionReceivedContext(action, endpoint, entityName);
+            this.ExceptionReceivedContext = new ExceptionReceivedContext(action, endpoint, entityName, clientId);
         }
 
         /// <summary>Gets the parent class exception to which this event data belongs.</summary>

--- a/src/Microsoft.Azure.ServiceBus/QueueClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/QueueClient.cs
@@ -291,8 +291,8 @@ namespace Microsoft.Azure.ServiceBus
 
         /// <summary>Asynchronously processes a message.</summary>
         /// <param name="handler"></param>
-        /// <param name="exceptionReceivedHandler"></param>
-        public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, Action<object, ExceptionReceivedEventArgs> exceptionReceivedHandler)
+        /// <param name="exceptionReceivedHandler">A <see cref="Func{T1, TResult}"/> that is used to notify exceptions.</param>
+        public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler)
         {
             this.InnerReceiver.RegisterMessageHandler(handler, new MessageHandlerOptions(exceptionReceivedHandler));
         }
@@ -307,9 +307,10 @@ namespace Microsoft.Azure.ServiceBus
 
         /// <summary>Register a session handler.</summary>
         /// <param name="handler"></param>
-        public void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, Task> handler)
+        /// <param name="exceptionReceivedHandler">A <see cref="Func{T1, TResult}"/> that is used to notify exceptions.</param>
+        public void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, Task> handler, Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler)
         {
-            var sessionHandlerOptions = new SessionHandlerOptions();
+            var sessionHandlerOptions = new SessionHandlerOptions(exceptionReceivedHandler);
             this.RegisterSessionHandler(handler, sessionHandlerOptions);
         }
 

--- a/src/Microsoft.Azure.ServiceBus/QueueClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/QueueClient.cs
@@ -290,7 +290,7 @@ namespace Microsoft.Azure.ServiceBus
         }
 
         /// <summary>Asynchronously processes a message.</summary>
-        /// <param name="handler"></param>
+        /// <param name="handler">A <see cref="Func{T1, T2, TResult}"/> that processes messages.</param>
         /// <param name="exceptionReceivedHandler">A <see cref="Func{T1, TResult}"/> that is used to notify exceptions.</param>
         public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler)
         {
@@ -298,7 +298,7 @@ namespace Microsoft.Azure.ServiceBus
         }
 
         /// <summary>Asynchronously processes a message.</summary>
-        /// <param name="handler"></param>
+        /// <param name="handler">A <see cref="Func{T1, T2, TResult}"/> that processes messages.</param>
         /// <param name="messageHandlerOptions">Options associated with message pump processing.</param>
         public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, MessageHandlerOptions messageHandlerOptions)
         {
@@ -306,7 +306,7 @@ namespace Microsoft.Azure.ServiceBus
         }
 
         /// <summary>Register a session handler.</summary>
-        /// <param name="handler"></param>
+        /// <param name="handler">A <see cref="Func{T1, T2, TResult}"/> that processes sessions.</param>
         /// <param name="exceptionReceivedHandler">A <see cref="Func{T1, TResult}"/> that is used to notify exceptions.</param>
         public void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, Task> handler, Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler)
         {
@@ -315,7 +315,7 @@ namespace Microsoft.Azure.ServiceBus
         }
 
         /// <summary>Register a session handler.</summary>
-        /// <param name="handler"></param>
+        /// <param name="handler">A <see cref="Func{T1, T2, TResult}"/> that processes sessions.</param>
         /// <param name="sessionHandlerOptions">Options associated with session pump processing.</param>
         public void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, Task> handler, SessionHandlerOptions sessionHandlerOptions)
         {

--- a/src/Microsoft.Azure.ServiceBus/QueueClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/QueueClient.cs
@@ -291,9 +291,10 @@ namespace Microsoft.Azure.ServiceBus
 
         /// <summary>Asynchronously processes a message.</summary>
         /// <param name="handler"></param>
-        public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler)
+        /// <param name="exceptionReceivedHandler"></param>
+        public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, Action<object, ExceptionReceivedEventArgs> exceptionReceivedHandler)
         {
-            this.InnerReceiver.RegisterMessageHandler(handler);
+            this.InnerReceiver.RegisterMessageHandler(handler, new MessageHandlerOptions(exceptionReceivedHandler));
         }
 
         /// <summary>Asynchronously processes a message.</summary>
@@ -317,7 +318,7 @@ namespace Microsoft.Azure.ServiceBus
         /// <param name="sessionHandlerOptions">Options associated with session pump processing.</param>
         public void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, Task> handler, SessionHandlerOptions sessionHandlerOptions)
         {
-            this.SessionPumpHost.OnSessionHandlerAsync(handler, sessionHandlerOptions).GetAwaiter().GetResult();
+            this.SessionPumpHost.OnSessionHandler(handler, sessionHandlerOptions);
         }
 
         /// <summary>

--- a/src/Microsoft.Azure.ServiceBus/SessionHandlerOptions.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionHandlerOptions.cs
@@ -101,7 +101,14 @@ namespace Microsoft.Azure.ServiceBus
 
         internal async Task RaiseExceptionReceived(ExceptionReceivedEventArgs eventArgs)
         {
-            await this.ExceptionReceivedHandler(eventArgs).ConfigureAwait(false);
+            try
+            {
+                await this.ExceptionReceivedHandler(eventArgs).ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                MessagingEventSource.Log.ExceptionReceivedHandlerThrewException(exception);
+            }
         }
     }
 }

--- a/src/Microsoft.Azure.ServiceBus/SessionPumpHost.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionPumpHost.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.ServiceBus
             }
         }
 
-        public async Task OnSessionHandlerAsync(
+        public void OnSessionHandler(
             Func<IMessageSession, Message, CancellationToken, Task> callback,
             SessionHandlerOptions sessionHandlerOptions)
         {
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.ServiceBus
 
             try
             {
-                await this.sessionReceivePump.StartPumpAsync().ConfigureAwait(false);
+                this.sessionReceivePump.StartPump();
             }
             catch (Exception exception)
             {

--- a/src/Microsoft.Azure.ServiceBus/SessionReceivePump.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionReceivePump.cs
@@ -72,10 +72,10 @@ namespace Microsoft.Azure.ServiceBus
                 this.sessionHandlerOptions.AutoRenewLock;
         }
 
-        async Task RaiseExceptionReceived(Exception e, string action)
+        Task RaiseExceptionReceived(Exception e, string action)
         {
             var eventArgs = new ExceptionReceivedEventArgs(e, action, this.endpoint, this.entityPath, this.clientId);
-            await this.sessionHandlerOptions.RaiseExceptionReceived(eventArgs).ConfigureAwait(false);
+            return this.sessionHandlerOptions.RaiseExceptionReceived(eventArgs);
         }
 
         async Task CompleteMessageIfNeededAsync(IMessageSession session, Message message)

--- a/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
@@ -253,7 +253,7 @@ namespace Microsoft.Azure.ServiceBus
         }
 
         /// <summary>Asynchronously processes a message.</summary>
-        /// <param name="handler"></param>
+        /// <param name="handler">A <see cref="Func{T1, T2, TResult}"/> that processes messages.</param>
         /// <param name="exceptionReceivedHandler">A <see cref="Func{T1, TResult}"/> that is used to notify exceptions.</param>
         public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler)
         {
@@ -261,7 +261,7 @@ namespace Microsoft.Azure.ServiceBus
         }
 
         /// <summary>Asynchronously processes a message.</summary>
-        /// <param name="handler"></param>
+        /// <param name="handler">A <see cref="Func{T1, T2, TResult}"/> that processes messages.</param>
         /// <param name="registerHandlerOptions">Calls a message option.</param>
         public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, MessageHandlerOptions registerHandlerOptions)
         {
@@ -269,7 +269,7 @@ namespace Microsoft.Azure.ServiceBus
         }
 
         /// <summary>Register a session handler.</summary>
-        /// <param name="handler"></param>
+        /// <param name="handler">A <see cref="Func{T1, T2, TResult}"/> that processes sessions.</param>
         /// <param name="exceptionReceivedHandler">A <see cref="Func{T1, TResult}"/> that is used to notify exceptions.</param>
         public void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, Task> handler, Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler)
         {
@@ -278,7 +278,7 @@ namespace Microsoft.Azure.ServiceBus
         }
 
         /// <summary>Register a session handler.</summary>
-        /// <param name="handler"></param>
+        /// <param name="handler">A <see cref="Func{T1, T2, TResult}"/> that processes sessions.</param>
         /// <param name="sessionHandlerOptions">Options associated with session pump processing.</param>
         public void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, Task> handler, SessionHandlerOptions sessionHandlerOptions)
         {

--- a/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
@@ -254,9 +254,10 @@ namespace Microsoft.Azure.ServiceBus
 
         /// <summary>Asynchronously processes a message.</summary>
         /// <param name="handler"></param>
-        public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler)
+        /// <param name="exceptionReceivedHandler"></param>
+        public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, Action<object, ExceptionReceivedEventArgs> exceptionReceivedHandler)
         {
-            this.InnerSubscriptionClient.InnerReceiver.RegisterMessageHandler(handler);
+            this.InnerSubscriptionClient.InnerReceiver.RegisterMessageHandler(handler, exceptionReceivedHandler);
         }
 
         /// <summary>Asynchronously processes a message.</summary>
@@ -280,7 +281,7 @@ namespace Microsoft.Azure.ServiceBus
         /// <param name="sessionHandlerOptions">Options associated with session pump processing.</param>
         public void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, Task> handler, SessionHandlerOptions sessionHandlerOptions)
         {
-            this.SessionPumpHost.OnSessionHandlerAsync(handler, sessionHandlerOptions).GetAwaiter().GetResult();
+            this.SessionPumpHost.OnSessionHandler(handler, sessionHandlerOptions);
         }
 
         /// <summary>

--- a/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
@@ -254,8 +254,8 @@ namespace Microsoft.Azure.ServiceBus
 
         /// <summary>Asynchronously processes a message.</summary>
         /// <param name="handler"></param>
-        /// <param name="exceptionReceivedHandler"></param>
-        public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, Action<object, ExceptionReceivedEventArgs> exceptionReceivedHandler)
+        /// <param name="exceptionReceivedHandler">A <see cref="Func{T1, TResult}"/> that is used to notify exceptions.</param>
+        public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler)
         {
             this.InnerSubscriptionClient.InnerReceiver.RegisterMessageHandler(handler, exceptionReceivedHandler);
         }
@@ -270,9 +270,10 @@ namespace Microsoft.Azure.ServiceBus
 
         /// <summary>Register a session handler.</summary>
         /// <param name="handler"></param>
-        public void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, Task> handler)
+        /// <param name="exceptionReceivedHandler">A <see cref="Func{T1, TResult}"/> that is used to notify exceptions.</param>
+        public void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, Task> handler, Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler)
         {
-            var sessionHandlerOptions = new SessionHandlerOptions();
+            var sessionHandlerOptions = new SessionHandlerOptions(exceptionReceivedHandler);
             this.RegisterSessionHandler(handler, sessionHandlerOptions);
         }
 

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -103,11 +103,11 @@ namespace Microsoft.Azure.ServiceBus
     }
     public sealed class MessageHandlerOptions
     {
-        public MessageHandlerOptions() { }
+        public MessageHandlerOptions(System.Func<Microsoft.Azure.ServiceBus.Primitives.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler) { }
         public bool AutoComplete { get; set; }
+        public System.Func<Microsoft.Azure.ServiceBus.Primitives.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> ExceptionReceivedHandler { get; set; }
         public System.TimeSpan MaxAutoRenewDuration { get; set; }
         public int MaxConcurrentCalls { get; set; }
-        public event System.EventHandler<Microsoft.Azure.ServiceBus.Primitives.ExceptionReceivedEventArgs> ExceptionReceived;
     }
     public sealed class MessageLockLostException : Microsoft.Azure.ServiceBus.ServiceBusException { }
     public sealed class MessagingEntityDisabledException : Microsoft.Azure.ServiceBus.ServiceBusException { }
@@ -130,10 +130,10 @@ namespace Microsoft.Azure.ServiceBus
         public System.Threading.Tasks.Task CompleteAsync(string lockToken) { }
         public System.Threading.Tasks.Task DeadLetterAsync(string lockToken) { }
         protected override System.Threading.Tasks.Task OnClosingAsync() { }
-        public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler) { }
+        public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Func<Microsoft.Azure.ServiceBus.Primitives.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler) { }
         public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, Microsoft.Azure.ServiceBus.MessageHandlerOptions messageHandlerOptions) { }
         public void RegisterPlugin(Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin serviceBusPlugin) { }
-        public void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler) { }
+        public void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Func<Microsoft.Azure.ServiceBus.Primitives.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler) { }
         public void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, Microsoft.Azure.ServiceBus.SessionHandlerOptions sessionHandlerOptions) { }
         public System.Threading.Tasks.Task<long> ScheduleMessageAsync(Microsoft.Azure.ServiceBus.Message message, System.DateTimeOffset scheduleEnqueueTimeUtc) { }
         public System.Threading.Tasks.Task SendAsync(Microsoft.Azure.ServiceBus.Message message) { }
@@ -209,12 +209,12 @@ namespace Microsoft.Azure.ServiceBus
     }
     public sealed class SessionHandlerOptions
     {
-        public SessionHandlerOptions() { }
+        public SessionHandlerOptions(System.Func<Microsoft.Azure.ServiceBus.Primitives.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler) { }
         public bool AutoComplete { get; set; }
+        public System.Func<Microsoft.Azure.ServiceBus.Primitives.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> ExceptionReceivedHandler { get; set; }
         public System.TimeSpan MaxAutoRenewDuration { get; set; }
         public int MaxConcurrentSessions { get; set; }
         public System.TimeSpan MessageWaitTimeout { get; set; }
-        public event System.EventHandler<Microsoft.Azure.ServiceBus.Primitives.ExceptionReceivedEventArgs> ExceptionReceived;
     }
     public sealed class SessionLockLostException : Microsoft.Azure.ServiceBus.ServiceBusException { }
     public class SharedAccessSignatureTokenProvider : Microsoft.Azure.ServiceBus.TokenProvider
@@ -240,10 +240,10 @@ namespace Microsoft.Azure.ServiceBus
         public System.Threading.Tasks.Task CompleteAsync(string lockToken) { }
         public System.Threading.Tasks.Task DeadLetterAsync(string lockToken) { }
         protected override System.Threading.Tasks.Task OnClosingAsync() { }
-        public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler) { }
+        public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Func<Microsoft.Azure.ServiceBus.Primitives.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler) { }
         public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, Microsoft.Azure.ServiceBus.MessageHandlerOptions registerHandlerOptions) { }
         public void RegisterPlugin(Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin serviceBusPlugin) { }
-        public void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler) { }
+        public void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Func<Microsoft.Azure.ServiceBus.Primitives.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler) { }
         public void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, Microsoft.Azure.ServiceBus.SessionHandlerOptions sessionHandlerOptions) { }
         public System.Threading.Tasks.Task RemoveRuleAsync(string ruleName) { }
         public void UnregisterPlugin(string serviceBusPluginName) { }
@@ -311,7 +311,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         System.Threading.Tasks.Task AbandonAsync(string lockToken);
         System.Threading.Tasks.Task CompleteAsync(string lockToken);
         System.Threading.Tasks.Task DeadLetterAsync(string lockToken);
-        void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler);
+        void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Func<Microsoft.Azure.ServiceBus.Primitives.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler);
         void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, Microsoft.Azure.ServiceBus.MessageHandlerOptions registerHandlerOptions);
     }
     public interface ISenderClient : Microsoft.Azure.ServiceBus.IClientEntity
@@ -357,7 +357,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         public System.Threading.Tasks.Task<System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Message>> ReceiveAsync(int maxMessageCount, System.TimeSpan serverWaitTime) { }
         public System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.Message> ReceiveBySequenceNumberAsync(long sequenceNumber) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Message>> ReceiveBySequenceNumberAsync(System.Collections.Generic.IEnumerable<long> sequenceNumbers) { }
-        public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler) { }
+        public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Func<Microsoft.Azure.ServiceBus.Primitives.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler) { }
         public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, Microsoft.Azure.ServiceBus.MessageHandlerOptions messageHandlerOptions) { }
         public void RegisterPlugin(Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin serviceBusPlugin) { }
         public System.Threading.Tasks.Task<System.DateTime> RenewLockAsync(string lockToken) { }
@@ -446,14 +446,15 @@ namespace Microsoft.Azure.ServiceBus.Primitives
     
     public class ExceptionReceivedContext
     {
-        public ExceptionReceivedContext(string action, string endpoint, string entityPath) { }
+        public ExceptionReceivedContext(string action, string endpoint, string entityPath, string clientId) { }
         public string Action { get; }
+        public string ClientId { get; }
         public string Endpoint { get; }
         public string EntityPath { get; }
     }
     public sealed class ExceptionReceivedEventArgs : System.EventArgs
     {
-        public ExceptionReceivedEventArgs(System.Exception exception, string action, string endpoint, string entityName) { }
+        public ExceptionReceivedEventArgs(System.Exception exception, string action, string endpoint, string entityName, string clientId) { }
         public System.Exception Exception { get; }
         public Microsoft.Azure.ServiceBus.Primitives.ExceptionReceivedContext ExceptionReceivedContext { get; }
     }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/OnMessageQueueTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/OnMessageQueueTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
 
         [Fact]
         [DisplayTestMethodName]
-        void OnMessageExceptionHandlerCalledTest()
+        async Task OnMessageExceptionHandlerCalledTest()
         {
             string queueName = "nonexistentqueuename";
             bool exceptionReceivedHandlerCalled = false;
@@ -89,10 +89,12 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                     break;
                 }
 
-                Task.Delay(TimeSpan.FromSeconds(1));
+                await Task.Delay(TimeSpan.FromSeconds(1));
             }
 
             Assert.True(exceptionReceivedHandlerCalled);
+
+            await queueClient.CloseAsync();
         }
 
         async Task OnMessageTestAsync(string queueName, int maxConcurrentCalls, ReceiveMode mode, bool autoComplete)

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/OnMessageQueueTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/OnMessageQueueTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit.Sdk;
-
 namespace Microsoft.Azure.ServiceBus.UnitTests
 {
     using System.Collections.Generic;
@@ -43,7 +41,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             await this.OnMessageTestAsync(queueName, maxConcurrentCalls, ReceiveMode.ReceiveAndDelete, false);
         }
 
-        [Theory(Skip = "Flaky. Needs work.")]
+        [Theory]
         [MemberData(nameof(TestPermutations))]
         [DisplayTestMethodName]
         async Task OnMessageRegistrationWithoutPendingMessagesReceiveAndDelete(string queueName, int maxConcurrentCalls)
@@ -51,7 +49,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             var queueClient = new QueueClient(TestUtility.NamespaceConnectionString, queueName, ReceiveMode.ReceiveAndDelete);
             try
             {
-                this.OnMessageRegistrationWithoutPendingMessagesTestCase(queueClient.InnerReceiver, maxConcurrentCalls, true);
+                await this.OnMessageRegistrationWithoutPendingMessagesTestCase(queueClient.InnerSender, queueClient.InnerReceiver, maxConcurrentCalls, true);
             }
             finally
             {

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/OnSessionQueueTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/OnSessionQueueTests.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Threading.Tasks;
     using Core;
     using Microsoft.Azure.ServiceBus.Primitives;
@@ -98,17 +99,44 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
 
         [Fact]
         [DisplayTestMethodName]
-        void OnSessionHandlerShouldFailOnNonSessionFulQueue()
+        async Task OnSessionExceptionHandlerCalledWhenRegisteredOnNonSessionFulQueue()
         {
+            bool exceptionReceivedHandlerCalled = false;
             var queueClient = new QueueClient(TestUtility.NamespaceConnectionString, TestConstants.NonPartitionedQueueName);
 
-            Assert.Throws<InvalidOperationException>(
-               () => queueClient.RegisterSessionHandler(
+            SessionHandlerOptions sessionHandlerOptions = new SessionHandlerOptions(
+            (eventArgs) =>
+            {
+                Assert.NotNull(eventArgs);
+                Assert.NotNull(eventArgs.Exception);
+                if (eventArgs.Exception is InvalidOperationException)
+                {
+                    exceptionReceivedHandlerCalled = true;
+                }
+                return Task.CompletedTask;
+            })
+            { MaxConcurrentSessions = 1 };
+
+            queueClient.RegisterSessionHandler(
                (session, message, token) =>
                {
                    return Task.CompletedTask;
                },
-               ExceptionReceivedHandler));
+               sessionHandlerOptions);
+
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            while (stopwatch.Elapsed.TotalSeconds <= 5)
+            {
+                if (exceptionReceivedHandlerCalled)
+                {
+                    break;
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(1));
+            }
+
+            Assert.True(exceptionReceivedHandlerCalled);
+            await queueClient.CloseAsync();
         }
 
         async Task OnSessionTestAsync(string queueName, int maxConcurrentCalls, ReceiveMode mode, bool autoComplete)

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/OnSessionQueueTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/OnSessionQueueTests.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Core;
+    using Microsoft.Azure.ServiceBus.Primitives;
     using Xunit;
 
     public class OnSessionQueueTests
@@ -60,7 +61,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             try
             {
                 SessionHandlerOptions handlerOptions =
-                    new SessionHandlerOptions()
+                    new SessionHandlerOptions(ExceptionReceivedHandler)
                     {
                         MaxConcurrentSessions = 5,
                         MessageWaitTimeout = TimeSpan.FromSeconds(5),
@@ -106,7 +107,8 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                (session, message, token) =>
                {
                    return Task.CompletedTask;
-               }));
+               },
+               ExceptionReceivedHandler));
         }
 
         async Task OnSessionTestAsync(string queueName, int maxConcurrentCalls, ReceiveMode mode, bool autoComplete)
@@ -116,7 +118,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             try
             {
                 SessionHandlerOptions handlerOptions =
-                    new SessionHandlerOptions()
+                    new SessionHandlerOptions(ExceptionReceivedHandler)
                     {
                         MaxConcurrentSessions = maxConcurrentCalls,
                         MessageWaitTimeout = TimeSpan.FromSeconds(5),
@@ -142,6 +144,12 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             {
                 await queueClient.CloseAsync();
             }
+        }
+
+        Task ExceptionReceivedHandler(ExceptionReceivedEventArgs eventArgs)
+        {
+            TestUtility.Log($"Exception Received: ClientId: {eventArgs.ExceptionReceivedContext.ClientId}, EntityPath: {eventArgs.ExceptionReceivedContext.EntityPath}, Exception: {eventArgs.Exception.Message}");
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/OnSessionTopicSubscriptionTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/OnSessionTopicSubscriptionTests.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using Microsoft.Azure.ServiceBus.Primitives;
     using Xunit;
 
     public class OnSessionTopicSubscriptionTests
@@ -52,7 +53,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                (session, message, token) =>
                {
                    return Task.CompletedTask;
-               }));
+               }, ExceptionReceivedHandler));
         }
 
         async Task OnSessionTestAsync(string topicName, int maxConcurrentCalls, ReceiveMode mode, bool autoComplete)
@@ -68,7 +69,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             try
             {
                 SessionHandlerOptions handlerOptions =
-                    new SessionHandlerOptions()
+                    new SessionHandlerOptions(ExceptionReceivedHandler)
                     {
                         MaxConcurrentSessions = 5,
                         MessageWaitTimeout = TimeSpan.FromSeconds(5),
@@ -95,6 +96,12 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 await subscriptionClient.CloseAsync();
                 await topicClient.CloseAsync();
             }
+        }
+
+        Task ExceptionReceivedHandler(ExceptionReceivedEventArgs eventArgs)
+        {
+            TestUtility.Log($"Exception Received: ClientId: {eventArgs.ExceptionReceivedContext.ClientId}, EntityPath: {eventArgs.ExceptionReceivedContext.EntityPath}, Exception: {eventArgs.Exception.Message}");
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/TestSessionHandler.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/TestSessionHandler.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
 
         public void RegisterSessionHandler(SessionHandlerOptions handlerOptions)
         {
-            this.sessionPumpHost.OnSessionHandlerAsync(this.OnSessionHandler, this.sessionHandlerOptions).GetAwaiter().GetResult();
+            this.sessionPumpHost.OnSessionHandler(this.OnSessionHandler, this.sessionHandlerOptions);
         }
 
         public async Task SendSessionMessages()


### PR DESCRIPTION
## Description
Address issue #189 
Do not block waiting for a message/session when Registering a message/session handler.
Also make the exception handling contract a must when registering an on OnMessage/OnSession handler() so that user thinks about exceptions that might happen on the OnMessage Pump right from the getgo. 


This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.