### PR TITLE
Fix Azure Resource Manager template link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See our [Contribution Guidelines](./.github/CONTRIBUTING.md).
 
 In order to run the unit tests, you will need to do the following:
 
-1. Deploy the Azure Resource Manager template located at [/build/azuredeploy.json](/templates/azuredeploy.json) by clicking the following button:
+1. Deploy the Azure Resource Manager template located at [/build/azuredeploy.json](/build/azuredeploy.json) by clicking the following button:
 
     <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-service-bus-dotnet%2Fmaster%2Fbuild%2Fazuredeploy.json" target="_blank">
         <img src="http://azuredeploy.net/deploybutton.png"/>


### PR DESCRIPTION
## Description
In README.md, the link text to download the Azure Resource Manager template for unit tests is /build/azuredeploy.json, but the link itself is /templates/azuredeploy.json.

This minor change brings the link in line, fixing the broken link.