### PR TITLE
Moved public properties of SessionId and LockedUntilUtc

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Constants.cs
+++ b/src/Microsoft.Azure.ServiceBus/Constants.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Azure.ServiceBus
 
         public const int MaximumSqlRuleActionStatementLength = 1024;
 
+        public const int DefaultClientPrefetchCount = 0;
+
         public static readonly int MaximumMessageHeaderPropertySize = ushort.MaxValue;
 
         public static readonly long DefaultLastPeekedSequenceNumber = 0;
@@ -36,9 +38,7 @@ namespace Microsoft.Azure.ServiceBus
         public static readonly TimeSpan MaximumRenewBufferDuration = TimeSpan.FromSeconds(10);
 
         public static readonly TimeSpan DefaultRetryDeltaBackoff = TimeSpan.FromSeconds(3);
-
-        public static readonly int DefaultClientPumpPrefetchCount = 5;
-
+        
         public static readonly TimeSpan NoMessageBackoffTimeSpan = TimeSpan.FromSeconds(5);
     }
 }

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -42,7 +42,6 @@ namespace Microsoft.Azure.ServiceBus.Core
     public class MessageReceiver : ClientEntity, IMessageReceiver
     {
         private static readonly TimeSpan DefaultBatchFlushInterval = TimeSpan.FromMilliseconds(20);
-        private const int DefaultPrefetchCount = 0;
 
         readonly ConcurrentExpiringSet<Guid> requestResponseLockedMessages;
         readonly bool isSessionReceiver;
@@ -67,7 +66,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             ServiceBusConnectionStringBuilder connectionStringBuilder,
             ReceiveMode receiveMode = ReceiveMode.PeekLock,
             RetryPolicy retryPolicy = null,
-            int prefetchCount = DefaultPrefetchCount)
+            int prefetchCount = Constants.DefaultClientPrefetchCount)
             : this(connectionStringBuilder?.GetNamespaceConnectionString(), connectionStringBuilder?.EntityPath, receiveMode, retryPolicy, prefetchCount)
         {
         }
@@ -88,7 +87,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             string entityPath,
             ReceiveMode receiveMode = ReceiveMode.PeekLock,
             RetryPolicy retryPolicy = null,
-            int prefetchCount = DefaultPrefetchCount)
+            int prefetchCount = Constants.DefaultClientPrefetchCount)
             : this(entityPath, null, receiveMode, new ServiceBusNamespaceConnection(connectionString), null, retryPolicy, prefetchCount)
         {
             if (string.IsNullOrWhiteSpace(connectionString))
@@ -112,7 +111,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             ServiceBusConnection serviceBusConnection,
             ICbsTokenProvider cbsTokenProvider,
             RetryPolicy retryPolicy,
-            int prefetchCount = DefaultPrefetchCount,
+            int prefetchCount = Constants.DefaultClientPrefetchCount,
             string sessionId = null,
             bool isSessionReceiver = false)
             : base(nameof(MessageReceiver) + StringUtility.GetRandomString(), retryPolicy ?? RetryPolicy.Default)
@@ -123,7 +122,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             this.Path = entityPath;
             this.EntityType = entityType;   
             this.CbsTokenProvider = cbsTokenProvider;
-            this.SessionId = sessionId;
+            this.SessionIdInternal = sessionId;
             this.isSessionReceiver = isSessionReceiver;
             this.ReceiveLinkManager = new FaultTolerantAmqpObject<ReceivingAmqpLink>(this.CreateLinkAsync, this.CloseSession);
             this.RequestResponseLinkManager = new FaultTolerantAmqpObject<RequestResponseAmqpLink>(this.CreateRequestResponseLinkAsync, this.CloseRequestResponseSession);
@@ -216,12 +215,12 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// <summary>
         /// Gets the DateTime that the current receiver is locked until. This is only applicable when Sessions are used.
         /// </summary>
-        public DateTime LockedUntilUtc { get; set; }
+        internal DateTime LockedUntilUtcInternal { get; set; }
 
         /// <summary>
         /// Gets the SessionId of the current receiver. This is only applicable when Sessions are used.
         /// </summary>
-        public string SessionId { get; set; }
+        internal string SessionIdInternal { get; set; }
 
         internal MessagingEntityType? EntityType { get; private set; }
 
@@ -706,10 +705,10 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
             if (!string.IsNullOrWhiteSpace(tempSessionId))
             {
-                this.SessionId = tempSessionId;
+                this.SessionIdInternal = tempSessionId;
             }
             long lockedUntilUtcTicks;
-            this.LockedUntilUtc = receivingAmqpLink.Settings.Properties.TryGetValue(AmqpClientConstants.LockedUntilUtc, out lockedUntilUtcTicks) ? new DateTime(lockedUntilUtcTicks, DateTimeKind.Utc) : DateTime.MinValue;
+            this.LockedUntilUtcInternal = receivingAmqpLink.Settings.Properties.TryGetValue(AmqpClientConstants.LockedUntilUtc, out lockedUntilUtcTicks) ? new DateTime(lockedUntilUtcTicks, DateTimeKind.Utc) : DateTime.MinValue;
         }
 
         internal async Task<AmqpResponseMessage> ExecuteRequestResponseAsync(AmqpRequestMessage amqpRequestMessage)
@@ -814,9 +813,9 @@ namespace Microsoft.Azure.ServiceBus.Core
                 requestMessage.Map[ManagementConstants.Properties.FromSequenceNumber] = fromSequenceNumber;
                 requestMessage.Map[ManagementConstants.Properties.MessageCount] = messageCount;
 
-                if (!string.IsNullOrWhiteSpace(this.SessionId))
+                if (!string.IsNullOrWhiteSpace(this.SessionIdInternal))
                 {
-                    requestMessage.Map[ManagementConstants.Properties.SessionId] = this.SessionId;
+                    requestMessage.Map[ManagementConstants.Properties.SessionId] = this.SessionIdInternal;
                 }
 
                 List<Message> messages = new List<Message>();
@@ -1092,7 +1091,7 @@ namespace Microsoft.Azure.ServiceBus.Core
 
             if (this.isSessionReceiver)
             {
-                filterMap = new FilterSet { { AmqpClientConstants.SessionFilterName, this.SessionId } };
+                filterMap = new FilterSet { { AmqpClientConstants.SessionFilterName, this.SessionIdInternal } };
             }
 
             AmqpLinkSettings linkSettings = new AmqpLinkSettings

--- a/src/Microsoft.Azure.ServiceBus/MessageSession.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageSession.cs
@@ -32,8 +32,8 @@ namespace Microsoft.Azure.ServiceBus
         /// </summary>
         public DateTime LockedUntilUtc
         {
-            get => LockedUntilUtcInternal;
-            internal set => LockedUntilUtcInternal = value;
+            get => this.LockedUntilUtcInternal;
+            internal set => this.LockedUntilUtcInternal = value;
         }
 
         /// <summary>
@@ -41,8 +41,8 @@ namespace Microsoft.Azure.ServiceBus
         /// </summary>
         public string SessionId
         {
-            get => SessionIdInternal;
-            internal set => SessionIdInternal = value;
+            get => this.SessionIdInternal;
+            internal set => this.SessionIdInternal = value;
         }
 
         public Task<Stream> GetStateAsync()

--- a/src/Microsoft.Azure.ServiceBus/MessageSession.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageSession.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.ServiceBus
         }
 
         /// <summary>
-        /// Gets the DateTime that the current receiver is locked until. This is only applicable when Sessions are used.
+        /// Gets the time that the session identified by <see cref="SessionId"/> is locked until for this client.
         /// </summary>
         public DateTime LockedUntilUtc
         {
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.ServiceBus
         }
 
         /// <summary>
-        /// Gets the SessionId of the current receiver. This is only applicable when Sessions are used.
+        /// Gets the SessionId.
         /// </summary>
         public string SessionId
         {

--- a/src/Microsoft.Azure.ServiceBus/SessionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionClient.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Azure.ServiceBus
             MessagingEventSource.Log.AmqpSessionClientAcceptMessageSessionStop(
                 this.ClientId,
                 this.EntityPath,
-                session.SessionId);
+                session.SessionIdInternal);
 
             return session;
         }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -363,12 +363,10 @@ namespace Microsoft.Azure.ServiceBus.Core
         public MessageReceiver(string connectionString, string entityPath, Microsoft.Azure.ServiceBus.ReceiveMode receiveMode = 0, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null, int prefetchCount = 0) { }
         protected MessageReceiver(Microsoft.Azure.ServiceBus.ReceiveMode receiveMode, System.TimeSpan operationTimeout, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy) { }
         public long LastPeekedSequenceNumber { get; }
-        public System.DateTime LockedUntilUtc { get; set; }
         public string Path { get; }
         public int PrefetchCount { get; set; }
         public Microsoft.Azure.ServiceBus.ReceiveMode ReceiveMode { get; set; }
         public override System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin> RegisteredPlugins { get; }
-        public string SessionId { get; set; }
         public System.Threading.Tasks.Task AbandonAsync(string lockToken) { }
         public System.Threading.Tasks.Task CompleteAsync(string lockToken) { }
         public System.Threading.Tasks.Task CompleteAsync(System.Collections.Generic.IEnumerable<string> lockTokens) { }


### PR DESCRIPTION
## Description
Moved public properties of SessionId and LockedUntilUtc from MessageReceiver to MessageSession.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.