### PR TITLE
Do not attempt to abandon the message if we know that the message / session lock is already lost.

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/MessageReceivePump.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageReceivePump.cs
@@ -109,13 +109,15 @@ namespace Microsoft.Azure.ServiceBus
             {
                 MessagingEventSource.Log.MessageReceiverPumpUserCallbackException(this.messageReceiver.ClientId, message, exception);
                 await this.RaiseExceptionReceived(exception, ExceptionReceivedEventArgsAction.UserCallback).ConfigureAwait(false);
-                this.maxConcurrentCallsSemaphoreSlim.Release();
-
+                
                 // Nothing much to do if UserCallback throws, Abandon message and Release semaphore.
                 if (!(exception is MessageLockLostException))
                 {
                     await this.AbandonMessageIfNeededAsync(message).ConfigureAwait(false); 
                 }
+
+                // AbandonMessageIfNeededAsync should take care of not throwing exception
+                this.maxConcurrentCallsSemaphoreSlim.Release();
                 return;
             }
             finally

--- a/src/Microsoft.Azure.ServiceBus/SessionReceivePump.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionReceivePump.cs
@@ -219,7 +219,10 @@ namespace Microsoft.Azure.ServiceBus
                         MessagingEventSource.Log.MessageReceivePumpTaskException(this.clientId, session.SessionId, exception);
                         await this.RaiseExceptionReceived(exception, ExceptionReceivedEventArgsAction.UserCallback).ConfigureAwait(false);
                         callbackExceptionOccured = true;
-                        await this.AbandonMessageIfNeededAsync(session, message).ConfigureAwait(false);
+                        if (!(exception is MessageLockLostException || exception is SessionLockLostException))
+                        {
+                            await this.AbandonMessageIfNeededAsync(session, message).ConfigureAwait(false); 
+                        }
                     }
                     finally
                     {


### PR DESCRIPTION
## Description
Do not attempt to abandon the message if we know that the message / session lock is already lost.

This following list is used to make sure that common guidelines for a pull request are followed.

- **Read the [contribution guidelines](./CONTRIBUTING.md).** 
- Make title of the pull request clear and informative. 
- Link to appropriate [issue](https://github.com/Azure/azure-service-bus-dotnet/issues).
- Include test coverage for the changes.
