### PR TITLE
Fix to throw ObjectDisposedExceptions when Client is already closed and Update AMQP library version

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Amqp/ActiveClientLinkManager.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/ActiveClientLinkManager.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Azure.ServiceBus.Amqp
 
         readonly string clientId;
         readonly ICbsTokenProvider cbsTokenProvider;
-        readonly Timer sendReceiveLinkCBSTokenRenewalTimer;
-        readonly Timer requestResponseLinkCBSTokenRenewalTimer;
+        Timer sendReceiveLinkCBSTokenRenewalTimer;
+        Timer requestResponseLinkCBSTokenRenewalTimer;
 
         ActiveSendReceiveClientLink activeSendReceiveClientLink;
         ActiveRequestResponseLink activeRequestResponseClientLink;
@@ -31,8 +31,10 @@ namespace Microsoft.Azure.ServiceBus.Amqp
 
         public void Close()
         {
-            this.ChangeRenewTimer(this.activeSendReceiveClientLink, Timeout.InfiniteTimeSpan);
-            this.ChangeRenewTimer(this.activeRequestResponseClientLink, Timeout.InfiniteTimeSpan);
+            this.sendReceiveLinkCBSTokenRenewalTimer.Dispose();
+            this.sendReceiveLinkCBSTokenRenewalTimer = null;
+            this.requestResponseLinkCBSTokenRenewalTimer.Dispose();
+            this.requestResponseLinkCBSTokenRenewalTimer = null;
         }
 
         public void SetActiveSendReceiveLink(ActiveSendReceiveClientLink sendReceiveClientLink)
@@ -92,11 +94,11 @@ namespace Microsoft.Azure.ServiceBus.Amqp
         {
             if (activeClientLinkObject is ActiveSendReceiveClientLink)
             {
-                this.sendReceiveLinkCBSTokenRenewalTimer.Change(dueTime, Timeout.InfiniteTimeSpan);
+                this.sendReceiveLinkCBSTokenRenewalTimer?.Change(dueTime, Timeout.InfiniteTimeSpan);
             }
             else
             {
-                this.requestResponseLinkCBSTokenRenewalTimer.Change(dueTime, Timeout.InfiniteTimeSpan);
+                this.requestResponseLinkCBSTokenRenewalTimer?.Change(dueTime, Timeout.InfiniteTimeSpan);
             }
         }
 

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             int prefetchCount = Constants.DefaultClientPrefetchCount,
             string sessionId = null,
             bool isSessionReceiver = false)
-            : base(ClientEntity.GenerateClientId(nameof(MessageReceiver), entityPath), retryPolicy ?? RetryPolicy.Default)
+            : base(nameof(MessageReceiver), entityPath, retryPolicy ?? RetryPolicy.Default)
         {
             MessagingEventSource.Log.MessageReceiverCreateStart(serviceBusConnection?.Endpoint.Authority, entityPath, receiveMode.ToString());
 
@@ -235,46 +235,6 @@ namespace Microsoft.Azure.ServiceBus.Core
 
         FaultTolerantAmqpObject<RequestResponseAmqpLink> RequestResponseLinkManager { get; }
 
-        private async Task<Message> ProcessMessage(Message message)
-        {
-            var processedMessage = message;
-            foreach (var plugin in this.RegisteredPlugins)
-            {
-                try
-                {
-                    MessagingEventSource.Log.PluginCallStarted(plugin.Name, message.MessageId);
-                    processedMessage = await plugin.AfterMessageReceive(message).ConfigureAwait(false);
-                    MessagingEventSource.Log.PluginCallCompleted(plugin.Name, message.MessageId);
-                }
-                catch (Exception ex)
-                {
-                    MessagingEventSource.Log.PluginCallFailed(plugin.Name, message.MessageId, ex);
-                    if (!plugin.ShouldContinueOnException)
-                    {
-                        throw;
-                    }
-                }
-            }
-            return processedMessage;
-        }
-
-        private async Task<IList<Message>> ProcessMessages(IList<Message> messageList)
-        {
-            if (this.RegisteredPlugins.Count < 1)
-            {
-                return messageList;
-            }
-
-            var processedMessageList = new List<Message>();
-            foreach (var message in messageList)
-            {
-                var processedMessage = await this.ProcessMessage(message).ConfigureAwait(false);
-                processedMessageList.Add(processedMessage);
-            }
-
-            return processedMessageList;
-        }
-
         /// <summary>
         /// Receive a message from the entity defined by <see cref="Path"/> using <see cref="ReceiveMode"/> mode.
         /// </summary>
@@ -321,6 +281,8 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// <remarks> Receving less than <paramref name="maxMessageCount"/> messages is not an indication of empty entity.</remarks>
         public async Task<IList<Message>> ReceiveAsync(int maxMessageCount, TimeSpan operationTimeout)
         {
+            this.ThrowIfClosed();
+
             MessagingEventSource.Log.MessageReceiveStart(this.ClientId, maxMessageCount);
 
             IList<Message> unprocessedMessageList = null;
@@ -376,7 +338,9 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// <seealso cref="DeferAsync"/>
         public async Task<IList<Message>> ReceiveDeferredMessageAsync(IEnumerable<long> sequenceNumbers)
         {
+            this.ThrowIfClosed();
             this.ThrowIfNotPeekLockMode();
+            
             int count = MessageReceiver.ValidateSequenceNumbers(sequenceNumbers);
 
             MessagingEventSource.Log.MessageReceiveDeferredMessageStart(this.ClientId, count, sequenceNumbers);
@@ -427,6 +391,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// <returns>The asynchronous operation.</returns>
         public async Task CompleteAsync(IEnumerable<string> lockTokens)
         {
+            this.ThrowIfClosed();
             this.ThrowIfNotPeekLockMode();
             int count = MessageReceiver.ValidateLockTokens(lockTokens);
 
@@ -460,6 +425,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// <returns>The asynchronous operation.</returns>
         public async Task AbandonAsync(string lockToken)
         {
+            this.ThrowIfClosed();
             this.ThrowIfNotPeekLockMode();
 
             MessagingEventSource.Log.MessageAbandonStart(this.ClientId, 1, lockToken);
@@ -493,6 +459,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// <returns>The asynchronous operation.</returns>
         public async Task DeferAsync(string lockToken)
         {
+            this.ThrowIfClosed();
             this.ThrowIfNotPeekLockMode();
 
             MessagingEventSource.Log.MessageDeferStart(this.ClientId, 1, lockToken);
@@ -527,6 +494,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// <returns>The asynchronous operation.</returns>
         public async Task DeadLetterAsync(string lockToken)
         {
+            this.ThrowIfClosed();
             this.ThrowIfNotPeekLockMode();
 
             MessagingEventSource.Log.MessageDeadLetterStart(this.ClientId, 1, lockToken);
@@ -562,6 +530,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// <returns>The asynchronous operation.</returns>
         public async Task RenewLockAsync(Message message)
         {
+            this.ThrowIfClosed();
             this.ThrowIfNotPeekLockMode();
 
             MessagingEventSource.Log.MessageRenewLockStart(this.ClientId, 1, message.SystemProperties.LockToken);
@@ -631,6 +600,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// <returns>A batch of messages peeked.</returns>
         public async Task<IList<Message>> PeekBySequenceNumberAsync(long fromSequenceNumber, int messageCount)
         {
+            this.ThrowIfClosed();
             IList<Message> messages = null;
 
             MessagingEventSource.Log.MessagePeekStart(this.ClientId, fromSequenceNumber, messageCount);
@@ -673,7 +643,98 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// <remarks>Enable prefetch to speeden up the receive rate.</remarks>
         public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, MessageHandlerOptions messageHandlerOptions)
         {
+            this.ThrowIfClosed();
             this.OnMessageHandler(messageHandlerOptions, handler);
+        }
+
+        /// <summary>
+        /// Registers a <see cref="ServiceBusPlugin"/> to be used with this receiver.
+        /// </summary>
+        /// <param name="serviceBusPlugin">The <see cref="ServiceBusPlugin"/> to register.</param>
+        public override void RegisterPlugin(ServiceBusPlugin serviceBusPlugin)
+        {
+            this.ThrowIfClosed();
+            if (serviceBusPlugin == null)
+            {
+                throw new ArgumentNullException(nameof(serviceBusPlugin), Resources.ArgumentNullOrWhiteSpace.FormatForUser(nameof(serviceBusPlugin)));
+            }
+            else if (this.RegisteredPlugins.Any(p => p.Name == serviceBusPlugin.Name))
+            {
+                throw new ArgumentException(nameof(serviceBusPlugin), Resources.PluginAlreadyRegistered.FormatForUser(nameof(serviceBusPlugin)));
+            }
+            this.RegisteredPlugins.Add(serviceBusPlugin);
+        }
+
+        /// <summary>
+        /// Unregisters a <see cref="ServiceBusPlugin"/>.
+        /// </summary>
+        /// <param name="serviceBusPluginName">The <see cref="ServiceBusPlugin.Name"/> of the plugin to be unregistered.</param>
+        public override void UnregisterPlugin(string serviceBusPluginName)
+        {
+            this.ThrowIfClosed();
+            if (this.RegisteredPlugins == null)
+            {
+                return;
+            }
+            if (serviceBusPluginName == null)
+            {
+                throw new ArgumentNullException(nameof(serviceBusPluginName), Resources.ArgumentNullOrWhiteSpace.FormatForUser(nameof(serviceBusPluginName)));
+            }
+            if (this.RegisteredPlugins.Any(p => p.Name == serviceBusPluginName))
+            {
+                var plugin = this.RegisteredPlugins.First(p => p.Name == serviceBusPluginName);
+                this.RegisteredPlugins.Remove(plugin);
+            }
+        }
+
+        internal async Task GetSessionReceiverLinkAsync(TimeSpan serverWaitTime)
+        {
+            TimeoutHelper timeoutHelper = new TimeoutHelper(serverWaitTime, true);
+            ReceivingAmqpLink receivingAmqpLink = await this.ReceiveLinkManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+
+            Source source = (Source)receivingAmqpLink.Settings.Source;
+            string tempSessionId;
+            if (!source.FilterSet.TryGetValue(AmqpClientConstants.SessionFilterName, out tempSessionId))
+            {
+                receivingAmqpLink.Session.SafeClose();
+                throw new ServiceBusException(true, Resources.SessionFilterMissing);
+            }
+
+            if (string.IsNullOrWhiteSpace(tempSessionId))
+            {
+                receivingAmqpLink.Session.SafeClose();
+                throw new ServiceBusException(true, Resources.AmqpFieldSessionId);
+            }
+
+            receivingAmqpLink.Closed += this.OnSessionReceiverLinkClosed;
+            this.SessionIdInternal = tempSessionId;
+            long lockedUntilUtcTicks;
+            this.LockedUntilUtcInternal = receivingAmqpLink.Settings.Properties.TryGetValue(AmqpClientConstants.LockedUntilUtc, out lockedUntilUtcTicks) ? new DateTime(lockedUntilUtcTicks, DateTimeKind.Utc) : DateTime.MinValue;
+        }
+
+        internal async Task<AmqpResponseMessage> ExecuteRequestResponseAsync(AmqpRequestMessage amqpRequestMessage)
+        {
+            AmqpMessage amqpMessage = amqpRequestMessage.AmqpMessage;
+            if (this.isSessionReceiver)
+            {
+                this.ThrowIfSessionLockLost();
+            }
+
+            TimeoutHelper timeoutHelper = new TimeoutHelper(this.OperationTimeout, true);
+            RequestResponseAmqpLink requestResponseAmqpLink = null;
+            if (!this.RequestResponseLinkManager.TryGetOpenedObject(out requestResponseAmqpLink))
+            {
+                MessagingEventSource.Log.CreatingNewLink(this.ClientId, this.isSessionReceiver, this.SessionIdInternal, true, this.LinkException);
+                requestResponseAmqpLink = await this.RequestResponseLinkManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
+            }
+
+            AmqpMessage responseAmqpMessage = await Task.Factory.FromAsync(
+                (c, s) => requestResponseAmqpLink.BeginRequest(amqpMessage, timeoutHelper.RemainingTime(), c, s),
+                (a) => requestResponseAmqpLink.EndRequest(a),
+                this).ConfigureAwait(false);
+
+            AmqpResponseMessage responseMessage = AmqpResponseMessage.CreateResponse(responseAmqpMessage);
+            return responseMessage;
         }
 
         /// <summary></summary>
@@ -697,72 +758,6 @@ namespace Microsoft.Azure.ServiceBus.Core
             {
                 await this.ServiceBusConnection.CloseAsync().ConfigureAwait(false);
             }
-        }
-
-        internal async Task GetSessionReceiverLinkAsync(TimeSpan serverWaitTime)
-        {
-            TimeoutHelper timeoutHelper = new TimeoutHelper(serverWaitTime, true);
-            ReceivingAmqpLink receivingAmqpLink = await this.ReceiveLinkManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
-            
-            Source source = (Source)receivingAmqpLink.Settings.Source;
-            string tempSessionId;
-            if (!source.FilterSet.TryGetValue(AmqpClientConstants.SessionFilterName, out tempSessionId))
-            {
-                receivingAmqpLink.Session.SafeClose();
-                throw new ServiceBusException(true, Resources.SessionFilterMissing);
-            }
-
-            if (string.IsNullOrWhiteSpace(tempSessionId))
-            {
-                receivingAmqpLink.Session.SafeClose();
-                throw new ServiceBusException(true, Resources.AmqpFieldSessionId);
-            }
-
-            receivingAmqpLink.Closed += this.OnSessionReceiverLinkClosed;
-            this.SessionIdInternal = tempSessionId;
-            long lockedUntilUtcTicks;
-            this.LockedUntilUtcInternal = receivingAmqpLink.Settings.Properties.TryGetValue(AmqpClientConstants.LockedUntilUtc, out lockedUntilUtcTicks) ? new DateTime(lockedUntilUtcTicks, DateTimeKind.Utc) : DateTime.MinValue;
-        }
-
-        void OnSessionReceiverLinkClosed(object sender, EventArgs e)
-        {
-            ReceivingAmqpLink amqpLink = (ReceivingAmqpLink)sender;
-            if (amqpLink != null)
-            {
-                var exception = amqpLink.GetInnerException();
-                if (!(exception is SessionLockLostException))
-                {
-                    exception = new SessionLockLostException("Session lock lost. Accept a new session", exception);
-                }
-
-                this.LinkException = exception;
-                MessagingEventSource.Log.SessionReceiverLinkClosed(this.ClientId, this.SessionIdInternal, this.LinkException);
-            }
-        }
-
-        internal async Task<AmqpResponseMessage> ExecuteRequestResponseAsync(AmqpRequestMessage amqpRequestMessage)
-        {
-            AmqpMessage amqpMessage = amqpRequestMessage.AmqpMessage;
-            if (this.isSessionReceiver)
-            {
-                this.ThrowIfSessionLockLost();
-            }
-
-            TimeoutHelper timeoutHelper = new TimeoutHelper(this.OperationTimeout, true);
-            RequestResponseAmqpLink requestResponseAmqpLink = null;
-            if (!this.RequestResponseLinkManager.TryGetOpenedObject(out requestResponseAmqpLink))
-            {
-                MessagingEventSource.Log.CreatingNewLink(this.ClientId, this.isSessionReceiver, this.SessionIdInternal, true, this.LinkException);
-                requestResponseAmqpLink = await this.RequestResponseLinkManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false); 
-            }
-
-            AmqpMessage responseAmqpMessage = await Task.Factory.FromAsync(
-                (c, s) => requestResponseAmqpLink.BeginRequest(amqpMessage, timeoutHelper.RemainingTime(), c, s),
-                (a) => requestResponseAmqpLink.EndRequest(a),
-                this).ConfigureAwait(false);
-
-            AmqpResponseMessage responseMessage = AmqpResponseMessage.CreateResponse(responseAmqpMessage);
-            return responseMessage;
         }
 
         /// <summary></summary>
@@ -1048,6 +1043,109 @@ namespace Microsoft.Azure.ServiceBus.Core
             return lockedUntilUtc;
         }
 
+        /// <summary> </summary>
+        protected virtual void OnMessageHandler(
+            MessageHandlerOptions registerHandlerOptions,
+            Func<Message, CancellationToken, Task> callback)
+        {
+            MessagingEventSource.Log.RegisterOnMessageHandlerStart(this.ClientId, registerHandlerOptions);
+
+            lock (this.messageReceivePumpSyncLock)
+            {
+                if (this.receivePump != null)
+                {
+                    throw new InvalidOperationException(Resources.MessageHandlerAlreadyRegistered);
+                }
+
+                this.receivePumpCancellationTokenSource = new CancellationTokenSource();
+                this.receivePump = new MessageReceivePump(this, registerHandlerOptions, callback, this.ServiceBusConnection.Endpoint.Authority, this.receivePumpCancellationTokenSource.Token);
+            }
+
+            try
+            {
+                this.receivePump.StartPump();
+            }
+            catch (Exception exception)
+            {
+                MessagingEventSource.Log.RegisterOnMessageHandlerException(this.ClientId, exception);
+                lock (this.messageReceivePumpSyncLock)
+                {
+                    if (this.receivePump != null)
+                    {
+                        this.receivePumpCancellationTokenSource.Cancel();
+                        this.receivePumpCancellationTokenSource.Dispose();
+                        this.receivePump = null;
+                    }
+                }
+
+                throw;
+            }
+
+            MessagingEventSource.Log.RegisterOnMessageHandlerStop(this.ClientId);
+        }
+
+        static int ValidateLockTokens(IEnumerable<string> lockTokens)
+        {
+            int count;
+            if (lockTokens == null || (count = lockTokens.Count()) == 0)
+            {
+                throw Fx.Exception.ArgumentNull(nameof(lockTokens));
+            }
+
+            return count;
+        }
+
+        static int ValidateSequenceNumbers(IEnumerable<long> sequenceNumbers)
+        {
+            int count;
+            if (sequenceNumbers == null || (count = sequenceNumbers.Count()) == 0)
+            {
+                throw Fx.Exception.ArgumentNull(nameof(sequenceNumbers));
+            }
+
+            return count;
+        }
+
+        async Task<Message> ProcessMessage(Message message)
+        {
+            var processedMessage = message;
+            foreach (var plugin in this.RegisteredPlugins)
+            {
+                try
+                {
+                    MessagingEventSource.Log.PluginCallStarted(plugin.Name, message.MessageId);
+                    processedMessage = await plugin.AfterMessageReceive(message).ConfigureAwait(false);
+                    MessagingEventSource.Log.PluginCallCompleted(plugin.Name, message.MessageId);
+                }
+                catch (Exception ex)
+                {
+                    MessagingEventSource.Log.PluginCallFailed(plugin.Name, message.MessageId, ex);
+                    if (!plugin.ShouldContinueOnException)
+                    {
+                        throw;
+                    }
+                }
+            }
+            return processedMessage;
+        }
+
+        async Task<IList<Message>> ProcessMessages(IList<Message> messageList)
+        {
+            if (this.RegisteredPlugins.Count < 1)
+            {
+                return messageList;
+            }
+
+            var processedMessageList = new List<Message>();
+            foreach (var message in messageList)
+            {
+                var processedMessage = await this.ProcessMessage(message).ConfigureAwait(false);
+                processedMessageList.Add(processedMessage);
+            }
+
+            return processedMessageList;
+        }
+
         async Task DisposeMessagesAsync(IEnumerable<Guid> lockTokens, Outcome outcome)
         {
             if(this.isSessionReceiver)
@@ -1140,11 +1238,6 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
         }
 
-        IList<ArraySegment<byte>> ConvertLockTokensToDeliveryTags(IEnumerable<Guid> lockTokens)
-        {
-            return lockTokens.Select(lockToken => new ArraySegment<byte>(lockToken.ToByteArray())).ToList();
-        }
-
         async Task<ReceivingAmqpLink> CreateLinkAsync(TimeSpan timeout)
         {
             FilterSet filterMap = null;
@@ -1220,6 +1313,27 @@ namespace Microsoft.Azure.ServiceBus.Core
             return requestResponseAmqpLink;
         }
 
+        void OnSessionReceiverLinkClosed(object sender, EventArgs e)
+        {
+            ReceivingAmqpLink amqpLink = (ReceivingAmqpLink)sender;
+            if (amqpLink != null)
+            {
+                var exception = amqpLink.GetInnerException();
+                if (!(exception is SessionLockLostException))
+                {
+                    exception = new SessionLockLostException("Session lock lost. Accept a new session", exception);
+                }
+
+                this.LinkException = exception;
+                MessagingEventSource.Log.SessionReceiverLinkClosed(this.ClientId, this.SessionIdInternal, this.LinkException);
+            }
+        }
+
+        IList<ArraySegment<byte>> ConvertLockTokensToDeliveryTags(IEnumerable<Guid> lockTokens)
+        {
+            return lockTokens.Select(lockToken => new ArraySegment<byte>(lockToken.ToByteArray())).ToList();
+        }
+
         void CloseSession(ReceivingAmqpLink link)
         {
             link.Session.SafeClose();
@@ -1228,28 +1342,6 @@ namespace Microsoft.Azure.ServiceBus.Core
         void CloseRequestResponseSession(RequestResponseAmqpLink requestResponseAmqpLink)
         {
             requestResponseAmqpLink.Session.SafeClose();
-        }
-
-        static int ValidateLockTokens(IEnumerable<string> lockTokens)
-        {
-            int count;
-            if (lockTokens == null || (count = lockTokens.Count()) == 0)
-            {
-                throw Fx.Exception.ArgumentNull(nameof(lockTokens));
-            }
-
-            return count;
-        }
-
-        static int ValidateSequenceNumbers(IEnumerable<long> sequenceNumbers)
-        {
-            int count;
-            if (sequenceNumbers == null || (count = sequenceNumbers.Count()) == 0)
-            {
-                throw Fx.Exception.ArgumentNull(nameof(sequenceNumbers));
-            }
-
-            return count;
         }
 
         void ThrowIfNotPeekLockMode()
@@ -1265,85 +1357,6 @@ namespace Microsoft.Azure.ServiceBus.Core
             if (this.LinkException != null)
             {
                 throw this.LinkException;
-            }
-        }
-
-        /// <summary> </summary>
-        protected virtual void OnMessageHandler(
-            MessageHandlerOptions registerHandlerOptions,
-            Func<Message, CancellationToken, Task> callback)
-        {
-            MessagingEventSource.Log.RegisterOnMessageHandlerStart(this.ClientId, registerHandlerOptions);
-
-            lock (this.messageReceivePumpSyncLock)
-            {
-                if (this.receivePump != null)
-                {
-                    throw new InvalidOperationException(Resources.MessageHandlerAlreadyRegistered);
-                }
-
-                this.receivePumpCancellationTokenSource = new CancellationTokenSource();
-                this.receivePump = new MessageReceivePump(this, registerHandlerOptions, callback, this.ServiceBusConnection.Endpoint.Authority, this.receivePumpCancellationTokenSource.Token);
-            }
-
-            try
-            {
-                this.receivePump.StartPump();
-            }
-            catch (Exception exception)
-            {
-                MessagingEventSource.Log.RegisterOnMessageHandlerException(this.ClientId, exception);
-                lock (this.messageReceivePumpSyncLock)
-                {
-                    if (this.receivePump != null)
-                    {
-                        this.receivePumpCancellationTokenSource.Cancel();
-                        this.receivePumpCancellationTokenSource.Dispose();
-                        this.receivePump = null;
-                    }
-                }
-
-                throw;
-            }
-
-            MessagingEventSource.Log.RegisterOnMessageHandlerStop(this.ClientId);
-        }
-
-        /// <summary>
-        /// Registers a <see cref="ServiceBusPlugin"/> to be used with this receiver.
-        /// </summary>
-        /// <param name="serviceBusPlugin">The <see cref="ServiceBusPlugin"/> to register.</param>
-        public override void RegisterPlugin(ServiceBusPlugin serviceBusPlugin)
-        {
-            if (serviceBusPlugin == null)
-            {
-                throw new ArgumentNullException(nameof(serviceBusPlugin), Resources.ArgumentNullOrWhiteSpace.FormatForUser(nameof(serviceBusPlugin)));
-            }
-            else if (this.RegisteredPlugins.Any(p => p.Name == serviceBusPlugin.Name))
-            {
-                throw new ArgumentException(nameof(serviceBusPlugin), Resources.PluginAlreadyRegistered.FormatForUser(nameof(serviceBusPlugin)));
-            }
-            this.RegisteredPlugins.Add(serviceBusPlugin);
-        }
-
-        /// <summary>
-        /// Unregisters a <see cref="ServiceBusPlugin"/>.
-        /// </summary>
-        /// <param name="serviceBusPluginName">The <see cref="ServiceBusPlugin.Name"/> of the plugin to be unregistered.</param>
-        public override void UnregisterPlugin(string serviceBusPluginName)
-        {
-            if (this.RegisteredPlugins == null)
-            {
-                return;
-            }
-            if (serviceBusPluginName == null)
-            {
-                throw new ArgumentNullException(nameof(serviceBusPluginName), Resources.ArgumentNullOrWhiteSpace.FormatForUser(nameof(serviceBusPluginName)));
-            }
-            if (this.RegisteredPlugins.Any(p => p.Name == serviceBusPluginName))
-            {
-                var plugin = this.RegisteredPlugins.First(p => p.Name == serviceBusPluginName);
-                this.RegisteredPlugins.Remove(plugin);
             }
         }
     }

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             ServiceBusConnection serviceBusConnection,
             ICbsTokenProvider cbsTokenProvider,
             RetryPolicy retryPolicy)
-            : base(ClientEntity.GenerateClientId(nameof(MessageSender), entityPath), retryPolicy ?? RetryPolicy.Default)
+            : base(nameof(MessageSender), entityPath, retryPolicy ?? RetryPolicy.Default)
         {
             MessagingEventSource.Log.MessageSenderCreateStart(serviceBusConnection?.Endpoint.Authority, entityPath);
 
@@ -132,59 +132,6 @@ namespace Microsoft.Azure.ServiceBus.Core
 
         FaultTolerantAmqpObject<RequestResponseAmqpLink> RequestResponseLinkManager { get; }
 
-        /// <summary>Closes the connection.</summary>
-        protected override async Task OnClosingAsync()
-        {
-            this.clientLinkManager.Close();
-            await this.SendLinkManager.CloseAsync().ConfigureAwait(false);
-            await this.RequestResponseLinkManager.CloseAsync().ConfigureAwait(false);
-
-            if (this.ownsConnection)
-            {
-                await this.ServiceBusConnection.CloseAsync().ConfigureAwait(false);
-            }
-        }
-
-        async Task<Message> ProcessMessage(Message message)
-        {
-            var processedMessage = message;
-            foreach (var plugin in this.RegisteredPlugins)
-            {
-                try
-                {
-                    MessagingEventSource.Log.PluginCallStarted(plugin.Name, message.MessageId);
-                    processedMessage = await plugin.BeforeMessageSend(message).ConfigureAwait(false);
-                    MessagingEventSource.Log.PluginCallCompleted(plugin.Name, message.MessageId);
-                }
-                catch (Exception ex)
-                {
-                    MessagingEventSource.Log.PluginCallFailed(plugin.Name, message.MessageId, ex);
-                    if (!plugin.ShouldContinueOnException)
-                    {
-                        throw;
-                    }
-                }
-            }
-            return processedMessage;
-        }
-
-        async Task<IList<Message>> ProcessMessages(IList<Message> messageList)
-        {
-            if (this.RegisteredPlugins.Count < 1)
-            {
-                return messageList;
-            }
-
-            var processedMessageList = new List<Message>();
-            foreach (var message in messageList)
-            {
-                var processedMessage = await this.ProcessMessage(message).ConfigureAwait(false);
-                processedMessageList.Add(processedMessage);
-            }
-
-            return processedMessageList;
-        }
-
         /// <summary>
         /// Sends a message to the entity as described by <see cref="Path"/>.
         /// </summary>
@@ -202,6 +149,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// <returns>An asynchronous operation</returns>
         public async Task SendAsync(IList<Message> messageList)
         {
+            this.ThrowIfClosed();
             int count = MessageSender.ValidateMessages(messageList);
             MessagingEventSource.Log.MessageSendStart(this.ClientId, count);
 
@@ -233,6 +181,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// <returns>The sequence number of the message that was scheduled.</returns>
         public async Task<long> ScheduleMessageAsync(Message message, DateTimeOffset scheduleEnqueueTimeUtc)
         {
+            this.ThrowIfClosed();
             if (message == null)
             {
                 throw Fx.Exception.ArgumentNull(nameof(message));
@@ -279,6 +228,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// <returns>An asynchronous operation</returns>
         public async Task CancelScheduledMessageAsync(long sequenceNumber)
         {
+            this.ThrowIfClosed();
             MessagingEventSource.Log.CancelScheduledMessageStart(this.ClientId, sequenceNumber);
 
             try
@@ -299,6 +249,43 @@ namespace Microsoft.Azure.ServiceBus.Core
             MessagingEventSource.Log.CancelScheduledMessageStop(this.ClientId);
         }
 
+        /// <summary>
+        /// Registers a <see cref="ServiceBusPlugin"/> to be used with this sender.
+        /// </summary>
+        /// <param name="serviceBusPlugin">The <see cref="ServiceBusPlugin"/> to register.</param>
+        public override void RegisterPlugin(ServiceBusPlugin serviceBusPlugin)
+        {
+            this.ThrowIfClosed();
+            if (serviceBusPlugin == null)
+            {
+                throw new ArgumentNullException(nameof(serviceBusPlugin), Resources.ArgumentNullOrWhiteSpace.FormatForUser(nameof(serviceBusPlugin)));
+            }
+
+            if (this.RegisteredPlugins.Any(p => p.GetType() == serviceBusPlugin.GetType()))
+            {
+                throw new ArgumentException(nameof(serviceBusPlugin), Resources.PluginAlreadyRegistered.FormatForUser(nameof(serviceBusPlugin)));
+            }
+            this.RegisteredPlugins.Add(serviceBusPlugin);
+        }
+
+        /// <summary>
+        /// Unregisters a <see cref="ServiceBusPlugin"/>.
+        /// </summary>
+        /// <param name="serviceBusPluginName">The name <see cref="ServiceBusPlugin.Name"/> to be unregistered</param>
+        public override void UnregisterPlugin(string serviceBusPluginName)
+        {
+            this.ThrowIfClosed();
+            if (serviceBusPluginName == null)
+            {
+                throw new ArgumentNullException(nameof(serviceBusPluginName), Resources.ArgumentNullOrWhiteSpace.FormatForUser(nameof(serviceBusPluginName)));
+            }
+            if (this.RegisteredPlugins.Any(p => p.Name == serviceBusPluginName))
+            {
+                var plugin = this.RegisteredPlugins.First(p => p.Name == serviceBusPluginName);
+                this.RegisteredPlugins.Remove(plugin);
+            }
+        }
+
         internal async Task<AmqpResponseMessage> ExecuteRequestResponseAsync(AmqpRequestMessage amqpRequestMessage)
         {
             RequestResponseAmqpLink requestResponseAmqpLink = null;
@@ -307,7 +294,7 @@ namespace Microsoft.Azure.ServiceBus.Core
 
             if (!this.RequestResponseLinkManager.TryGetOpenedObject(out requestResponseAmqpLink))
             {
-                requestResponseAmqpLink = await this.RequestResponseLinkManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false); 
+                requestResponseAmqpLink = await this.RequestResponseLinkManager.GetOrCreateAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
             }
 
             AmqpMessage responseAmqpMessage = await Task.Factory.FromAsync(
@@ -317,6 +304,84 @@ namespace Microsoft.Azure.ServiceBus.Core
 
             AmqpResponseMessage responseMessage = AmqpResponseMessage.CreateResponse(responseAmqpMessage);
             return responseMessage;
+        }
+
+        /// <summary>Closes the connection.</summary>
+        protected override async Task OnClosingAsync()
+        {
+            this.clientLinkManager.Close();
+            await this.SendLinkManager.CloseAsync().ConfigureAwait(false);
+            await this.RequestResponseLinkManager.CloseAsync().ConfigureAwait(false);
+
+            if (this.ownsConnection)
+            {
+                await this.ServiceBusConnection.CloseAsync().ConfigureAwait(false);
+            }
+        }
+
+        static int ValidateMessages(IList<Message> messageList)
+        {
+            int count = 0;
+            if (messageList == null)
+            {
+                throw Fx.Exception.ArgumentNull(nameof(messageList));
+            }
+
+            foreach (var message in messageList)
+            {
+                count++;
+                ValidateMessage(message);
+            }
+
+            return count;
+        }
+
+        static void ValidateMessage(Message message)
+        {
+            if (message.SystemProperties.IsLockTokenSet)
+            {
+                throw Fx.Exception.Argument(nameof(message), "Cannot send a message that was already received.");
+            }
+        }
+
+        async Task<Message> ProcessMessage(Message message)
+        {
+            var processedMessage = message;
+            foreach (var plugin in this.RegisteredPlugins)
+            {
+                try
+                {
+                    MessagingEventSource.Log.PluginCallStarted(plugin.Name, message.MessageId);
+                    processedMessage = await plugin.BeforeMessageSend(message).ConfigureAwait(false);
+                    MessagingEventSource.Log.PluginCallCompleted(plugin.Name, message.MessageId);
+                }
+                catch (Exception ex)
+                {
+                    MessagingEventSource.Log.PluginCallFailed(plugin.Name, message.MessageId, ex);
+                    if (!plugin.ShouldContinueOnException)
+                    {
+                        throw;
+                    }
+                }
+            }
+            return processedMessage;
+        }
+
+        async Task<IList<Message>> ProcessMessages(IList<Message> messageList)
+        {
+            if (this.RegisteredPlugins.Count < 1)
+            {
+                return messageList;
+            }
+
+            var processedMessageList = new List<Message>();
+            foreach (var message in messageList)
+            {
+                var processedMessage = await this.ProcessMessage(message).ConfigureAwait(false);
+                processedMessageList.Add(processedMessage);
+            }
+
+            return processedMessageList;
         }
 
         async Task OnSendAsync(IList<Message> messageList)
@@ -422,12 +487,6 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
         }
 
-        ArraySegment<byte> GetNextDeliveryTag()
-        {
-            int deliveryId = Interlocked.Increment(ref this.deliveryCount);
-            return new ArraySegment<byte>(BitConverter.GetBytes(deliveryId));
-        }
-
         async Task<SendingAmqpLink> CreateLinkAsync(TimeSpan timeout)
         {
             MessagingEventSource.Log.AmqpSendLinkCreateStart(this.ClientId, this.EntityType, this.Path);
@@ -496,6 +555,12 @@ namespace Microsoft.Azure.ServiceBus.Core
             return requestResponseAmqpLink;
         }
 
+        ArraySegment<byte> GetNextDeliveryTag()
+        {
+            int deliveryId = Interlocked.Increment(ref this.deliveryCount);
+            return new ArraySegment<byte>(BitConverter.GetBytes(deliveryId));
+        }
+
         void CloseSession(SendingAmqpLink link)
         {
             // Note we close the session (which includes the link).
@@ -505,66 +570,6 @@ namespace Microsoft.Azure.ServiceBus.Core
         void CloseRequestResponseSession(RequestResponseAmqpLink requestResponseAmqpLink)
         {
             requestResponseAmqpLink.Session.SafeClose();
-        }
-
-        static int ValidateMessages(IList<Message> messageList)
-        {
-            int count = 0;
-            if (messageList == null)
-            {
-                throw Fx.Exception.ArgumentNull(nameof(messageList));
-            }
-
-            foreach (var message in messageList)
-            {
-                count++;
-                ValidateMessage(message);
-            }
-
-            return count;
-        }
-
-        static void ValidateMessage(Message message)
-        {
-            if (message.SystemProperties.IsLockTokenSet)
-            {
-                throw Fx.Exception.Argument(nameof(message), "Cannot send a message that was already received.");
-            }
-        }
-
-        /// <summary>
-        /// Registers a <see cref="ServiceBusPlugin"/> to be used with this sender.
-        /// </summary>
-        /// <param name="serviceBusPlugin">The <see cref="ServiceBusPlugin"/> to register.</param>
-        public override void RegisterPlugin(ServiceBusPlugin serviceBusPlugin)
-        {
-            if (serviceBusPlugin == null)
-            {
-                throw new ArgumentNullException(nameof(serviceBusPlugin), Resources.ArgumentNullOrWhiteSpace.FormatForUser(nameof(serviceBusPlugin)));
-            }
-
-            if (this.RegisteredPlugins.Any(p => p.GetType() == serviceBusPlugin.GetType()))
-            {
-                throw new ArgumentException(nameof(serviceBusPlugin), Resources.PluginAlreadyRegistered.FormatForUser(nameof(serviceBusPlugin)));
-            }
-            this.RegisteredPlugins.Add(serviceBusPlugin);
-        }
-
-        /// <summary>
-        /// Unregisters a <see cref="ServiceBusPlugin"/>.
-        /// </summary>
-        /// <param name="serviceBusPluginName">The name <see cref="ServiceBusPlugin.Name"/> to be unregistered</param>
-        public override void UnregisterPlugin(string serviceBusPluginName)
-        {
-            if (serviceBusPluginName == null)
-            {
-                throw new ArgumentNullException(nameof(serviceBusPluginName), Resources.ArgumentNullOrWhiteSpace.FormatForUser(nameof(serviceBusPluginName)));
-            }
-            if (this.RegisteredPlugins.Any(p => p.Name == serviceBusPluginName))
-            {
-                var plugin = this.RegisteredPlugins.First(p => p.Name == serviceBusPluginName);
-                this.RegisteredPlugins.Remove(plugin);
-            }
         }
     }
 }

--- a/src/Microsoft.Azure.ServiceBus/MessageSession.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageSession.cs
@@ -44,16 +44,19 @@ namespace Microsoft.Azure.ServiceBus
 
         public Task<byte[]> GetStateAsync()
         {
+            this.ThrowIfClosed();
             return this.OnGetStateAsync();
         }
 
         public Task SetStateAsync(byte[] sessionState)
         {
+            this.ThrowIfClosed();
             return this.OnSetStateAsync(sessionState);
         }
 
         public Task RenewSessionLockAsync()
         {
+            this.ThrowIfClosed();
             return this.OnRenewSessionLockAsync();
         }
 
@@ -147,6 +150,17 @@ namespace Microsoft.Azure.ServiceBus
             catch (Exception exception)
             {
                 throw AmqpExceptionHelper.GetClientException(exception);
+            }
+        }
+
+        /// <summary>
+        /// Throw an OperationCanceledException if the object is Closing.
+        /// </summary>
+        protected override void ThrowIfClosed()
+        {
+            if (this.IsClosedOrClosing)
+            {
+                throw new ObjectDisposedException($"MessageSession with Id '{this.ClientId}' has already been closed. Please accept a new MessageSession.");
             }
         }
     }

--- a/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
+++ b/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.1.1" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
   </ItemGroup>
 

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.ServiceBus
     
     public abstract class ClientEntity : Microsoft.Azure.ServiceBus.IClientEntity
     {
-        protected ClientEntity(string clientId, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy) { }
+        protected ClientEntity(string clientTypeName, string postfix, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy) { }
         public string ClientId { get; }
         public bool IsClosedOrClosing { get; }
         public abstract System.TimeSpan OperationTimeout { get; set; }
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.ServiceBus
         protected static long GetNextId() { }
         protected abstract System.Threading.Tasks.Task OnClosingAsync();
         public abstract void RegisterPlugin(Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin serviceBusPlugin);
+        protected virtual void ThrowIfClosed() { }
         public abstract void UnregisterPlugin(string serviceBusPluginName);
     }
     public sealed class CorrelationFilter : Microsoft.Azure.ServiceBus.Filter


### PR DESCRIPTION
This PR addresses the following

1. Today the client calls fail somewhere internally with messages such as 'X' object already disposed etc. This is changed to consistently throw ObjectDisposed Exceptions when the client is already disposed.
2. Update AMQP Version. Related to issue below:
    -  https://github.com/Azure/azure-service-bus-dotnet/issues/277
3. Some nit updates to order the methods (public>internal>protected>private) correctly (in files touched). We will need to enable the Style rules on this project so we can fix all other places too. Will address this in a different PR.
