### PR TITLE
ExceptionReceivedHandler can be set via constructor only to avoid accidental override via getter property

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/MessageHandlerOptions.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageHandlerOptions.cs
@@ -36,16 +36,13 @@ namespace Microsoft.Azure.ServiceBus
 
         /// <summary>Occurs when an exception is received. Enables you to be notified of any errors encountered by the message pump.
         /// When errors are received calls will automatically be retried, so this is informational. </summary>
-        public Func<ExceptionReceivedEventArgs, Task> ExceptionReceivedHandler { get; set; }
+        public Func<ExceptionReceivedEventArgs, Task> ExceptionReceivedHandler { get; }
 
         /// <summary>Gets or sets the maximum number of concurrent calls to the callback the message pump should initiate.</summary>
         /// <value>The maximum number of concurrent calls to the callback.</value>
         public int MaxConcurrentCalls
         {
-            get
-            {
-                return this.maxConcurrentCalls;
-            }
+            get => this.maxConcurrentCalls;
 
             set
             {
@@ -69,10 +66,7 @@ namespace Microsoft.Azure.ServiceBus
         /// <value>The maximum duration during which locks are automatically renewed.</value>
         public TimeSpan MaxAutoRenewDuration
         {
-            get
-            {
-                return this.maxAutoRenewDuration;
-            }
+            get => this.maxAutoRenewDuration;
 
             set
             {
@@ -83,7 +77,7 @@ namespace Microsoft.Azure.ServiceBus
 
         internal bool AutoRenewLock => this.MaxAutoRenewDuration > TimeSpan.Zero;        
 
-        internal TimeSpan ReceiveTimeOut { get; set; }
+        internal TimeSpan ReceiveTimeOut { get; }
 
         internal async Task RaiseExceptionReceived(ExceptionReceivedEventArgs eventArgs)
         {

--- a/src/Microsoft.Azure.ServiceBus/SessionHandlerOptions.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionHandlerOptions.cs
@@ -38,16 +38,13 @@ namespace Microsoft.Azure.ServiceBus
 
         /// <summary>Occurs when an exception is received. Enables you to be notified of any errors encountered by the session pump.
         /// When errors are received calls will automatically be retried, so this is informational. </summary>
-        public Func<ExceptionReceivedEventArgs, Task> ExceptionReceivedHandler { get; set; }
+        public Func<ExceptionReceivedEventArgs, Task> ExceptionReceivedHandler { get; }
 
         /// <summary>Gets or sets the duration for which the session lock will be renewed automatically.</summary>
         /// <value>The duration for which the session renew its state.</value>
         public TimeSpan MaxAutoRenewDuration
         {
-            get
-            {
-                return this.maxAutoRenewDuration;
-            }
+            get => this.maxAutoRenewDuration;
 
             set
             {
@@ -60,10 +57,7 @@ namespace Microsoft.Azure.ServiceBus
         /// <value>The time to wait for receiving the message.</value>
         public TimeSpan MessageWaitTimeout
         {
-            get
-            {
-                return this.messageWaitTimeout;
-            }
+            get => this.messageWaitTimeout;
 
             set
             {
@@ -76,10 +70,7 @@ namespace Microsoft.Azure.ServiceBus
         /// <value>The maximum number of sessions that the User wants to handle concurrently.</value>
         public int MaxConcurrentSessions
         {
-            get
-            {
-                return this.maxConcurrentSessions;
-            }
+            get => this.maxConcurrentSessions;
 
             set
             {

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.ServiceBus
     {
         public MessageHandlerOptions(System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler) { }
         public bool AutoComplete { get; set; }
-        public System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> ExceptionReceivedHandler { get; set; }
+        public System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> ExceptionReceivedHandler { get; }
         public System.TimeSpan MaxAutoRenewDuration { get; set; }
         public int MaxConcurrentCalls { get; set; }
     }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -284,7 +284,7 @@ namespace Microsoft.Azure.ServiceBus
     {
         public SessionHandlerOptions(System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler) { }
         public bool AutoComplete { get; set; }
-        public System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> ExceptionReceivedHandler { get; set; }
+        public System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> ExceptionReceivedHandler { get; }
         public System.TimeSpan MaxAutoRenewDuration { get; set; }
         public int MaxConcurrentSessions { get; set; }
         public System.TimeSpan MessageWaitTimeout { get; set; }


### PR DESCRIPTION
Fixes issue #240

`MessageHandlerOptions` mandates `ExceptionReceivedHandler` argument for the constructor.
At the same time, `ExceptionReceivedHandler` property can be set, leading to an override of the original callback. This PR removes the option to override `ExceptionReceivedHandler` via setter property and forces a valid error callback to be specified during `MessageHandlerOptions` construction time.