### PR TITLE
Fix Rule Creation Issue

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ branches:
 skip_tags: true
 matrix:
   fast_finish: true 
-image: Previous Visual Studio 2017
+os: Previous Visual Studio 2017
 environment:
   azure-service-bus-dotnet/ClientSecret:
     secure: yO+qgkyY5FO/4a7rMRl60F5eMTrz03L6r3oD/VCzgKhtuYW5APmgvd9Wu+AHM8T7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ branches:
 skip_tags: true
 matrix:
   fast_finish: true 
-image: Visual Studio 2017
+image: Previous Visual Studio 2017
 environment:
   azure-service-bus-dotnet/ClientSecret:
     secure: yO+qgkyY5FO/4a7rMRl60F5eMTrz03L6r3oD/VCzgKhtuYW5APmgvd9Wu+AHM8T7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ branches:
 skip_tags: true
 matrix:
   fast_finish: true 
-os: Previous Visual Studio 2017
+image: Visual Studio 2017
 environment:
   azure-service-bus-dotnet/ClientSecret:
     secure: yO+qgkyY5FO/4a7rMRl60F5eMTrz03L6r3oD/VCzgKhtuYW5APmgvd9Wu+AHM8T7

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
@@ -357,6 +357,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
 
             AmqpMap amqpAction = GetRuleActionMap(description.Action as SqlRuleAction);
             ruleDescriptionMap[ManagementConstants.Properties.SqlRuleAction] = amqpAction;
+            ruleDescriptionMap[ManagementConstants.Properties.RuleName] = description.Name;
 
             return ruleDescriptionMap;
         }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/SubscriptionClientTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/SubscriptionClientTests.cs
@@ -38,9 +38,9 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 {
                     await subscriptionClient.RemoveRuleAsync(RuleDescription.DefaultRuleName);
                 }
-                catch
+                catch (Exception e)
                 {
-                    // ignored
+                    TestUtility.Log($"Remove Default Rule failed with Exception: {e.Message}");
                 }
 
                 await subscriptionClient.AddRuleAsync(new RuleDescription
@@ -64,8 +64,16 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             }
             finally
             {
-                await subscriptionClient.RemoveRuleAsync("RedCorrelation");
-                await subscriptionClient.AddRuleAsync(RuleDescription.DefaultRuleName, new TrueFilter());
+                try
+                {
+                    await subscriptionClient.RemoveRuleAsync("RedCorrelation");
+                    await subscriptionClient.AddRuleAsync(RuleDescription.DefaultRuleName, new TrueFilter());
+                }
+                catch (Exception e)
+                {
+                    TestUtility.Log($" Cleanup failed with Exception: {e.Message}");
+                }
+
                 await subscriptionClient.CloseAsync();
                 await topicClient.CloseAsync();
             }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/SubscriptionClientTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/SubscriptionClientTests.cs
@@ -129,13 +129,20 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 var messages = await subscriptionClient.InnerSubscriptionClient.InnerReceiver.ReceiveAsync(maxMessageCount: 2);
                 Assert.NotNull(messages);
                 Assert.True(messages.Count == 1);
-                Assert.True(messageId2.Equals(messages.First().MessageId));
-
-                await subscriptionClient.RemoveRuleAsync("RedSql");
-                await subscriptionClient.AddRuleAsync(RuleDescription.DefaultRuleName, new TrueFilter());
+                Assert.True(messageId2.Equals(messages.First().MessageId));                
             }
             finally
-            {               
+            {
+                try
+                {
+                    await subscriptionClient.RemoveRuleAsync("RedSql");
+                    await subscriptionClient.AddRuleAsync(RuleDescription.DefaultRuleName, new TrueFilter());
+                }
+                catch (Exception e)
+                {
+                    TestUtility.Log($" Cleanup failed with Exception: {e.Message}");
+                }
+
                 await subscriptionClient.CloseAsync();
                 await topicClient.CloseAsync();
             }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/SubscriptionClientTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/SubscriptionClientTests.cs
@@ -89,9 +89,9 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 {
                     await subscriptionClient.RemoveRuleAsync(RuleDescription.DefaultRuleName);
                 }
-                catch
+                catch(Exception e)
                 {
-                    // ignored
+                    TestUtility.Log($"Remove Default Rule failed with: {e.Message}");
                 }
 
                 await subscriptionClient.AddRuleAsync(new RuleDescription
@@ -122,11 +122,12 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 Assert.NotNull(messages);
                 Assert.True(messages.Count == 1);
                 Assert.True(messageId2.Equals(messages.First().MessageId));
-            }
-            finally
-            {
+
                 await subscriptionClient.RemoveRuleAsync("RedSql");
                 await subscriptionClient.AddRuleAsync(RuleDescription.DefaultRuleName, new TrueFilter());
+            }
+            finally
+            {               
                 await subscriptionClient.CloseAsync();
                 await topicClient.CloseAsync();
             }


### PR DESCRIPTION
## Description
Amqp RuleCreation on Service Side is expecting the RuleName to be part of the descriptionMap. Until this expectation is resolved on the Service side, passing the RuleName as part of the description Map in the Client.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.