### PR TITLE
Handle the scenario where session link is closed from the broker due to Session timing out

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Azure.ServiceBus.Core
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
@@ -709,8 +708,6 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
 
             receivingAmqpLink.Closed += this.OnSessionReceiverLinkClosed;
-            Debug.WriteLine($"{DateTime.Now}: ReceivingLink: {receivingAmqpLink}");
-
             this.SessionIdInternal = tempSessionId;
             long lockedUntilUtcTicks;
             this.LockedUntilUtcInternal = receivingAmqpLink.Settings.Properties.TryGetValue(AmqpClientConstants.LockedUntilUtc, out lockedUntilUtcTicks) ? new DateTime(lockedUntilUtcTicks, DateTimeKind.Utc) : DateTime.MinValue;
@@ -768,10 +765,8 @@ namespace Microsoft.Azure.ServiceBus.Core
                 TimeoutHelper timeoutHelper = new TimeoutHelper(serverWaitTime, true);              
                 if(!this.ReceiveLinkManager.TryGetOpenedObject(out receiveLink))
                 {
-                    Debug.WriteLine($"{DateTime.Now}: No OpenedObject found: Calling GetOrCreateAsync()");
-                    Console.WriteLine($"{DateTime.Now}: No OpenedObject found: Calling GetOrCreateAsync()");
                     receiveLink = await this.ReceiveLinkManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
-                }              
+                }
 
                 IEnumerable<AmqpMessage> amqpMessages = null;
                 IList<Message> brokeredMessages = null;
@@ -1127,8 +1122,6 @@ namespace Microsoft.Azure.ServiceBus.Core
         async Task<ReceivingAmqpLink> CreateLinkAsync(TimeSpan timeout)
         {
             FilterSet filterMap = null;
-            Debug.WriteLine($"{DateTime.Now}: CreateLinkAsync() called");
-            Console.WriteLine($"{DateTime.Now}: CreateLinkAsync() called");
             MessagingEventSource.Log.AmqpReceiveLinkCreateStart(this.ClientId, false, this.EntityType, this.Path);
 
             if (this.isSessionReceiver)

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -1030,6 +1030,11 @@ namespace Microsoft.Azure.ServiceBus.Core
 
         async Task DisposeMessagesAsync(IEnumerable<Guid> lockTokens, Outcome outcome)
         {
+            if(this.isSessionReceiver)
+            {
+                this.ThrowIfSessionLockLost();
+            }
+
             TimeoutHelper timeoutHelper = new TimeoutHelper(this.OperationTimeout, true);
             IList<ArraySegment<byte>> deliveryTags = this.ConvertLockTokensToDeliveryTags(lockTokens);
 

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -735,6 +735,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             RequestResponseAmqpLink requestResponseAmqpLink = null;
             if (!this.RequestResponseLinkManager.TryGetOpenedObject(out requestResponseAmqpLink))
             {
+                MessagingEventSource.Log.CreatingNewLink(this.ClientId, this.isSessionReceiver, this.SessionIdInternal, true, this.LinkError);
                 requestResponseAmqpLink = await this.RequestResponseLinkManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false); 
             }
 
@@ -765,6 +766,7 @@ namespace Microsoft.Azure.ServiceBus.Core
                 TimeoutHelper timeoutHelper = new TimeoutHelper(serverWaitTime, true);              
                 if(!this.ReceiveLinkManager.TryGetOpenedObject(out receiveLink))
                 {
+                    MessagingEventSource.Log.CreatingNewLink(this.ClientId, this.isSessionReceiver, this.SessionIdInternal, false, this.LinkError);
                     receiveLink = await this.ReceiveLinkManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 }
 
@@ -1043,6 +1045,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             {
                 if (!this.ReceiveLinkManager.TryGetOpenedObject(out receiveLink))
                 {
+                    MessagingEventSource.Log.CreatingNewLink(this.ClientId, this.isSessionReceiver, this.SessionIdInternal, false, this.LinkError);
                     receiveLink = await this.ReceiveLinkManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false); 
                 }
 

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -1122,6 +1122,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         async Task<ReceivingAmqpLink> CreateLinkAsync(TimeSpan timeout)
         {
             FilterSet filterMap = null;
+
             MessagingEventSource.Log.AmqpReceiveLinkCreateStart(this.ClientId, false, this.EntityType, this.Path);
 
             if (this.isSessionReceiver)

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -720,6 +720,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             {
                 AmqpException amqpException = amqpLink.TerminalException as AmqpException;
                 this.LinkError = amqpException != null ? amqpException.Error : null;
+                MessagingEventSource.Log.SessionReceiverLinkClosed(this.ClientId, this.SessionIdInternal, this.LinkError);
             }
         }
 

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
@@ -289,9 +289,14 @@ namespace Microsoft.Azure.ServiceBus.Core
 
         internal async Task<AmqpResponseMessage> ExecuteRequestResponseAsync(AmqpRequestMessage amqpRequestMessage)
         {
+            RequestResponseAmqpLink requestResponseAmqpLink = null;
             AmqpMessage amqpMessage = amqpRequestMessage.AmqpMessage;
             TimeoutHelper timeoutHelper = new TimeoutHelper(this.OperationTimeout, true);
-            RequestResponseAmqpLink requestResponseAmqpLink = await this.RequestResponseLinkManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+
+            if (!this.RequestResponseLinkManager.TryGetOpenedObject(out requestResponseAmqpLink))
+            {
+                requestResponseAmqpLink = await this.RequestResponseLinkManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false); 
+            }
 
             AmqpMessage responseAmqpMessage = await Task.Factory.FromAsync(
                 (c, s) => requestResponseAmqpLink.BeginRequest(amqpMessage, timeoutHelper.RemainingTime(), c, s),
@@ -310,7 +315,10 @@ namespace Microsoft.Azure.ServiceBus.Core
                 SendingAmqpLink amqpLink = null;
                 try
                 {
-                    amqpLink = await this.SendLinkManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+                    if (!this.SendLinkManager.TryGetOpenedObject(out amqpLink))
+                    {
+                        amqpLink = await this.SendLinkManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false); 
+                    }
                     if (amqpLink.Settings.MaxMessageSize.HasValue)
                     {
                         ulong size = (ulong)amqpMessage.SerializedMessageSize;

--- a/src/Microsoft.Azure.ServiceBus/MessagingEventSource.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessagingEventSource.cs
@@ -1190,5 +1190,21 @@ namespace Microsoft.Azure.ServiceBus
         {
             WriteEvent(105, clientId, isSessionReceiver, sessionId, isRequestResponseLink, linkError);
         }
+
+        [NonEvent]
+        public void SessionReceiverLinkClosed(string clientId, string sessionId, Error linkError)
+        {
+            if (this.IsEnabled())
+            {
+                string linkErrorString = linkError != null ? linkError.Condition.Value : string.Empty;
+                this.SessionReceiverLinkClosed(clientId, sessionId ?? string.Empty, linkErrorString);
+            }
+        }
+
+        [Event(106, Level = EventLevel.Error, Message = "SessionReceiver Link Closed. ClientId: {0}, SessionId: {1}, LinkError: {2}.")]
+        void SessionReceiverLinkClosed(string clientId, string sessionId, string linkError)
+        {
+            WriteEvent(106, clientId, sessionId, linkError);
+        }
     }
 }

--- a/src/Microsoft.Azure.ServiceBus/MessagingEventSource.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessagingEventSource.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.ServiceBus
     using System.Reflection;
     using System.Threading.Tasks;
     using Microsoft.Azure.Amqp;
+    using Microsoft.Azure.Amqp.Framing;
 
     [EventSource(Name = "Microsoft-Azure-ServiceBus")]
     internal sealed class MessagingEventSource : EventSource
@@ -1172,6 +1173,22 @@ namespace Microsoft.Azure.ServiceBus
             {
                 WriteEvent(101, oldClientId, newClientId); 
             }
+        }
+
+        [NonEvent]
+        public void CreatingNewLink(string clientId, bool isSessionReceiver, string sessionId, bool isRequestResponseLink, Error linkError)
+        {
+            if (this.IsEnabled())
+            {
+                string linkErrorString = linkError != null ? linkError.Condition.Value : string.Empty;
+                this.CreatingNewLink(clientId, isSessionReceiver, sessionId ?? string.Empty, isRequestResponseLink, linkErrorString);
+            }
+        }
+
+        [Event(102, Level = EventLevel.Error, Message = "Creating/Recreating New Link. ClientId: {0}, IsSessionReceiver: {1}, SessionId: {2}, IsRequestResponseLink: {3}, LinkError: {4}.")]
+        void CreatingNewLink(string clientId, bool isSessionReceiver, string sessionId, bool isRequestResponseLink, string linkError)
+        {
+            WriteEvent(102, clientId, isSessionReceiver, sessionId, isRequestResponseLink, linkError);
         }
     }
 }

--- a/src/Microsoft.Azure.ServiceBus/MessagingEventSource.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessagingEventSource.cs
@@ -1185,10 +1185,10 @@ namespace Microsoft.Azure.ServiceBus
             }
         }
 
-        [Event(102, Level = EventLevel.Error, Message = "Creating/Recreating New Link. ClientId: {0}, IsSessionReceiver: {1}, SessionId: {2}, IsRequestResponseLink: {3}, LinkError: {4}.")]
+        [Event(105, Level = EventLevel.Informational, Message = "Creating/Recreating New Link. ClientId: {0}, IsSessionReceiver: {1}, SessionId: {2}, IsRequestResponseLink: {3}, LinkError: {4}.")]
         void CreatingNewLink(string clientId, bool isSessionReceiver, string sessionId, bool isRequestResponseLink, string linkError)
         {
-            WriteEvent(102, clientId, isSessionReceiver, sessionId, isRequestResponseLink, linkError);
+            WriteEvent(105, clientId, isSessionReceiver, sessionId, isRequestResponseLink, linkError);
         }
     }
 }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/ExpectedMessagingExceptionTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/ExpectedMessagingExceptionTests.cs
@@ -73,57 +73,66 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         }
 
         // TODO: Update this when Session is implemented
-        /*
+
         [Fact]
         async Task SessionLockLostExceptionTest()
         {
-            var messagingFactory = new ServiceBusClientFactory();
-            var queueClient =
-                (QueueClient)messagingFactory.CreateQueueClientFromConnectionString(
-                    TestUtility.GetEntityConnectionString(TestConstants.SessionNonPartitionedQueueName));
+            var sender = new MessageSender(TestUtility.NamespaceConnectionString, TestConstants.SessionNonPartitionedQueueName);
+            var sessionClient = new SessionClient(TestUtility.NamespaceConnectionString, TestConstants.SessionNonPartitionedQueueName);
 
             try
             {
                 var messageId = "test-message1";
                 var sessionId = Guid.NewGuid().ToString();
-            await queueClient.SendAsync(new Message
-                { MessageId = messageId, SessionId = sessionId });
+                await sender.SendAsync(new Message() { MessageId = messageId, SessionId = sessionId });
                 TestUtility.Log($"Sent Message: {messageId} to Session: {sessionId}");
 
-                MessageSession messageSession = await queueClient.AcceptMessageSessionAsync(sessionId);
-            Assert.NotNull(messageSession);
+                var sessionReceiver = await sessionClient.AcceptMessageSessionAsync(sessionId);
+                Assert.NotNull(sessionReceiver);
+                TestUtility.Log($"{DateTime.UtcNow}: Received Session: SessionId: {sessionReceiver.SessionId}");
 
-                var message = await messageSession.ReceiveAsync();
+                Message message = await sessionReceiver.ReceiveAsync();
                 Assert.True(message.MessageId == messageId);
-                TestUtility.Log($"Received Message: SessionId: {messageSession.SessionId}");
+                TestUtility.Log($"{DateTime.UtcNow}: Received Message: MessageId: {message.MessageId}");
 
                 // Let the Session expire
-                await Task.Delay(TimeSpan.FromMinutes(1));
+                TestUtility.Log($"{DateTime.UtcNow}: Waiting 1 min for session lock to time out...");
+                await Task.Delay(TimeSpan.FromSeconds(65));
 
-                // Complete should throw
-                await Assert.ThrowsAsync<SessionLockLostException>(async () => await message.CompleteAsync());
                 try
                 {
-                    await messageSession.CloseAsync();
+                    message = await sessionReceiver.ReceiveAsync();
+                    TestUtility.Log($"{DateTime.UtcNow}: Received Session: SessionId: {sessionReceiver.SessionId}");
                 }
-                catch (Exception e)
+                catch(Exception e)
                 {
-                    TestUtility.Log($"Got Exception on Session Close(): SessionId: {messageSession.SessionId}, Exception: {e.Message}");
+                    TestUtility.Log($"{DateTime.UtcNow}: Got Exception: {e.Message}");
                 }
 
-                messageSession = await queueClient.AcceptMessageSessionAsync(sessionId);
-            Assert.NotNull(messageSession);
+                await Assert.ThrowsAsync<SessionLockLostException>(async () => await sessionReceiver.ReceiveAsync());
+                await Assert.ThrowsAsync<SessionLockLostException>(async () => await sessionReceiver.RenewSessionLockAsync());
+                await Assert.ThrowsAsync<SessionLockLostException>(async () => await sessionReceiver.GetStateAsync());
+                await Assert.ThrowsAsync<SessionLockLostException>(async () => await sessionReceiver.SetStateAsync(null));
+                await Assert.ThrowsAsync<SessionLockLostException>(async () => await sessionReceiver.CompleteAsync(message.SystemProperties.LockToken));
 
-                message = await messageSession.ReceiveAsync();
-                TestUtility.Log($"Received Message: SessionId: {messageSession.SessionId}");
+                await sessionReceiver.CloseAsync();
+                TestUtility.Log($"{DateTime.UtcNow}: Closed Session Receiver...");
 
-                await message.CompleteAsync();
+                //Accept a new Session and Complete the message
+                sessionReceiver = await sessionClient.AcceptMessageSessionAsync(sessionId);
+                Assert.NotNull(sessionReceiver);
+                TestUtility.Log($"{DateTime.UtcNow}: Received Session: SessionId: {sessionReceiver.SessionId}");
+                message = await sessionReceiver.ReceiveAsync();
+                TestUtility.Log($"{DateTime.UtcNow}: Received Message: MessageId: {message.MessageId}");
+                await sessionReceiver.CompleteAsync(message.SystemProperties.LockToken);
+                await sessionReceiver.CloseAsync();
             }
             finally
             {
-                await queueClient.CloseAsync();
+                await sender.CloseAsync();
+                await sessionClient.CloseAsync();
             }
         }
-        */
+
     }
 }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/ExpectedMessagingExceptionTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/ExpectedMessagingExceptionTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 TestUtility.Log($"Received Message: MessageId: {message.MessageId}");
 
                 // Let the Session expire
-                TestUtility.Log($"Waiting 1 min for session lock to time out...");
+                TestUtility.Log($"Waiting for session lock to time out...");
                 await Task.Delay(TimeSpan.FromSeconds(65));
 
                 await Assert.ThrowsAsync<SessionLockLostException>(async () => await sessionReceiver.ReceiveAsync());

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/ExpectedMessagingExceptionTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/ExpectedMessagingExceptionTests.cs
@@ -87,25 +87,15 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
 
                 var sessionReceiver = await sessionClient.AcceptMessageSessionAsync(sessionId);
                 Assert.NotNull(sessionReceiver);
-                TestUtility.Log($"{DateTime.UtcNow}: Received Session: SessionId: {sessionReceiver.SessionId}");
+                TestUtility.Log($"Received Session: SessionId: {sessionReceiver.SessionId}");
 
                 Message message = await sessionReceiver.ReceiveAsync();
                 Assert.True(message.MessageId == messageId);
-                TestUtility.Log($"{DateTime.UtcNow}: Received Message: MessageId: {message.MessageId}");
+                TestUtility.Log($"Received Message: MessageId: {message.MessageId}");
 
                 // Let the Session expire
-                TestUtility.Log($"{DateTime.UtcNow}: Waiting 1 min for session lock to time out...");
+                TestUtility.Log($"Waiting 1 min for session lock to time out...");
                 await Task.Delay(TimeSpan.FromSeconds(65));
-
-                try
-                {
-                    message = await sessionReceiver.ReceiveAsync();
-                    TestUtility.Log($"{DateTime.UtcNow}: Received Session: SessionId: {sessionReceiver.SessionId}");
-                }
-                catch(Exception e)
-                {
-                    TestUtility.Log($"{DateTime.UtcNow}: Got Exception: {e.Message}");
-                }
 
                 await Assert.ThrowsAsync<SessionLockLostException>(async () => await sessionReceiver.ReceiveAsync());
                 await Assert.ThrowsAsync<SessionLockLostException>(async () => await sessionReceiver.RenewSessionLockAsync());
@@ -114,14 +104,14 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 await Assert.ThrowsAsync<SessionLockLostException>(async () => await sessionReceiver.CompleteAsync(message.SystemProperties.LockToken));
 
                 await sessionReceiver.CloseAsync();
-                TestUtility.Log($"{DateTime.UtcNow}: Closed Session Receiver...");
+                TestUtility.Log($"Closed Session Receiver...");
 
                 //Accept a new Session and Complete the message
                 sessionReceiver = await sessionClient.AcceptMessageSessionAsync(sessionId);
                 Assert.NotNull(sessionReceiver);
-                TestUtility.Log($"{DateTime.UtcNow}: Received Session: SessionId: {sessionReceiver.SessionId}");
+                TestUtility.Log($"Received Session: SessionId: {sessionReceiver.SessionId}");
                 message = await sessionReceiver.ReceiveAsync();
-                TestUtility.Log($"{DateTime.UtcNow}: Received Message: MessageId: {message.MessageId}");
+                TestUtility.Log($"Received Message: MessageId: {message.MessageId}");
                 await sessionReceiver.CompleteAsync(message.SystemProperties.LockToken);
                 await sessionReceiver.CloseAsync();
             }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/ExpectedMessagingExceptionTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/ExpectedMessagingExceptionTests.cs
@@ -72,8 +72,6 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             }
         }
 
-        // TODO: Update this when Session is implemented
-
         [Fact]
         async Task SessionLockLostExceptionTest()
         {

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/ExpectedMessagingExceptionTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/ExpectedMessagingExceptionTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
 
                 var sessionReceiver = await sessionClient.AcceptMessageSessionAsync(sessionId);
                 Assert.NotNull(sessionReceiver);
-                TestUtility.Log($"Received Session: SessionId: {sessionReceiver.SessionId}");
+                TestUtility.Log($"Received Session: SessionId: {sessionReceiver.SessionId}: LockedUntilUtc: {sessionReceiver.LockedUntilUtc}");
 
                 Message message = await sessionReceiver.ReceiveAsync();
                 Assert.True(message.MessageId == messageId);
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
 
                 // Let the Session expire
                 TestUtility.Log($"Waiting for session lock to time out...");
-                await Task.Delay(TimeSpan.FromSeconds(65));
+                await Task.Delay(sessionReceiver.LockedUntilUtc - DateTime.UtcNow);
 
                 await Assert.ThrowsAsync<SessionLockLostException>(async () => await sessionReceiver.ReceiveAsync());
                 await Assert.ThrowsAsync<SessionLockLostException>(async () => await sessionReceiver.RenewSessionLockAsync());

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/ExpectedMessagingExceptionTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/ExpectedMessagingExceptionTests.cs
@@ -93,9 +93,9 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 Assert.True(message.MessageId == messageId);
                 TestUtility.Log($"Received Message: MessageId: {message.MessageId}");
 
-                // Let the Session expire
+                // Let the Session expire with some buffer time
                 TestUtility.Log($"Waiting for session lock to time out...");
-                await Task.Delay(sessionReceiver.LockedUntilUtc - DateTime.UtcNow);
+                await Task.Delay((sessionReceiver.LockedUntilUtc - DateTime.UtcNow) + TimeSpan.FromSeconds(5));
 
                 await Assert.ThrowsAsync<SessionLockLostException>(async () => await sessionReceiver.ReceiveAsync());
                 await Assert.ThrowsAsync<SessionLockLostException>(async () => await sessionReceiver.RenewSessionLockAsync());

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/RetryTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/RetryTests.cs
@@ -140,6 +140,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                     }, TimeSpan.FromSeconds(8))
                 .ConfigureAwait(false));
 
+            TestUtility.Log($"Elapsed Milliseconds: {watch.Elapsed.TotalMilliseconds}");
             Assert.True(watch.Elapsed.TotalSeconds < 7);
         }
 


### PR DESCRIPTION
## Description
Handle the scenario where session link is closed from the broker due to Session timing out. The client should detect that scenario and throw SessionLockLostExceptions for any further operations on the session.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.