### PR TITLE
Removing filtering of expired messages from `ReceiveAsync()`

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
+++ b/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
@@ -30,7 +30,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.1.2" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
   </ItemGroup>
 

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/SenderReceiverTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/SenderReceiverTests.cs
@@ -186,29 +186,19 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
 
         [Fact]
         [DisplayTestMethodName]
-        public async Task WaitingReceiveShouldThrowWhenReceiverIsClosed()
+        public async Task WaitingReceiveShouldReturnImmediatelyWhenReceiverIsClosed()
         {
             var receiver = new MessageReceiver(TestUtility.NamespaceConnectionString, TestConstants.NonPartitionedQueueName, ReceiveMode.ReceiveAndDelete);
 
             TestUtility.Log("Begin to receive from an empty queue.");
-            Task throwingTask;
-            var exceptionReceived = false;
-            var syncLock = new object();
+            Task quickTask;
             try
             {
-                throwingTask = Task.Run(async () =>
+                quickTask = Task.Run(async () =>
                 {
                     try
                     {
-                        var message = await receiver.ReceiveAsync(TimeSpan.FromSeconds(40));
-                        throw new Exception($"Received unexpected message: {Encoding.ASCII.GetString(message.Body)}");
-                    }
-                    catch (ObjectDisposedException)
-                    {
-                        lock (syncLock)
-                        {
-                            exceptionReceived = true;
-                        }
+                        await receiver.ReceiveAsync(TimeSpan.FromSeconds(40));
                     }
                     catch (Exception e)
                     {
@@ -226,13 +216,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
 
             TestUtility.Log("Waiting for maximum 10 Secs");
             var waitingTask = Task.Delay(10000);
-            await Task.WhenAny(throwingTask, waitingTask);
-
-            Assert.True(throwingTask.IsCompleted, "ReceiveAsync did not return immediately after closing connection");
-            lock (syncLock)
-            {
-                Assert.True(exceptionReceived, "Did not receive ObjectDisposedException"); 
-            }
+            Assert.Equal(quickTask, await Task.WhenAny(quickTask, waitingTask));
         }
 
         [Fact]

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/SenderReceiverTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/SenderReceiverTests.cs
@@ -215,8 +215,8 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                         TestUtility.Log("Unexpected exception: " + e);
                     }
                 });
-                await Task.Delay(1000);
-                TestUtility.Log("Waited for 1 Sec");
+                await Task.Delay(2000);
+                TestUtility.Log("Waited for 2 Seconds for the ReceiveAsync to establish connection.");
             }
             finally
             {


### PR DESCRIPTION
We had logic written in `MessageReceiver.ReceiveAsync()` to filter out expired messages before returning the message to the user. This might lead to problems when there is a machine time difference between the ASB service and the client machine which may lead to never receiving a message. 
Removing this "smart" handling of expired messages. 
If the prefetch count is high, customers can receive messages from the prefetched queue which are already expired. This also helps customers in calculating the optimal prefetch count. If they receive expired messages, then the prefetch count needs to be re-looked at. 