### PR TITLE
Exposing OperationTimeout property's setter on all clients

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -202,6 +202,14 @@ namespace Microsoft.Azure.ServiceBus.Core
         public virtual string Path { get; private set; }
 
         /// <summary>
+        /// Duration after which individual operations will timeout.
+        /// </summary>
+        public override TimeSpan OperationTimeout {
+            get => this.ServiceBusConnection.OperationTimeout;
+            set => this.ServiceBusConnection.OperationTimeout = value;
+        }
+
+        /// <summary>
         /// Gets the DateTime that the current receiver is locked until. This is only applicable when Sessions are used.
         /// </summary>
         internal DateTime LockedUntilUtcInternal { get; set; }

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
@@ -111,6 +111,15 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// </summary>
         public virtual string Path { get; private set; }
 
+        /// <summary>
+        /// Duration after which individual operations will timeout.
+        /// </summary>
+        public override TimeSpan OperationTimeout
+        {
+            get => this.ServiceBusConnection.OperationTimeout;
+            set => this.ServiceBusConnection.OperationTimeout = value;
+        }
+
         internal MessagingEntityType? EntityType { get; private set; }
 
         ServiceBusConnection ServiceBusConnection { get; }

--- a/src/Microsoft.Azure.ServiceBus/Primitives/ClientEntity.cs
+++ b/src/Microsoft.Azure.ServiceBus/Primitives/ClientEntity.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.ServiceBus
         /// <summary>
         /// Duration after which individual operations will timeout.
         /// </summary>
-        public TimeSpan OperationTimeout { get; internal set; }
+        public abstract TimeSpan OperationTimeout { get; set; }
 
         /// <summary>
         /// Gets the ID to identify this client. This can be used to correlate logs and exceptions.

--- a/src/Microsoft.Azure.ServiceBus/Primitives/IClientEntity.cs
+++ b/src/Microsoft.Azure.ServiceBus/Primitives/IClientEntity.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.ServiceBus
         /// <summary>
         /// Duration after which individual operations will timeout.
         /// </summary>
-        TimeSpan OperationTimeout { get; }
+        TimeSpan OperationTimeout { get; set; }
 
         /// <summary>
         /// Closes the Client. Closes the connections opened by it.

--- a/src/Microsoft.Azure.ServiceBus/QueueClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/QueueClient.cs
@@ -126,6 +126,15 @@ namespace Microsoft.Azure.ServiceBus
         public ReceiveMode ReceiveMode { get; }
 
         /// <summary>
+        /// Duration after which individual operations will timeout.
+        /// </summary>
+        public override TimeSpan OperationTimeout
+        {
+            get => this.ServiceBusConnection.OperationTimeout;
+            set => this.ServiceBusConnection.OperationTimeout = value;
+        }
+
+        /// <summary>
         /// Gets the name of the queue.
         /// </summary>
         public string Path => this.QueueName;

--- a/src/Microsoft.Azure.ServiceBus/SessionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionClient.cs
@@ -141,6 +141,15 @@ namespace Microsoft.Azure.ServiceBus
         /// </summary>
         public string EntityPath { get; }
 
+        /// <summary>
+        /// Duration after which individual operations will timeout.
+        /// </summary>
+        public override TimeSpan OperationTimeout
+        {
+            get => this.ServiceBusConnection.OperationTimeout;
+            set => this.ServiceBusConnection.OperationTimeout = value;
+        }
+
         MessagingEntityType? EntityType { get; }
 
         int PrefetchCount { get; }

--- a/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
@@ -140,6 +140,15 @@ namespace Microsoft.Azure.ServiceBus
         public ReceiveMode ReceiveMode { get; }
 
         /// <summary>
+        /// Duration after which individual operations will timeout.
+        /// </summary>
+        public override TimeSpan OperationTimeout
+        {
+            get => this.ServiceBusConnection.OperationTimeout;
+            set => this.ServiceBusConnection.OperationTimeout = value;
+        }
+
+        /// <summary>
         /// Prefetch speeds up the message flow by aiming to have a message readily available for local retrieval when and before the application asks for one using Receive.
         /// Setting a non-zero value prefetches PrefetchCount number of messages.
         /// Setting the value to zero turns prefetch off.</summary>

--- a/src/Microsoft.Azure.ServiceBus/TopicClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/TopicClient.cs
@@ -91,6 +91,15 @@ namespace Microsoft.Azure.ServiceBus
         public string TopicName { get; }
 
         /// <summary>
+        /// Duration after which individual operations will timeout.
+        /// </summary>
+        public override TimeSpan OperationTimeout
+        {
+            get => this.ServiceBusConnection.OperationTimeout;
+            set => this.ServiceBusConnection.OperationTimeout = value;
+        }
+
+        /// <summary>
         /// Gets the name of the topic.
         /// </summary>
         public string Path => this.TopicName;

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.ServiceBus
         protected ClientEntity(string clientId, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy) { }
         public string ClientId { get; }
         public bool IsClosedOrClosing { get; }
-        public System.TimeSpan OperationTimeout { get; }
+        public abstract System.TimeSpan OperationTimeout { get; set; }
         public abstract System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin> RegisteredPlugins { get; }
         public Microsoft.Azure.ServiceBus.RetryPolicy RetryPolicy { get; }
         public System.Threading.Tasks.Task CloseAsync() { }
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.ServiceBus
     {
         string ClientId { get; }
         bool IsClosedOrClosing { get; }
-        System.TimeSpan OperationTimeout { get; }
+        System.TimeSpan OperationTimeout { get; set; }
         System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin> RegisteredPlugins { get; }
         System.Threading.Tasks.Task CloseAsync();
         void RegisterPlugin(Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin serviceBusPlugin);
@@ -134,6 +134,7 @@ namespace Microsoft.Azure.ServiceBus
     {
         public QueueClient(Microsoft.Azure.ServiceBus.ServiceBusConnectionStringBuilder connectionStringBuilder, Microsoft.Azure.ServiceBus.ReceiveMode receiveMode = 0, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null) { }
         public QueueClient(string connectionString, string entityPath, Microsoft.Azure.ServiceBus.ReceiveMode receiveMode = 0, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null) { }
+        public override System.TimeSpan OperationTimeout { get; set; }
         public string Path { get; }
         public int PrefetchCount { get; set; }
         public string QueueName { get; }
@@ -226,6 +227,7 @@ namespace Microsoft.Azure.ServiceBus
         public SessionClient(Microsoft.Azure.ServiceBus.ServiceBusConnectionStringBuilder connectionStringBuilder, Microsoft.Azure.ServiceBus.ReceiveMode receiveMode = 0, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null, int prefetchCount = 0) { }
         public SessionClient(string connectionString, string entityPath, Microsoft.Azure.ServiceBus.ReceiveMode receiveMode = 0, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null, int prefetchCount = 0) { }
         public string EntityPath { get; }
+        public override System.TimeSpan OperationTimeout { get; set; }
         public override System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin> RegisteredPlugins { get; }
         public System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.IMessageSession> AcceptMessageSessionAsync() { }
         public System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.IMessageSession> AcceptMessageSessionAsync(System.TimeSpan serverWaitTime) { }
@@ -256,6 +258,7 @@ namespace Microsoft.Azure.ServiceBus
     {
         public SubscriptionClient(Microsoft.Azure.ServiceBus.ServiceBusConnectionStringBuilder connectionStringBuilder, string subscriptionName, Microsoft.Azure.ServiceBus.ReceiveMode receiveMode = 0, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null) { }
         public SubscriptionClient(string connectionString, string topicPath, string subscriptionName, Microsoft.Azure.ServiceBus.ReceiveMode receiveMode = 0, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null) { }
+        public override System.TimeSpan OperationTimeout { get; set; }
         public string Path { get; }
         public int PrefetchCount { get; set; }
         public Microsoft.Azure.ServiceBus.ReceiveMode ReceiveMode { get; }
@@ -301,6 +304,7 @@ namespace Microsoft.Azure.ServiceBus
     {
         public TopicClient(Microsoft.Azure.ServiceBus.ServiceBusConnectionStringBuilder connectionStringBuilder, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null) { }
         public TopicClient(string connectionString, string entityPath, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null) { }
+        public override System.TimeSpan OperationTimeout { get; set; }
         public string Path { get; }
         public override System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin> RegisteredPlugins { get; }
         public string TopicName { get; }
@@ -365,6 +369,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         public MessageReceiver(Microsoft.Azure.ServiceBus.ServiceBusConnectionStringBuilder connectionStringBuilder, Microsoft.Azure.ServiceBus.ReceiveMode receiveMode = 0, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null, int prefetchCount = 0) { }
         public MessageReceiver(string connectionString, string entityPath, Microsoft.Azure.ServiceBus.ReceiveMode receiveMode = 0, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null, int prefetchCount = 0) { }
         public long LastPeekedSequenceNumber { get; }
+        public override System.TimeSpan OperationTimeout { get; set; }
         public string Path { get; }
         public int PrefetchCount { get; set; }
         public Microsoft.Azure.ServiceBus.ReceiveMode ReceiveMode { get; set; }
@@ -404,6 +409,7 @@ namespace Microsoft.Azure.ServiceBus.Core
     {
         public MessageSender(Microsoft.Azure.ServiceBus.ServiceBusConnectionStringBuilder connectionStringBuilder, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null) { }
         public MessageSender(string connectionString, string entityPath, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null) { }
+        public override System.TimeSpan OperationTimeout { get; set; }
         public string Path { get; }
         public override System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin> RegisteredPlugins { get; }
         public System.Threading.Tasks.Task CancelScheduledMessageAsync(long sequenceNumber) { }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/ExpectedMessagingExceptionTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/ExpectedMessagingExceptionTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
 
                 // Let the Session expire with some buffer time
                 TestUtility.Log($"Waiting for session lock to time out...");
-                await Task.Delay((sessionReceiver.LockedUntilUtc - DateTime.UtcNow) + TimeSpan.FromSeconds(5));
+                await Task.Delay((sessionReceiver.LockedUntilUtc - DateTime.UtcNow) + TimeSpan.FromSeconds(10));
 
                 await Assert.ThrowsAsync<SessionLockLostException>(async () => await sessionReceiver.ReceiveAsync());
                 await Assert.ThrowsAsync<SessionLockLostException>(async () => await sessionReceiver.RenewSessionLockAsync());


### PR DESCRIPTION
## Description
Exposing OperationTimeout property's setter on all clients

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.