### PR TITLE
Added SharedAccessSignature support for Connection String

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
 
             this.ownsConnection = true;
-            var tokenProvider = TokenProvider.CreateSharedAccessSignatureTokenProvider(this.ServiceBusConnection.SasKeyName, this.ServiceBusConnection.SasKey);
+            var tokenProvider = this.ServiceBusConnection.CreateTokenProvider();
             this.CbsTokenProvider = new TokenProviderAdapter(tokenProvider, this.ServiceBusConnection.OperationTimeout);
         }
 

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
@@ -74,9 +74,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
 
             this.ownsConnection = true;
-            var tokenProvider = TokenProvider.CreateSharedAccessSignatureTokenProvider(
-                this.ServiceBusConnection.SasKeyName,
-                this.ServiceBusConnection.SasKey);
+            var tokenProvider = this.ServiceBusConnection.CreateTokenProvider();
             this.CbsTokenProvider = new TokenProviderAdapter(tokenProvider, this.ServiceBusConnection.OperationTimeout);
         }
 

--- a/src/Microsoft.Azure.ServiceBus/Primitives/ServiceBusConnection.cs
+++ b/src/Microsoft.Azure.ServiceBus/Primitives/ServiceBusConnection.cs
@@ -38,9 +38,14 @@ namespace Microsoft.Azure.ServiceBus.Primitives
         public string SasKey { get; set; }
 
         /// <summary>
-        /// Get the shared access policy owner name from the connection string
+        /// Get the shared access policy name from the connection string
         /// </summary>
         public string SasKeyName { get; set; }
+
+        /// <summary>
+        /// Get the shared access signature token from the connection string
+        /// </summary>
+        public string SasToken { get; set; }
 
         /// <summary>
         /// Get the transport type from the connection string.
@@ -60,6 +65,7 @@ namespace Microsoft.Azure.ServiceBus.Primitives
             this.Endpoint = new Uri(builder.Endpoint);
             this.SasKeyName = builder.SasKeyName;
             this.SasKey = builder.SasKey;
+            this.SasToken = builder.SasToken;
             this.TransportType = builder.TransportType;
             this.ConnectionManager = new FaultTolerantAmqpObject<AmqpConnection>(this.CreateConnectionAsync, CloseConnection);
         }
@@ -122,5 +128,18 @@ namespace Microsoft.Azure.ServiceBus.Primitives
                 port: port,
                 useSslStreamSecurity: true);
         }
+
+        internal TokenProvider CreateTokenProvider()
+        {
+            if (SasToken != null)
+            {
+                return TokenProvider.CreateSharedAccessSignatureTokenProvider(SasToken);
+            }
+            else
+            {
+                return TokenProvider.CreateSharedAccessSignatureTokenProvider(SasKeyName, SasKey);
+            }
+        }
+
     }
 }

--- a/src/Microsoft.Azure.ServiceBus/QueueClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/QueueClient.cs
@@ -107,9 +107,7 @@ namespace Microsoft.Azure.ServiceBus
             this.syncLock = new object();
             this.QueueName = entityPath;
             this.ReceiveMode = receiveMode;
-            this.TokenProvider = TokenProvider.CreateSharedAccessSignatureTokenProvider(
-                serviceBusConnection.SasKeyName,
-                serviceBusConnection.SasKey);
+            this.TokenProvider = this.ServiceBusConnection.CreateTokenProvider();
             this.CbsTokenProvider = new TokenProviderAdapter(this.TokenProvider, serviceBusConnection.OperationTimeout);
 
             MessagingEventSource.Log.QueueClientCreateStop(serviceBusConnection.Endpoint.Authority, entityPath, this.ClientId);

--- a/src/Microsoft.Azure.ServiceBus/SessionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionClient.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.ServiceBus
             }
 
             this.ownsConnection = true;
-            var tokenProvider = TokenProvider.CreateSharedAccessSignatureTokenProvider(this.ServiceBusConnection.SasKeyName, this.ServiceBusConnection.SasKey);
+            var tokenProvider = this.ServiceBusConnection.CreateTokenProvider();
             this.CbsTokenProvider = new TokenProviderAdapter(tokenProvider, this.ServiceBusConnection.OperationTimeout);
         }
 

--- a/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
@@ -106,9 +106,7 @@ namespace Microsoft.Azure.ServiceBus
             this.SubscriptionName = subscriptionName;
             this.Path = EntityNameHelper.FormatSubscriptionPath(this.TopicPath, this.SubscriptionName);
             this.ReceiveMode = receiveMode;
-            this.TokenProvider = TokenProvider.CreateSharedAccessSignatureTokenProvider(
-                serviceBusConnection.SasKeyName,
-                serviceBusConnection.SasKey);
+            this.TokenProvider = this.ServiceBusConnection.CreateTokenProvider();
             this.CbsTokenProvider = new TokenProviderAdapter(this.TokenProvider, serviceBusConnection.OperationTimeout);
 
             MessagingEventSource.Log.SubscriptionClientCreateStop(serviceBusConnection.Endpoint.Authority, topicPath, subscriptionName, this.ClientId);

--- a/src/Microsoft.Azure.ServiceBus/TopicClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/TopicClient.cs
@@ -77,9 +77,7 @@ namespace Microsoft.Azure.ServiceBus
             this.OperationTimeout = this.ServiceBusConnection.OperationTimeout;
             this.syncLock = new object();
             this.TopicName = entityPath;
-            this.TokenProvider = TokenProvider.CreateSharedAccessSignatureTokenProvider(
-                serviceBusConnection.SasKeyName,
-                serviceBusConnection.SasKey);
+            this.TokenProvider = this.ServiceBusConnection.CreateTokenProvider();
             this.CbsTokenProvider = new TokenProviderAdapter(this.TokenProvider, serviceBusConnection.OperationTimeout);
 
             MessagingEventSource.Log.TopicClientCreateStop(serviceBusConnection?.Endpoint.Authority, entityPath, this.ClientId);

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -252,6 +252,7 @@ namespace Microsoft.Azure.ServiceBus
         public string EntityPath { get; set; }
         public string SasKey { get; set; }
         public string SasKeyName { get; set; }
+        public string SasToken { get; set; }
         public Microsoft.Azure.ServiceBus.TransportType TransportType { get; set; }
         public string GetEntityConnectionString() { }
         public string GetNamespaceConnectionString() { }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -247,7 +247,9 @@ namespace Microsoft.Azure.ServiceBus
         public ServiceBusConnectionStringBuilder() { }
         public ServiceBusConnectionStringBuilder(string connectionString) { }
         public ServiceBusConnectionStringBuilder(string endpoint, string entityPath, string sharedAccessKeyName, string sharedAccessKey) { }
+        public ServiceBusConnectionStringBuilder(string endpoint, string entityPath, string sharedAccessSignature) { }
         public ServiceBusConnectionStringBuilder(string endpoint, string entityPath, string sharedAccessKeyName, string sharedAccessKey, Microsoft.Azure.ServiceBus.TransportType transportType) { }
+        public ServiceBusConnectionStringBuilder(string endpoint, string entityPath, string sharedAccessSignature, Microsoft.Azure.ServiceBus.TransportType transportType) { }
         public string Endpoint { get; set; }
         public string EntityPath { get; set; }
         public string SasKey { get; set; }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/ServiceBusConnectionStringBuilderTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/ServiceBusConnectionStringBuilderTests.cs
@@ -123,5 +123,14 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             var csBuilder = new ServiceBusConnectionStringBuilder("Endpoint=sb://contoso.servicebus.windows.net;SharedAccessKeyName=keyname;SharedAccessKey=key");
             Assert.Equal(TransportType.Amqp, csBuilder.TransportType);
         }
+
+        [Fact]
+        void ConnectionStringBuilderShouldParseToken()
+        {
+            var token = "SharedAccessSignature sr=https%3a%2f%2fmynamespace.servicebus.windows.net%2fvendor-&sig=AQGQJjSzXxECxcz%2bbT2rasdfasdfasdfa%2bkBq%2bdJZVabU%3d&se=64953734126&skn=PolicyName";
+            var csBuilder = new ServiceBusConnectionStringBuilder("SharedAccessSignature=" + token+";Endpoint=sb://contoso.servicebus.windows.net");
+            Assert.Equal("sb://contoso.servicebus.windows.net", csBuilder.Endpoint);
+            Assert.Equal(token, csBuilder.SasToken);
+        }
     }
 }


### PR DESCRIPTION
Added SharedAccessSignature option for connection string builder, moved control of creating token provider into ServiceBusConnection,  added test. 

This will also resolve #332 