### PR TITLE
Handling session loss for non Session-Lock-Lost exceptions + Increasing AMQP nuget reference to 2.1.0

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Azure.ServiceBus.Core
 
         internal MessagingEntityType? EntityType { get; private set; }
 
-        Error LinkError { get; set; }
+        Exception LinkException { get; set; }
 
         ServiceBusConnection ServiceBusConnection { get; }
 
@@ -728,9 +728,14 @@ namespace Microsoft.Azure.ServiceBus.Core
             ReceivingAmqpLink amqpLink = (ReceivingAmqpLink)sender;
             if (amqpLink != null)
             {
-                AmqpException amqpException = amqpLink.GetInnerException() as AmqpException;
-                this.LinkError = amqpException?.Error;
-                MessagingEventSource.Log.SessionReceiverLinkClosed(this.ClientId, this.SessionIdInternal, this.LinkError);
+                var exception = amqpLink.GetInnerException();
+                if (!(exception is SessionLockLostException))
+                {
+                    exception = new SessionLockLostException("Session lock lost. Accept a new session", exception);
+                }
+
+                this.LinkException = exception;
+                MessagingEventSource.Log.SessionReceiverLinkClosed(this.ClientId, this.SessionIdInternal, this.LinkException);
             }
         }
 
@@ -746,7 +751,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             RequestResponseAmqpLink requestResponseAmqpLink = null;
             if (!this.RequestResponseLinkManager.TryGetOpenedObject(out requestResponseAmqpLink))
             {
-                MessagingEventSource.Log.CreatingNewLink(this.ClientId, this.isSessionReceiver, this.SessionIdInternal, true, this.LinkError);
+                MessagingEventSource.Log.CreatingNewLink(this.ClientId, this.isSessionReceiver, this.SessionIdInternal, true, this.LinkException);
                 requestResponseAmqpLink = await this.RequestResponseLinkManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false); 
             }
 
@@ -777,7 +782,7 @@ namespace Microsoft.Azure.ServiceBus.Core
                 TimeoutHelper timeoutHelper = new TimeoutHelper(serverWaitTime, true);              
                 if(!this.ReceiveLinkManager.TryGetOpenedObject(out receiveLink))
                 {
-                    MessagingEventSource.Log.CreatingNewLink(this.ClientId, this.isSessionReceiver, this.SessionIdInternal, false, this.LinkError);
+                    MessagingEventSource.Log.CreatingNewLink(this.ClientId, this.isSessionReceiver, this.SessionIdInternal, false, this.LinkException);
                     receiveLink = await this.ReceiveLinkManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
                 }
 
@@ -1056,7 +1061,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             {
                 if (!this.ReceiveLinkManager.TryGetOpenedObject(out receiveLink))
                 {
-                    MessagingEventSource.Log.CreatingNewLink(this.ClientId, this.isSessionReceiver, this.SessionIdInternal, false, this.LinkError);
+                    MessagingEventSource.Log.CreatingNewLink(this.ClientId, this.isSessionReceiver, this.SessionIdInternal, false, this.LinkException);
                     receiveLink = await this.ReceiveLinkManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false); 
                 }
 
@@ -1231,16 +1236,9 @@ namespace Microsoft.Azure.ServiceBus.Core
 
         void ThrowIfSessionLockLost()
         {
-            if (this.LinkError != null)
+            if (this.LinkException != null)
             {
-                if (this.LinkError.Condition.Equals(AmqpClientConstants.SessionLockLostError))
-                {
-                    throw this.LinkError.ToMessagingContractException();
-                }
-                else
-                {
-                    throw new SessionLockLostException("Session was lost. See inner exception for details.", this.LinkError.ToMessagingContractException());
-                }
+                throw this.LinkException;
             }
         }
 

--- a/src/Microsoft.Azure.ServiceBus/MessagingEventSource.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessagingEventSource.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.ServiceBus
     using System.Threading.Tasks;
     using Microsoft.Azure.Amqp;
     using Microsoft.Azure.Amqp.Framing;
+    using Microsoft.Azure.ServiceBus.Amqp;
     using Microsoft.Azure.ServiceBus.Primitives;
 
     [EventSource(Name = "Microsoft-Azure-ServiceBus")]
@@ -1034,7 +1035,7 @@ namespace Microsoft.Azure.ServiceBus
         {
             if (this.IsEnabled())
             {
-                this.AmqpLinkCreationException(entityPath, session.ToString(), session.State.ToString(), session.TerminalException != null ? session.TerminalException.ToString() : string.Empty, connection.ToString(), connection.State.ToString(), exception.ToString());
+                this.AmqpLinkCreationException(entityPath, session.ToString(), session.State.ToString(), session.GetInnerException()?.ToString() ?? string.Empty, connection.ToString(), connection.State.ToString(), exception.ToString());
             }
         }
 

--- a/src/Microsoft.Azure.ServiceBus/MessagingEventSource.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessagingEventSource.cs
@@ -1211,12 +1211,11 @@ namespace Microsoft.Azure.ServiceBus
         }
 
         [NonEvent]
-        public void CreatingNewLink(string clientId, bool isSessionReceiver, string sessionId, bool isRequestResponseLink, Error linkError)
+        public void CreatingNewLink(string clientId, bool isSessionReceiver, string sessionId, bool isRequestResponseLink, Exception linkException)
         {
             if (this.IsEnabled())
             {
-                string linkErrorString = linkError != null ? linkError.Condition.Value : string.Empty;
-                this.CreatingNewLink(clientId, isSessionReceiver, sessionId ?? string.Empty, isRequestResponseLink, linkErrorString);
+                this.CreatingNewLink(clientId, isSessionReceiver, sessionId ?? string.Empty, isRequestResponseLink, linkException.ToString());
             }
         }
 
@@ -1227,19 +1226,18 @@ namespace Microsoft.Azure.ServiceBus
         }
 
         [NonEvent]
-        public void SessionReceiverLinkClosed(string clientId, string sessionId, Error linkError)
+        public void SessionReceiverLinkClosed(string clientId, string sessionId, Exception linkException)
         {
             if (this.IsEnabled())
             {
-                string linkErrorString = linkError != null ? linkError.Condition.Value : string.Empty;
-                this.SessionReceiverLinkClosed(clientId, sessionId ?? string.Empty, linkErrorString);
+                this.SessionReceiverLinkClosed(clientId, sessionId ?? string.Empty, linkException.ToString());
             }
         }
 
-        [Event(106, Level = EventLevel.Error, Message = "SessionReceiver Link Closed. ClientId: {0}, SessionId: {1}, LinkError: {2}.")]
-        void SessionReceiverLinkClosed(string clientId, string sessionId, string linkError)
+        [Event(106, Level = EventLevel.Error, Message = "SessionReceiver Link Closed. ClientId: {0}, SessionId: {1}, linkException: {2}.")]
+        void SessionReceiverLinkClosed(string clientId, string sessionId, string linkException)
         {
-            WriteEvent(106, clientId, sessionId, linkError);
+            WriteEvent(106, clientId, sessionId, linkException);
         }
     }
 }

--- a/src/Microsoft.Azure.ServiceBus/MessagingEventSource.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessagingEventSource.cs
@@ -1215,7 +1215,7 @@ namespace Microsoft.Azure.ServiceBus
         {
             if (this.IsEnabled())
             {
-                this.CreatingNewLink(clientId, isSessionReceiver, sessionId ?? string.Empty, isRequestResponseLink, linkException.ToString());
+                this.CreatingNewLink(clientId, isSessionReceiver, sessionId ?? string.Empty, isRequestResponseLink, linkException?.ToString() ?? string.Empty);
             }
         }
 
@@ -1230,7 +1230,7 @@ namespace Microsoft.Azure.ServiceBus
         {
             if (this.IsEnabled())
             {
-                this.SessionReceiverLinkClosed(clientId, sessionId ?? string.Empty, linkException.ToString());
+                this.SessionReceiverLinkClosed(clientId, sessionId ?? string.Empty, linkException?.ToString() ?? string.Empty);
             }
         }
 

--- a/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
+++ b/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
@@ -38,7 +38,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.0.4" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.1.0" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Description

Throwing SessionLockLost exception when session is lost due to errors other than SessionLockLostException thrown from the server (eg: communication exceptions).

Also, increased Microsoft.Azure.Amqp nuget reference to 2.1.0