### PR TITLE
AmqpNotFoundErrors are translated as MessagingEntityNotFoundExceptions

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Amqp/ActiveClientLinkManager.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/ActiveClientLinkManager.cs
@@ -68,13 +68,13 @@ namespace Microsoft.Azure.ServiceBus.Amqp
         static async void OnRenewSendReceiveCBSToken(object state)
         {
             ActiveClientLinkManager thisPtr = (ActiveClientLinkManager)state;
-            await thisPtr.RenewCBSTokenAsync(thisPtr.activeSendReceiveClientLink);
+            await thisPtr.RenewCBSTokenAsync(thisPtr.activeSendReceiveClientLink).ConfigureAwait(false);
         }
 
         static async void OnRenewRequestResponseCBSToken(object state)
         {
             ActiveClientLinkManager thisPtr = (ActiveClientLinkManager)state;
-            await thisPtr.RenewCBSTokenAsync(thisPtr.activeRequestResponseClientLink);
+            await thisPtr.RenewCBSTokenAsync(thisPtr.activeRequestResponseClientLink).ConfigureAwait(false);
         }
 
         void SetRenewCBSTokenTimer(ActiveClientLinkObject activeClientLinkObject)

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpExceptionHelper.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpExceptionHelper.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
             return new ServiceBusException(true, message);
         }
 
-        public static Exception GetClientException(Exception exception, string referenceId = null, Exception innerException = null)
+        public static Exception GetClientException(Exception exception, string referenceId = null, Exception innerException = null, bool connectionError = false)
         {
             StringBuilder builder = new StringBuilder();
             builder.AppendFormat(CultureInfo.InvariantCulture, exception.Message);
@@ -187,10 +187,10 @@ namespace Microsoft.Azure.ServiceBus.Amqp
                     return new ServiceBusCommunicationException(message, aggregateException);
 
                 case AmqpException amqpException:
-                    return amqpException.Error.ToMessagingContractException();
+                    return amqpException.Error.ToMessagingContractException(connectionError);
 
                 case OperationCanceledException operationCanceledException when operationCanceledException.InnerException is AmqpException amqpException:
-                    return amqpException.Error.ToMessagingContractException();
+                    return amqpException.Error.ToMessagingContractException(connectionError);
 
                 case OperationCanceledException _:
                     return new ServiceBusException(true, message, aggregateException);

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpLinkCreator.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpLinkCreator.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
                     connection,
                     exception);
 
-                throw AmqpExceptionHelper.GetClientException(exception, null, link?.GetInnerException());
+                throw AmqpExceptionHelper.GetClientException(exception, null, link?.GetInnerException(), session.IsClosing());
             }
         }
 

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -841,7 +841,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
             catch (Exception exception)
             {
-                throw AmqpExceptionHelper.GetClientException(exception, receiveLink?.GetTrackingId());
+                throw AmqpExceptionHelper.GetClientException(exception, receiveLink?.GetTrackingId(), null, receiveLink?.Session.IsClosing() ?? false);
             }
         }
 

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
@@ -352,7 +352,7 @@ namespace Microsoft.Azure.ServiceBus.Core
                 }
                 catch (Exception exception)
                 {
-                    throw AmqpExceptionHelper.GetClientException(exception, amqpLink?.GetTrackingId());
+                    throw AmqpExceptionHelper.GetClientException(exception, amqpLink?.GetTrackingId(), null, amqpLink?.Session.IsClosing() ?? false);
                 }
             }
         }

--- a/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
+++ b/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the next generation Azure Service Bus .NET Standard client library that focuses on queues &amp; topics. For more information about Service Bus, see https://azure.microsoft.com/en-us/services/service-bus/</Description>
     <AssemblyTitle>Microsoft.Azure.ServiceBus</AssemblyTitle>
-    <VersionPrefix>1.0.0-RC1</VersionPrefix>
+    <VersionPrefix>1.0.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>net451;netstandard1.3;uap10.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
All AmqpErrorCode.NotFound Errors are manifesting as MessagingEntityNotFoundExceptions
