### PR TITLE
Closing sessionClient

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -354,7 +354,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// <returns>Message with the sequence number <paramref name="sequenceNumber"/>. Returns null if no such message is found.</returns>
         public async Task<Message> ReceiveBySequenceNumberAsync(long sequenceNumber)
         {
-            IList<Message> messages = await this.ReceiveBySequenceNumberAsync(new long[] { sequenceNumber });
+            IList<Message> messages = await this.ReceiveBySequenceNumberAsync(new long[] { sequenceNumber }).ConfigureAwait(false);
             if (messages != null && messages.Count > 0)
             {
                 return messages[0];

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
@@ -366,7 +366,7 @@ namespace Microsoft.Azure.ServiceBus.Core
                 request.Map[ManagementConstants.Properties.Messages] = new List<AmqpMap> { entry };
 
                 IEnumerable<long> sequenceNumbers = null;
-                var response = await this.ExecuteRequestResponseAsync(request);
+                var response = await this.ExecuteRequestResponseAsync(request).ConfigureAwait(false);
                 if (response.StatusCode == AmqpResponseStatusCode.OK)
                 {
                     sequenceNumbers = response.GetValue<long[]>(ManagementConstants.Properties.SequenceNumbers);

--- a/src/Microsoft.Azure.ServiceBus/MessageSession.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageSession.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.ServiceBus
 
         protected override Task<DateTime> OnRenewLockAsync(string lockToken)
         {
-            throw new InvalidOperationException($"{nameof(RenewLockAsync)} is not supported for Session. Use {this.RenewSessionLockAsync()} to renew sessions instead");
+            throw new InvalidOperationException($"{nameof(RenewLockAsync)} is not supported for Session. Use {nameof(RenewSessionLockAsync)} to renew sessions instead");
         }
 
         protected async Task<Stream> OnGetStateAsync()

--- a/src/Microsoft.Azure.ServiceBus/QueueClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/QueueClient.cs
@@ -284,6 +284,11 @@ namespace Microsoft.Azure.ServiceBus
                 await this.innerReceiver.CloseAsync().ConfigureAwait(false);
             }
 
+            if (this.sessionClient != null)
+            {
+                await this.sessionClient.CloseAsync().ConfigureAwait(false);
+            }
+
             this.sessionPumpHost?.Close();
 
             if (this.ownsConnection)

--- a/src/Microsoft.Azure.ServiceBus/QueueClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/QueueClient.cs
@@ -284,13 +284,13 @@ namespace Microsoft.Azure.ServiceBus
                 await this.innerReceiver.CloseAsync().ConfigureAwait(false);
             }
 
+            this.sessionPumpHost?.Close();
+
             if (this.sessionClient != null)
             {
                 await this.sessionClient.CloseAsync().ConfigureAwait(false);
             }
-
-            this.sessionPumpHost?.Close();
-
+            
             if (this.ownsConnection)
             {
                 await this.ServiceBusConnection.CloseAsync().ConfigureAwait(false);

--- a/src/Microsoft.Azure.ServiceBus/RetryPolicy.cs
+++ b/src/Microsoft.Azure.ServiceBus/RetryPolicy.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.ServiceBus
 
                 try
                 {
-                    await operation();
+                    await operation().ConfigureAwait(false);
 
                     // Its a successful operation. Preemptively reset ServerBusy status.
                     this.ResetServerBusy();

--- a/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
@@ -255,12 +255,12 @@ namespace Microsoft.Azure.ServiceBus
                 await this.innerSubscriptionClient.CloseAsync().ConfigureAwait(false);
             }
 
+            this.sessionPumpHost?.Close();
+
             if (this.sessionClient != null)
             {
                 await this.sessionClient.CloseAsync().ConfigureAwait(false);
             }
-
-            this.sessionPumpHost?.Close();
 
             if (this.ownsConnection)
             {

--- a/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
@@ -255,6 +255,11 @@ namespace Microsoft.Azure.ServiceBus
                 await this.innerSubscriptionClient.CloseAsync().ConfigureAwait(false);
             }
 
+            if (this.sessionClient != null)
+            {
+                await this.sessionClient.CloseAsync().ConfigureAwait(false);
+            }
+
             this.sessionPumpHost?.Close();
 
             if (this.ownsConnection)


### PR DESCRIPTION
## Description
Closing `SessionClient` in all the clients on close

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.