### PR TITLE
Handling receiver.Close and clientEntity.IsClosedOrClosing

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/ClientEntity.cs
+++ b/src/Microsoft.Azure.ServiceBus/ClientEntity.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.ServiceBus
         static int nextId;
         readonly string clientTypeName;
         readonly object syncLock;
+        bool isClosedOrClosing;
 
         protected ClientEntity(string clientTypeName, string postfix, RetryPolicy retryPolicy)
         {
@@ -32,8 +33,20 @@ namespace Microsoft.Azure.ServiceBus
         /// </summary>
         public bool IsClosedOrClosing
         {
-            get;
-            internal set;
+            get
+            {
+                lock (syncLock)
+                {
+                    return isClosedOrClosing;
+                }
+            }
+            internal set
+            {
+                lock (syncLock)
+                {
+                    isClosedOrClosing = value;
+                }
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -808,6 +808,8 @@ namespace Microsoft.Azure.ServiceBus.Core
 
                 while (timeoutHelper.RemainingTime() > TimeSpan.Zero)
                 {
+                    this.ThrowIfClosed();
+
                     IEnumerable<AmqpMessage> amqpMessages = null;
                     var hasMessages = await Task.Factory.FromAsync(
                         (c, s) => receiveLink.BeginReceiveRemoteMessages(maxMessageCount, DefaultBatchFlushInterval, timeoutHelper.RemainingTime(), c, s),


### PR DESCRIPTION
Fixes 2 issues

1. #258 - Pending Receiver.Receive should throw when the receiver is closed.
2. #297 - ClientEntity.IsClosedOrClosing should be thread safe (locking)