### PR TITLE
MSBuild enforced highest C# language version

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
+++ b/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
@@ -25,6 +25,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Microsoft.Azure.ServiceBus.xml</DocumentationFile>
     <DebugType>full</DebugType>
+	<LangVersion>7</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'uap10.0'">


### PR DESCRIPTION
## Description

Use MSBuild directive to control the highest version of C# language project permits and do not rely on 3rd party tools such as R#.

<details>
<summary>This following list is used to make sure that common guidelines for a pull request are followed.</summary>

- **Read the [contribution guidelines](./CONTRIBUTING.md).** 
- Make title of the pull request clear and informative. 
- Link to appropriate [issue](https://github.com/Azure/azure-service-bus-dotnet/issues).
- Include test coverage for the changes.
</details>