### PR TITLE
ReFix AmqpNotFound errors manifesting as MessagingEntityNotFoundException

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpExceptionHelper.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpExceptionHelper.cs
@@ -216,6 +216,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
 
         public static Exception GetInnerException(this AmqpObject amqpObject)
         {
+            bool connectionError = false;
             Exception innerException;
             switch (amqpObject)
             {
@@ -224,6 +225,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
                     break;
 
                 case AmqpLink amqpLink:
+                    connectionError = amqpLink.Session.IsClosing();
                     innerException = amqpLink.TerminalException ?? amqpLink.Session.TerminalException ?? amqpLink.Session.Connection.TerminalException;
                     break;
 
@@ -235,7 +237,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
                     return null;
             }
 
-            return innerException == null ? null : GetClientException(innerException);
+            return innerException == null ? null : GetClientException(innerException, null, null, connectionError);
         }
     }
 }

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -797,9 +797,10 @@ namespace Microsoft.Azure.ServiceBus.Core
                     a => receiveLink.EndReceiveMessages(a, out amqpMessages),
                     this).ConfigureAwait(false);
 
-                    if (receiveLink.GetInnerException() != null)
+                    Exception exception;
+                    if ((exception = receiveLink.GetInnerException()) != null)
                     {
-                        throw receiveLink.GetInnerException();
+                        throw exception;
                     }
 
                     if (hasMessages && amqpMessages != null)

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/OnSessionQueueTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/OnSessionQueueTests.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                sessionHandlerOptions);
 
             Stopwatch stopwatch = Stopwatch.StartNew();
-            while (stopwatch.Elapsed.TotalSeconds <= 5)
+            while (stopwatch.Elapsed.TotalSeconds <= 10)
             {
                 if (exceptionReceivedHandlerCalled)
                 {

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/OnSessionTopicSubscriptionTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/OnSessionTopicSubscriptionTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             try
             {
                 Stopwatch stopwatch = Stopwatch.StartNew();
-                while (stopwatch.Elapsed.TotalSeconds <= 5)
+                while (stopwatch.Elapsed.TotalSeconds <= 10)
                 {
                     if (exceptionReceivedHandlerCalled)
                     {


### PR DESCRIPTION
Looks like the issue was still happening in our stress runs. This was because of the way we handle exceptions in this path. 

Related to the same issue:
https://github.com/Azure/azure-service-bus-dotnet/issues/272