### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# This automatically requests reviews from the code owners when a pull request changes any owned files.
+# Details at https://help.github.com/articles/about-codeowners/
+*       @Azure/azure-service-bus-write


### PR DESCRIPTION
This automatically requests reviews from the code owners when a pull request changes any owned files.

`@Azure/azure-service-bus-write` is not visible to the external contributors. Rather than trying to ping this group or individuals for PRs, code owners will be automatically marked as PR reviewers and notified. More info: https://help.github.com/articles/about-codeowners/

@Azure/azure-service-bus-write please review (if merged, this won't be necessary 😃)