### PR TITLE
Reverting interface changes to push 1.1.0 

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
@@ -444,7 +444,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
             return action;
         }
 
-        internal static bool TryGetAmqpObjectFromNetObject(object netObject, MappingType mappingType, out object amqpObject)
+        static bool TryGetAmqpObjectFromNetObject(object netObject, MappingType mappingType, out object amqpObject)
         {
             amqpObject = null;
             if (netObject == null)

--- a/src/Microsoft.Azure.ServiceBus/Amqp/ManagementConstants.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/ManagementConstants.cs
@@ -56,9 +56,6 @@ namespace Microsoft.Azure.ServiceBus.Amqp
             public static readonly MapKey Message = new MapKey("message");
             public static readonly MapKey Messages = new MapKey("messages");
             public static readonly MapKey DispositionStatus = new MapKey("disposition-status");
-            public static readonly MapKey PropertiesToModify = new MapKey("properties-to-modify");
-            public static readonly MapKey DeadLetterReason = new MapKey("deadletter-reason");
-            public static readonly MapKey DeadLetterDescription = new MapKey("deadletter-description");
 
             public static readonly MapKey FromSequenceNumber = new MapKey("from-sequence-number");
             public static readonly MapKey MessageCount = new MapKey("message-count");

--- a/src/Microsoft.Azure.ServiceBus/Constants.cs
+++ b/src/Microsoft.Azure.ServiceBus/Constants.cs
@@ -23,8 +23,6 @@ namespace Microsoft.Azure.ServiceBus
 
         public const int DefaultClientPrefetchCount = 0;
 
-        public const int MaxDeadLetterReasonLength = 4096;
-
         public static readonly long DefaultLastPeekedSequenceNumber = 0;
 
         public static readonly TimeSpan DefaultOperationTimeout = TimeSpan.FromMinutes(1);

--- a/src/Microsoft.Azure.ServiceBus/Core/IMessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/IMessageReceiver.cs
@@ -133,19 +133,6 @@ namespace Microsoft.Azure.ServiceBus.Core
         Task RenewLockAsync(Message message);
 
         /// <summary>
-        /// Renews the lock on the message. The lock will be renewed based on the setting specified on the queue.
-        /// <returns>New lock token expiry date and time in UTC format.</returns>
-        /// </summary>
-        /// <param name="lockToken">Lock token associated with the message.</param>
-        /// <remarks>
-        /// When a message is received in <see cref="ServiceBus.ReceiveMode.PeekLock"/> mode, the message is locked on the server for this
-        /// receiver instance for a duration as specified during the Queue/Subscription creation (LockDuration).
-        /// If processing of the message requires longer than this duration, the lock needs to be renewed.
-        /// For each renewal, it resets the time the message is locked by the LockDuration set on the Entity.
-        /// </remarks>
-        Task<DateTime> RenewLockAsync(string lockToken);
-
-        /// <summary>
         /// Fetches the next active message without changing the state of the receiver or the message source.
         /// </summary>
         /// <remarks>

--- a/src/Microsoft.Azure.ServiceBus/Core/IMessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/IMessageReceiver.cs
@@ -111,7 +111,6 @@ namespace Microsoft.Azure.ServiceBus.Core
 
         /// <summary>Indicates that the receiver wants to defer the processing for the message.</summary>
         /// <param name="lockToken">The lock token of the <see cref="Message" />.</param>
-        /// <param name="propertiesToModify">The properties of the message to modify while deferring the message.</param>
         /// <remarks>
         /// A lock token can be found in <see cref="Message.SystemPropertiesCollection.LockToken"/>,
         /// only when <see cref="ReceiveMode"/> is set to <see cref="ServiceBus.ReceiveMode.PeekLock"/>.
@@ -120,7 +119,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// Deferring messages does not impact message's expiration, meaning that deferred messages can still expire.
         /// This operation can only be performed on messages that were received by this receiver.
         /// </remarks>
-        Task DeferAsync(string lockToken, IDictionary<string, object> propertiesToModify = null);
+        Task DeferAsync(string lockToken);
 
         /// <summary>
         /// Renews the lock on the message. The lock will be renewed based on the setting specified on the queue.

--- a/src/Microsoft.Azure.ServiceBus/Core/IReceiverClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/IReceiverClient.cs
@@ -4,7 +4,6 @@
 namespace Microsoft.Azure.ServiceBus.Core
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -83,19 +82,17 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// Abandons a <see cref="Message"/> using a lock token. This will make the message available again for processing.
         /// </summary>
         /// <param name="lockToken">The lock token of the corresponding message to abandon.</param>
-        /// <param name="propertiesToModify">The properties of the message to modify while abandoning the message.</param>
         /// <remarks>A lock token can be found in <see cref="Message.SystemPropertiesCollection.LockToken"/>,
         /// only when <see cref="ReceiveMode"/> is set to <see cref="ServiceBus.ReceiveMode.PeekLock"/>.
         /// Abandoning a message will increase the delivery count on the message.
         /// This operation can only be performed on messages that were received by this receiver.
         /// </remarks>
-        Task AbandonAsync(string lockToken, IDictionary<string, object> propertiesToModify = null);
+        Task AbandonAsync(string lockToken);
 
         /// <summary>
         /// Moves a message to the deadletter sub-queue.
         /// </summary>
         /// <param name="lockToken">The lock token of the corresponding message to deadletter.</param>
-        /// <param name="propertiesToModify">The properties of the message to modify while moving to sub-queue.</param>
         /// <remarks>
         /// A lock token can be found in <see cref="Message.SystemPropertiesCollection.LockToken"/>,
         /// only when <see cref="ReceiveMode"/> is set to <see cref="ServiceBus.ReceiveMode.PeekLock"/>.
@@ -103,21 +100,6 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// You can use <see cref="EntityNameHelper.FormatDeadLetterPath(string)"/> to help with this.
         /// This operation can only be performed on messages that were received by this receiver.
         /// </remarks>
-        Task DeadLetterAsync(string lockToken, IDictionary<string, object> propertiesToModify = null);
-
-        /// <summary>
-        /// Moves a message to the deadletter sub-queue.
-        /// </summary>
-        /// <param name="lockToken">The lock token of the corresponding message to deadletter.</param>
-        /// <param name="deadLetterReason">The reason for deadlettering the message.</param>
-        /// <param name="deadLetterErrorDescription">The error description for deadlettering the message.</param>
-        /// <remarks>
-        /// A lock token can be found in <see cref="Message.SystemPropertiesCollection.LockToken"/>,
-        /// only when <see cref="ReceiveMode"/> is set to <see cref="ServiceBus.ReceiveMode.PeekLock"/>.
-        /// In order to receive a message from the deadletter queue, you will need a new <see cref="IMessageReceiver"/>, with the corresponding path.
-        /// You can use <see cref="EntityNameHelper.FormatDeadLetterPath(string)"/> to help with this.
-        /// This operation can only be performed on messages that were received by this receiver.
-        /// </remarks>
-        Task DeadLetterAsync(string lockToken, string deadLetterReason, string deadLetterErrorDescription = null);
+        Task DeadLetterAsync(string lockToken);
     }
 }

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -121,6 +121,7 @@ namespace Microsoft.Azure.ServiceBus.Core
 
             this.ServiceBusConnection = serviceBusConnection ?? throw new ArgumentNullException(nameof(serviceBusConnection));
             this.ReceiveMode = receiveMode;
+            this.OperationTimeout = serviceBusConnection.OperationTimeout;
             this.Path = entityPath;
             this.EntityType = entityType;
             this.CbsTokenProvider = cbsTokenProvider;
@@ -444,13 +445,12 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// Abandons a <see cref="Message"/> using a lock token. This will make the message available again for processing.
         /// </summary>
         /// <param name="lockToken">The lock token of the corresponding message to abandon.</param>
-        /// <param name="propertiesToModify">The properties of the message to modify while abandoning the message.</param>
         /// <remarks>A lock token can be found in <see cref="Message.SystemPropertiesCollection.LockToken"/>,
         /// only when <see cref="ReceiveMode"/> is set to <see cref="ServiceBus.ReceiveMode.PeekLock"/>.
         /// Abandoning a message will increase the delivery count on the message.
         /// This operation can only be performed on messages that were received by this receiver.
         /// </remarks>
-        public async Task AbandonAsync(string lockToken, IDictionary<string, object> propertiesToModify = null)
+        public async Task AbandonAsync(string lockToken)
         {
             this.ThrowIfClosed();
             this.ThrowIfNotPeekLockMode();
@@ -458,7 +458,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             MessagingEventSource.Log.MessageAbandonStart(this.ClientId, 1, lockToken);
             try
             {
-                await this.RetryPolicy.RunOperation(() => this.OnAbandonAsync(lockToken, propertiesToModify), this.OperationTimeout)
+                await this.RetryPolicy.RunOperation(() => this.OnAbandonAsync(lockToken), this.OperationTimeout)
                     .ConfigureAwait(false);
             }
             catch (Exception exception)
@@ -472,7 +472,6 @@ namespace Microsoft.Azure.ServiceBus.Core
 
         /// <summary>Indicates that the receiver wants to defer the processing for the message.</summary>
         /// <param name="lockToken">The lock token of the <see cref="Message" />.</param>
-        /// <param name="propertiesToModify">The properties of the message to modify while deferring the message.</param>
         /// <remarks>
         /// A lock token can be found in <see cref="Message.SystemPropertiesCollection.LockToken"/>,
         /// only when <see cref="ReceiveMode"/> is set to <see cref="ServiceBus.ReceiveMode.PeekLock"/>.
@@ -481,7 +480,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// Deferring messages does not impact message's expiration, meaning that deferred messages can still expire.
         /// This operation can only be performed on messages that were received by this receiver.
         /// </remarks>
-        public async Task DeferAsync(string lockToken, IDictionary<string, object> propertiesToModify = null)
+        public async Task DeferAsync(string lockToken)
         {
             this.ThrowIfClosed();
             this.ThrowIfNotPeekLockMode();
@@ -490,7 +489,7 @@ namespace Microsoft.Azure.ServiceBus.Core
 
             try
             {
-                await this.RetryPolicy.RunOperation(() => this.OnDeferAsync(lockToken, propertiesToModify), this.OperationTimeout)
+                await this.RetryPolicy.RunOperation(() => this.OnDeferAsync(lockToken), this.OperationTimeout)
                     .ConfigureAwait(false);
             }
             catch (Exception exception)
@@ -506,7 +505,6 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// Moves a message to the deadletter sub-queue.
         /// </summary>
         /// <param name="lockToken">The lock token of the corresponding message to deadletter.</param>
-        /// <param name="propertiesToModify">The properties of the message to modify while moving to sub-queue.</param>
         /// <remarks>
         /// A lock token can be found in <see cref="Message.SystemPropertiesCollection.LockToken"/>,
         /// only when <see cref="ReceiveMode"/> is set to <see cref="ServiceBus.ReceiveMode.PeekLock"/>.
@@ -514,7 +512,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// You can use <see cref="EntityNameHelper.FormatDeadLetterPath(string)"/> to help with this.
         /// This operation can only be performed on messages that were received by this receiver.
         /// </remarks>
-        public async Task DeadLetterAsync(string lockToken, IDictionary<string, object> propertiesToModify = null)
+        public async Task DeadLetterAsync(string lockToken)
         {
             this.ThrowIfClosed();
             this.ThrowIfNotPeekLockMode();
@@ -523,41 +521,7 @@ namespace Microsoft.Azure.ServiceBus.Core
 
             try
             {
-                await this.RetryPolicy.RunOperation(() => this.OnDeadLetterAsync(lockToken, propertiesToModify), this.OperationTimeout)
-                    .ConfigureAwait(false);
-            }
-            catch (Exception exception)
-            {
-                MessagingEventSource.Log.MessageDeadLetterException(this.ClientId, exception);
-                throw;
-            }
-
-            MessagingEventSource.Log.MessageDeadLetterStop(this.ClientId);
-        }
-
-        /// <summary>
-        /// Moves a message to the deadletter sub-queue.
-        /// </summary>
-        /// <param name="lockToken">The lock token of the corresponding message to deadletter.</param>
-        /// <param name="deadLetterReason">The reason for deadlettering the message.</param>
-        /// <param name="deadLetterErrorDescription">The error description for deadlettering the message.</param>
-        /// <remarks>
-        /// A lock token can be found in <see cref="Message.SystemPropertiesCollection.LockToken"/>,
-        /// only when <see cref="ReceiveMode"/> is set to <see cref="ServiceBus.ReceiveMode.PeekLock"/>.
-        /// In order to receive a message from the deadletter queue, you will need a new <see cref="IMessageReceiver"/>, with the corresponding path.
-        /// You can use <see cref="EntityNameHelper.FormatDeadLetterPath(string)"/> to help with this.
-        /// This operation can only be performed on messages that were received by this receiver.
-        /// </remarks>
-        public async Task DeadLetterAsync(string lockToken, string deadLetterReason, string deadLetterErrorDescription = null)
-        {
-            this.ThrowIfClosed();
-            this.ThrowIfNotPeekLockMode();
-
-            MessagingEventSource.Log.MessageDeadLetterStart(this.ClientId, 1, lockToken);
-
-            try
-            {
-                await this.RetryPolicy.RunOperation(() => this.OnDeadLetterAsync(lockToken, null, deadLetterReason, deadLetterErrorDescription), this.OperationTimeout)
+                await this.RetryPolicy.RunOperation(() => this.OnDeadLetterAsync(lockToken), this.OperationTimeout)
                     .ConfigureAwait(false);
             }
             catch (Exception exception)
@@ -986,50 +950,39 @@ namespace Microsoft.Azure.ServiceBus.Core
             return this.DisposeMessagesAsync(lockTokenGuids, AmqpConstants.AcceptedOutcome);
         }
 
-        protected virtual Task OnAbandonAsync(string lockToken, IDictionary<string, object> propertiesToModify = null)
+        protected virtual Task OnAbandonAsync(string lockToken)
         {
             var lockTokens = new[] { new Guid(lockToken) };
             if (lockTokens.Any(lt => this.requestResponseLockedMessages.Contains(lt)))
             {
-                return this.DisposeMessageRequestResponseAsync(lockTokens, DispositionStatus.Abandoned, propertiesToModify);
+                return this.DisposeMessageRequestResponseAsync(lockTokens, DispositionStatus.Abandoned);
             }
-            return this.DisposeMessagesAsync(lockTokens, GetAbandonOutcome(propertiesToModify));
+            return this.DisposeMessagesAsync(lockTokens, new Modified());
         }
 
-        protected virtual Task OnDeferAsync(string lockToken, IDictionary<string, object> propertiesToModify = null)
+        protected virtual Task OnDeferAsync(string lockToken)
         {
             var lockTokens = new[] { new Guid(lockToken) };
             if (lockTokens.Any(lt => this.requestResponseLockedMessages.Contains(lt)))
             {
-                return this.DisposeMessageRequestResponseAsync(lockTokens, DispositionStatus.Defered, propertiesToModify);
+                return this.DisposeMessageRequestResponseAsync(lockTokens, DispositionStatus.Defered);
             }
-            return this.DisposeMessagesAsync(lockTokens, GetDeferOutcome(propertiesToModify));
+            return this.DisposeMessagesAsync(lockTokens, new Modified { UndeliverableHere = true });
         }
 
-        protected virtual Task OnDeadLetterAsync(string lockToken, IDictionary<string, object> propertiesToModify = null, string deadLetterReason = null, string deadLetterErrorDescription = null)
+        protected virtual Task OnDeadLetterAsync(string lockToken)
         {
-            if (deadLetterReason != null && deadLetterReason.Length > Constants.MaxDeadLetterReasonLength)
-            {
-                throw new ArgumentOutOfRangeException(nameof(deadLetterReason), $"Maximum permitted length is {Constants.MaxDeadLetterReasonLength}");
-            }
-
-            if (deadLetterErrorDescription != null && deadLetterErrorDescription.Length > Constants.MaxDeadLetterReasonLength)
-            {
-                throw new ArgumentOutOfRangeException(nameof(deadLetterErrorDescription), $"Maximum permitted length is {Constants.MaxDeadLetterReasonLength}");
-            }
-            
             var lockTokens = new[] { new Guid(lockToken) };
             if (lockTokens.Any(lt => this.requestResponseLockedMessages.Contains(lt)))
             {
-                return this.DisposeMessageRequestResponseAsync(lockTokens, DispositionStatus.Suspended, propertiesToModify, deadLetterReason, deadLetterErrorDescription);
+                return this.DisposeMessageRequestResponseAsync(lockTokens, DispositionStatus.Suspended);
             }
-
-            return this.DisposeMessagesAsync(lockTokens, GetRejectedOutcome(propertiesToModify, deadLetterReason, deadLetterErrorDescription));
+            return this.DisposeMessagesAsync(lockTokens, AmqpConstants.RejectedOutcome);
         }
 
         protected virtual async Task<DateTime> OnRenewLockAsync(string lockToken)
         {
-            DateTime lockedUntilUtc;
+            var lockedUntilUtc = DateTime.MinValue;
             try
             {
                 // Create an AmqpRequest Message to renew  lock
@@ -1216,7 +1169,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
         }
 
-        async Task DisposeMessageRequestResponseAsync(Guid[] lockTokens, DispositionStatus dispositionStatus, IDictionary<string, object> propertiesToModify = null, string deadLetterReason = null, string deadLetterDescription = null)
+        async Task DisposeMessageRequestResponseAsync(Guid[] lockTokens, DispositionStatus dispositionStatus)
         {
             try
             {
@@ -1224,42 +1177,6 @@ namespace Microsoft.Azure.ServiceBus.Core
                 var amqpRequestMessage = AmqpRequestMessage.CreateRequest(ManagementConstants.Operations.UpdateDispositionOperation, this.OperationTimeout, null);
                 amqpRequestMessage.Map[ManagementConstants.Properties.LockTokens] = lockTokens;
                 amqpRequestMessage.Map[ManagementConstants.Properties.DispositionStatus] = dispositionStatus.ToString().ToLowerInvariant();
-
-                if (deadLetterReason != null)
-                {
-                    amqpRequestMessage.Map[ManagementConstants.Properties.DeadLetterReason] = deadLetterReason;
-                }
-
-                if (deadLetterDescription != null)
-                {
-                    amqpRequestMessage.Map[ManagementConstants.Properties.DeadLetterDescription] = deadLetterDescription;
-                }
-
-                if (propertiesToModify != null)
-                {
-                    var amqpPropertiesToModify = new AmqpMap();
-                    foreach (var pair in propertiesToModify)
-                    {
-                        if (AmqpMessageConverter.TryGetAmqpObjectFromNetObject(pair.Value, MappingType.ApplicationProperty, out var amqpObject))
-                        {
-                            amqpPropertiesToModify[new MapKey(pair.Key)] = amqpObject;
-                        }
-                        else
-                        {
-                            throw new NotSupportedException(Resources.InvalidAmqpMessageProperty.FormatForUser(pair.Key.GetType()));
-                        }
-                    }
-
-                    if (amqpPropertiesToModify.Count > 0)
-                    {
-                        amqpRequestMessage.Map[ManagementConstants.Properties.PropertiesToModify] = amqpPropertiesToModify;
-                    }
-                }
-
-                if (!string.IsNullOrWhiteSpace(this.SessionIdInternal))
-                {
-                    amqpRequestMessage.Map[ManagementConstants.Properties.SessionId] = this.SessionIdInternal;
-                }
 
                 var amqpResponseMessage = await this.ExecuteRequestResponseAsync(amqpRequestMessage).ConfigureAwait(false);
                 if (amqpResponseMessage.StatusCode != AmqpResponseStatusCode.OK)
@@ -1382,78 +1299,6 @@ namespace Microsoft.Azure.ServiceBus.Core
             {
                 throw this.LinkException;
             }
-        }
-
-        Outcome GetAbandonOutcome(IDictionary<string, object> propertiesToModify)
-        {
-            return this.GetModifiedOutcome(propertiesToModify, false);
-        }
-
-        Outcome GetDeferOutcome(IDictionary<string, object> propertiesToModify)
-        {
-            return this.GetModifiedOutcome(propertiesToModify, true);
-        }
-
-        Outcome GetModifiedOutcome(IDictionary<string, object> propertiesToModify, bool undeliverableHere)
-        {
-            Modified modified = new Modified();
-            if (undeliverableHere)
-            {
-                modified.UndeliverableHere = true;
-            }
-
-            if (propertiesToModify != null)
-            {
-                modified.MessageAnnotations = new Fields();
-                foreach (var pair in propertiesToModify)
-                {
-                    if (AmqpMessageConverter.TryGetAmqpObjectFromNetObject(pair.Value, MappingType.ApplicationProperty, out var amqpObject))
-                    {
-                        modified.MessageAnnotations.Add(pair.Key, amqpObject);
-                    }
-                    else
-                    {
-                        throw new NotSupportedException(Resources.InvalidAmqpMessageProperty.FormatForUser(pair.Key.GetType()));
-                    }
-                }
-            }
-
-            return modified;
-        }
-
-        Rejected GetRejectedOutcome(IDictionary<string, object> propertiesToModify, string deadLetterReason, string deadLetterErrorDescription)
-        {
-            var rejected = AmqpConstants.RejectedOutcome;
-            if (deadLetterReason != null || deadLetterErrorDescription != null || propertiesToModify != null)
-            {
-                rejected = new Rejected { Error = new Error { Condition = AmqpClientConstants.DeadLetterName, Info = new Fields() } };
-                if (deadLetterReason != null)
-                {
-                    rejected.Error.Info.Add(Message.DeadLetterReasonHeader, deadLetterReason);
-                }
-
-                if (deadLetterErrorDescription != null)
-                {
-                    rejected.Error.Info.Add(Message.DeadLetterErrorDescriptionHeader, deadLetterErrorDescription);
-                }
-
-                if (propertiesToModify != null)
-                {
-                    foreach (var pair in propertiesToModify)
-                    {
-                        if (AmqpMessageConverter.TryGetAmqpObjectFromNetObject(pair.Value, MappingType.ApplicationProperty, out var amqpObject))
-                        {
-                            rejected.Error.Info.Add(pair.Key, amqpObject);
-                        }
-                        else
-                        {
-                            throw new NotSupportedException(Resources.InvalidAmqpMessageProperty.FormatForUser(pair.Key.GetType()));
-                        }
-                    }
-                }
-            }
-
-            return rejected;
         }
     }
 }

--- a/src/Microsoft.Azure.ServiceBus/Message.cs
+++ b/src/Microsoft.Azure.ServiceBus/Message.cs
@@ -13,16 +13,6 @@ namespace Microsoft.Azure.ServiceBus
     /// </summary>
     public class Message
     {
-        /// <summary>
-        /// User property key representing deadletter reason, when a message is received from a deadletter subqueue of an entity.
-        /// </summary>
-        public static string DeadLetterReasonHeader = "DeadLetterReason";
-
-        /// <summary>
-        /// User property key representing detailed error description, when a message is received from a deadletter subqueue of an entity.
-        /// </summary>
-        public static string DeadLetterErrorDescriptionHeader = "DeadLetterErrorDescription";
-
         private string messageId;
         private string sessionId;
         private string replyToSessionId;

--- a/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
+++ b/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
@@ -14,6 +14,7 @@
     <PackageProjectUrl>https://github.com/Azure/azure-service-bus-dotnet</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/Azure/azure-service-bus-dotnet/master/LICENSE</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludePDBsInPackage</TargetsForTfmSpecificContentInPackage>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
+++ b/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <Description>This is the next generation Azure Service Bus .NET Standard client library that focuses on queues &amp; topics. For more information about Service Bus, see https://azure.microsoft.com/en-us/services/service-bus/</Description>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>1.0.0</VersionPrefix>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard1.3</TargetFrameworks>
     <AssemblyOriginatorKeyFile>../../build/keyfile.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
@@ -14,6 +14,7 @@
     <PackageProjectUrl>https://github.com/Azure/azure-service-bus-dotnet</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/Azure/azure-service-bus-dotnet/master/LICENSE</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludePDBsInPackage</TargetsForTfmSpecificContentInPackage>

--- a/src/Microsoft.Azure.ServiceBus/Primitives/ClientInfo.cs
+++ b/src/Microsoft.Azure.ServiceBus/Primitives/ClientInfo.cs
@@ -22,11 +22,11 @@ namespace Microsoft.Azure.ServiceBus.Primitives
                 Product = GetAssemblyAttributeValue<AssemblyProductAttribute>(assembly, p => p.Product);
                 Version = GetAssemblyAttributeValue<AssemblyFileVersionAttribute>(assembly, v => v.Version);
                 Framework = GetAssemblyAttributeValue<TargetFrameworkAttribute>(assembly, f => f.FrameworkName);
-#if NETSTANDARD2_0
+#if NETSTANDARD1_3
                 Platform = System.Runtime.InteropServices.RuntimeInformation.OSDescription;
 #elif UAP10_0
                 Platform = "UAP";
-#elif NET461
+#elif NET451
                 Platform = Environment.OSVersion.VersionString;
 #else
                 Platform = "Unknown";

--- a/src/Microsoft.Azure.ServiceBus/QueueClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/QueueClient.cs
@@ -327,54 +327,33 @@ namespace Microsoft.Azure.ServiceBus
         /// Abandons a <see cref="Message"/> using a lock token. This will make the message available again for processing.
         /// </summary>
         /// <param name="lockToken">The lock token of the corresponding message to abandon.</param>
-        /// <param name="propertiesToModify">The properties of the message to modify while abandoning the message.</param>
         /// <remarks>A lock token can be found in <see cref="Message.SystemPropertiesCollection.LockToken"/>,
         /// only when <see cref="ReceiveMode"/> is set to <see cref="ServiceBus.ReceiveMode.PeekLock"/>.
         /// Abandoning a message will increase the delivery count on the message.
         /// This operation can only be performed on messages that were received by this client.
         /// </remarks>
         /// This operation can only be performed on messages that were received by this client.
-        public Task AbandonAsync(string lockToken, IDictionary<string, object> propertiesToModify = null)
+        public Task AbandonAsync(string lockToken)
         {
             this.ThrowIfClosed();
-            return this.InnerReceiver.AbandonAsync(lockToken, propertiesToModify);
+            return this.InnerReceiver.AbandonAsync(lockToken);
         }
 
         /// <summary>
         /// Moves a message to the deadletter sub-queue.
         /// </summary>
         /// <param name="lockToken">The lock token of the corresponding message to deadletter.</param>
-        /// <param name="propertiesToModify">The properties of the message to modify while moving to sub-queue.</param>
         /// <remarks>
         /// A lock token can be found in <see cref="Message.SystemPropertiesCollection.LockToken"/>,
         /// only when <see cref="ReceiveMode"/> is set to <see cref="ServiceBus.ReceiveMode.PeekLock"/>.
-        /// In order to receive a message from the deadletter queue, you will need a new <see cref="IMessageReceiver"/>, with the corresponding path.
+        /// In order to receive a message from the deadletter sub-queue, you will need a new <see cref="IMessageReceiver"/> or <see cref="IQueueClient"/>, with the corresponding path.
         /// You can use <see cref="EntityNameHelper.FormatDeadLetterPath(string)"/> to help with this.
-        /// This operation can only be performed on messages that were received by this receiver.
+        /// This operation can only be performed on messages that were received by this client.
         /// </remarks>
-        public Task DeadLetterAsync(string lockToken, IDictionary<string, object> propertiesToModify = null)
+        public Task DeadLetterAsync(string lockToken)
         {
             this.ThrowIfClosed();
-            return this.InnerReceiver.DeadLetterAsync(lockToken, propertiesToModify);
-        }
-
-        /// <summary>
-        /// Moves a message to the deadletter sub-queue.
-        /// </summary>
-        /// <param name="lockToken">The lock token of the corresponding message to deadletter.</param>
-        /// <param name="deadLetterReason">The reason for deadlettering the message.</param>
-        /// <param name="deadLetterErrorDescription">The error description for deadlettering the message.</param>
-        /// <remarks>
-        /// A lock token can be found in <see cref="Message.SystemPropertiesCollection.LockToken"/>,
-        /// only when <see cref="ReceiveMode"/> is set to <see cref="ServiceBus.ReceiveMode.PeekLock"/>.
-        /// In order to receive a message from the deadletter queue, you will need a new <see cref="IMessageReceiver"/>, with the corresponding path.
-        /// You can use <see cref="EntityNameHelper.FormatDeadLetterPath(string)"/> to help with this.
-        /// This operation can only be performed on messages that were received by this receiver.
-        /// </remarks>
-        public Task DeadLetterAsync(string lockToken, string deadLetterReason, string deadLetterErrorDescription = null)
-        {
-            this.ThrowIfClosed();
-            return this.InnerReceiver.DeadLetterAsync(lockToken, deadLetterReason, deadLetterErrorDescription);
+            return this.InnerReceiver.DeadLetterAsync(lockToken);
         }
 
         /// <summary>

--- a/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
@@ -280,16 +280,15 @@ namespace Microsoft.Azure.ServiceBus
         /// Abandons a <see cref="Message"/> using a lock token. This will make the message available again for processing.
         /// </summary>
         /// <param name="lockToken">The lock token of the corresponding message to abandon.</param>
-        /// <param name="propertiesToModify">The properties of the message to modify while abandoning the message.</param>
         /// <remarks>A lock token can be found in <see cref="Message.SystemPropertiesCollection.LockToken"/>,
         /// only when <see cref="ReceiveMode"/> is set to <see cref="ServiceBus.ReceiveMode.PeekLock"/>.
         /// Abandoning a message will increase the delivery count on the message.
         /// This operation can only be performed on messages that were received by this client.
         /// </remarks>
-        public Task AbandonAsync(string lockToken, IDictionary<string, object> propertiesToModify = null)
+        public Task AbandonAsync(string lockToken)
         {
             this.ThrowIfClosed();
-            return this.InnerSubscriptionClient.InnerReceiver.AbandonAsync(lockToken, propertiesToModify);
+            return this.InnerSubscriptionClient.InnerReceiver.AbandonAsync(lockToken);
         }
 
         /// <summary>
@@ -307,43 +306,6 @@ namespace Microsoft.Azure.ServiceBus
         {
             this.ThrowIfClosed();
             return this.InnerSubscriptionClient.InnerReceiver.DeadLetterAsync(lockToken);
-        }
-
-        /// <summary>
-        /// Moves a message to the deadletter sub-queue.
-        /// </summary>
-        /// <param name="lockToken">The lock token of the corresponding message to deadletter.</param>
-        /// <param name="propertiesToModify">The properties of the message to modify while moving to sub-queue.</param>
-        /// <remarks>
-        /// A lock token can be found in <see cref="Message.SystemPropertiesCollection.LockToken"/>,
-        /// only when <see cref="ReceiveMode"/> is set to <see cref="ServiceBus.ReceiveMode.PeekLock"/>.
-        /// In order to receive a message from the deadletter queue, you will need a new <see cref="IMessageReceiver"/>, with the corresponding path.
-        /// You can use <see cref="EntityNameHelper.FormatDeadLetterPath(string)"/> to help with this.
-        /// This operation can only be performed on messages that were received by this receiver.
-        /// </remarks>
-        public Task DeadLetterAsync(string lockToken, IDictionary<string, object> propertiesToModify)
-        {
-            this.ThrowIfClosed();
-            return this.InnerSubscriptionClient.InnerReceiver.DeadLetterAsync(lockToken, propertiesToModify);
-        }
-
-        /// <summary>
-        /// Moves a message to the deadletter sub-queue.
-        /// </summary>
-        /// <param name="lockToken">The lock token of the corresponding message to deadletter.</param>
-        /// <param name="deadLetterReason">The reason for deadlettering the message.</param>
-        /// <param name="deadLetterErrorDescription">The error description for deadlettering the message.</param>
-        /// <remarks>
-        /// A lock token can be found in <see cref="Message.SystemPropertiesCollection.LockToken"/>,
-        /// only when <see cref="ReceiveMode"/> is set to <see cref="ServiceBus.ReceiveMode.PeekLock"/>.
-        /// In order to receive a message from the deadletter queue, you will need a new <see cref="IMessageReceiver"/>, with the corresponding path.
-        /// You can use <see cref="EntityNameHelper.FormatDeadLetterPath(string)"/> to help with this.
-        /// This operation can only be performed on messages that were received by this receiver.
-        /// </remarks>
-        public Task DeadLetterAsync(string lockToken, string deadLetterReason, string deadLetterErrorDescription = null)
-        {
-            this.ThrowIfClosed();
-            return this.InnerSubscriptionClient.InnerReceiver.DeadLetterAsync(lockToken, deadLetterReason, deadLetterErrorDescription);
         }
 
         /// <summary>

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/APIApprovals.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/APIApprovals.cs
@@ -1,4 +1,4 @@
-﻿#if NET461
+﻿#if NET46
 namespace Microsoft.Azure.ServiceBus.UnitTests.API
 {
     using System.Runtime.CompilerServices;

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -382,7 +382,6 @@ namespace Microsoft.Azure.ServiceBus.Core
         System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.Message> ReceiveDeferredMessageAsync(long sequenceNumber);
         System.Threading.Tasks.Task<System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Message>> ReceiveDeferredMessageAsync(System.Collections.Generic.IEnumerable<long> sequenceNumbers);
         System.Threading.Tasks.Task RenewLockAsync(Microsoft.Azure.ServiceBus.Message message);
-        System.Threading.Tasks.Task<System.DateTime> RenewLockAsync(string lockToken);
     }
     public interface IMessageSender : Microsoft.Azure.ServiceBus.Core.ISenderClient, Microsoft.Azure.ServiceBus.IClientEntity { }
     public interface IReceiverClient : Microsoft.Azure.ServiceBus.IClientEntity
@@ -442,7 +441,6 @@ namespace Microsoft.Azure.ServiceBus.Core
         public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, Microsoft.Azure.ServiceBus.MessageHandlerOptions messageHandlerOptions) { }
         public override void RegisterPlugin(Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin serviceBusPlugin) { }
         public System.Threading.Tasks.Task RenewLockAsync(Microsoft.Azure.ServiceBus.Message message) { }
-        public System.Threading.Tasks.Task<System.DateTime> RenewLockAsync(string lockToken) { }
         public override void UnregisterPlugin(string serviceBusPluginName) { }
     }
     public class MessageSender : Microsoft.Azure.ServiceBus.ClientEntity, Microsoft.Azure.ServiceBus.Core.IMessageSender, Microsoft.Azure.ServiceBus.Core.ISenderClient, Microsoft.Azure.ServiceBus.IClientEntity

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -123,8 +123,6 @@ namespace Microsoft.Azure.ServiceBus
     }
     public class Message
     {
-        public static string DeadLetterErrorDescriptionHeader;
-        public static string DeadLetterReasonHeader;
         public Message() { }
         public Message(byte[] body) { }
         public byte[] Body { get; set; }
@@ -186,11 +184,10 @@ namespace Microsoft.Azure.ServiceBus
         public string QueueName { get; }
         public Microsoft.Azure.ServiceBus.ReceiveMode ReceiveMode { get; }
         public override System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin> RegisteredPlugins { get; }
-        public System.Threading.Tasks.Task AbandonAsync(string lockToken, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null) { }
+        public System.Threading.Tasks.Task AbandonAsync(string lockToken) { }
         public System.Threading.Tasks.Task CancelScheduledMessageAsync(long sequenceNumber) { }
         public System.Threading.Tasks.Task CompleteAsync(string lockToken) { }
-        public System.Threading.Tasks.Task DeadLetterAsync(string lockToken, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null) { }
-        public System.Threading.Tasks.Task DeadLetterAsync(string lockToken, string deadLetterReason, string deadLetterErrorDescription = null) { }
+        public System.Threading.Tasks.Task DeadLetterAsync(string lockToken) { }
         protected override System.Threading.Tasks.Task OnClosingAsync() { }
         public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler) { }
         public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, Microsoft.Azure.ServiceBus.MessageHandlerOptions messageHandlerOptions) { }
@@ -324,13 +321,11 @@ namespace Microsoft.Azure.ServiceBus
         public override System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin> RegisteredPlugins { get; }
         public string SubscriptionName { get; }
         public string TopicPath { get; }
-        public System.Threading.Tasks.Task AbandonAsync(string lockToken, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null) { }
+        public System.Threading.Tasks.Task AbandonAsync(string lockToken) { }
         public System.Threading.Tasks.Task AddRuleAsync(string ruleName, Microsoft.Azure.ServiceBus.Filter filter) { }
         public System.Threading.Tasks.Task AddRuleAsync(Microsoft.Azure.ServiceBus.RuleDescription description) { }
         public System.Threading.Tasks.Task CompleteAsync(string lockToken) { }
         public System.Threading.Tasks.Task DeadLetterAsync(string lockToken) { }
-        public System.Threading.Tasks.Task DeadLetterAsync(string lockToken, System.Collections.Generic.IDictionary<string, object> propertiesToModify) { }
-        public System.Threading.Tasks.Task DeadLetterAsync(string lockToken, string deadLetterReason, string deadLetterErrorDescription = null) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Azure.ServiceBus.RuleDescription>> GetRulesAsync() { }
         protected override System.Threading.Tasks.Task OnClosingAsync() { }
         public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler) { }
@@ -375,7 +370,7 @@ namespace Microsoft.Azure.ServiceBus.Core
     {
         long LastPeekedSequenceNumber { get; }
         System.Threading.Tasks.Task CompleteAsync(System.Collections.Generic.IEnumerable<string> lockTokens);
-        System.Threading.Tasks.Task DeferAsync(string lockToken, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null);
+        System.Threading.Tasks.Task DeferAsync(string lockToken);
         System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.Message> PeekAsync();
         System.Threading.Tasks.Task<System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Message>> PeekAsync(int maxMessageCount);
         System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.Message> PeekBySequenceNumberAsync(long fromSequenceNumber);
@@ -395,10 +390,9 @@ namespace Microsoft.Azure.ServiceBus.Core
         string Path { get; }
         int PrefetchCount { get; set; }
         Microsoft.Azure.ServiceBus.ReceiveMode ReceiveMode { get; }
-        System.Threading.Tasks.Task AbandonAsync(string lockToken, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null);
+        System.Threading.Tasks.Task AbandonAsync(string lockToken);
         System.Threading.Tasks.Task CompleteAsync(string lockToken);
-        System.Threading.Tasks.Task DeadLetterAsync(string lockToken, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null);
-        System.Threading.Tasks.Task DeadLetterAsync(string lockToken, string deadLetterReason, string deadLetterErrorDescription = null);
+        System.Threading.Tasks.Task DeadLetterAsync(string lockToken);
         void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler);
         void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, Microsoft.Azure.ServiceBus.MessageHandlerOptions messageHandlerOptions);
     }
@@ -419,17 +413,16 @@ namespace Microsoft.Azure.ServiceBus.Core
         public int PrefetchCount { get; set; }
         public Microsoft.Azure.ServiceBus.ReceiveMode ReceiveMode { get; set; }
         public override System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin> RegisteredPlugins { get; }
-        public System.Threading.Tasks.Task AbandonAsync(string lockToken, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null) { }
+        public System.Threading.Tasks.Task AbandonAsync(string lockToken) { }
         public System.Threading.Tasks.Task CompleteAsync(string lockToken) { }
         public System.Threading.Tasks.Task CompleteAsync(System.Collections.Generic.IEnumerable<string> lockTokens) { }
-        public System.Threading.Tasks.Task DeadLetterAsync(string lockToken, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null) { }
-        public System.Threading.Tasks.Task DeadLetterAsync(string lockToken, string deadLetterReason, string deadLetterErrorDescription = null) { }
-        public System.Threading.Tasks.Task DeferAsync(string lockToken, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null) { }
-        protected virtual System.Threading.Tasks.Task OnAbandonAsync(string lockToken, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null) { }
+        public System.Threading.Tasks.Task DeadLetterAsync(string lockToken) { }
+        public System.Threading.Tasks.Task DeferAsync(string lockToken) { }
+        protected virtual System.Threading.Tasks.Task OnAbandonAsync(string lockToken) { }
         protected override System.Threading.Tasks.Task OnClosingAsync() { }
         protected virtual System.Threading.Tasks.Task OnCompleteAsync(System.Collections.Generic.IEnumerable<string> lockTokens) { }
-        protected virtual System.Threading.Tasks.Task OnDeadLetterAsync(string lockToken, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null, string deadLetterReason = null, string deadLetterErrorDescription = null) { }
-        protected virtual System.Threading.Tasks.Task OnDeferAsync(string lockToken, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null) { }
+        protected virtual System.Threading.Tasks.Task OnDeadLetterAsync(string lockToken) { }
+        protected virtual System.Threading.Tasks.Task OnDeferAsync(string lockToken) { }
         protected virtual void OnMessageHandler(Microsoft.Azure.ServiceBus.MessageHandlerOptions registerHandlerOptions, System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> callback) { }
         protected virtual System.Threading.Tasks.Task<System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Message>> OnPeekAsync(long fromSequenceNumber, int messageCount = 1) { }
         protected virtual System.Threading.Tasks.Task<System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Message>> OnReceiveAsync(int maxMessageCount, System.TimeSpan serverWaitTime) { }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -1,7 +1,7 @@
 ﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute(@"Microsoft.Azure.ServiceBus.UnitTests,PublicKey=0024000004800000940000000602000000240000525341310004000001000100fdf4acac3b2244dd8a96737e5385b31414369dc3e42f371172127252856a0650793e1f5673a16d5d78e2ac852a104bc51e6f018dca44fdd26a219c27cb2b263956a80620223c8e9c2f8913c3c903e1e453e9e4e84098afdad5f4badb8c1ebe0a7b0a4b57a08454646a65886afe3e290a791ff3260099ce0edf0bdbccafadfeb6")]
 [assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
 [assembly: System.Runtime.InteropServices.GuidAttribute("a042adf0-ef65-4f87-b634-322a409f3d61")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.6.1", FrameworkDisplayName=".NET Framework 4.6.1")]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.5.1", FrameworkDisplayName=".NET Framework 4.5.1")]
 
 namespace Microsoft.Azure.ServiceBus
 {

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprover.6.0.0/PublicApiApprover.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprover.6.0.0/PublicApiApprover.cs
@@ -1,4 +1,4 @@
-﻿#if NET461
+﻿#if NET46
 
 using System.IO;
 using System.Reflection;

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/PublicApiGenerator.6.0.0/ApiGenerator.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/PublicApiGenerator.6.0.0/ApiGenerator.cs
@@ -1,4 +1,4 @@
-﻿#if NET461
+﻿#if NET46
 
 using System;
 using System.CodeDom;

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/MessageInterop/MessageInteropEnd2EndTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/MessageInterop/MessageInteropEnd2EndTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NET461
+#if NET46
 namespace Microsoft.Azure.ServiceBus.UnitTests.MessageInterop
 {
     using Microsoft.ServiceBus.Messaging;

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Microsoft.Azure.ServiceBus.UnitTests.csproj
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Microsoft.Azure.ServiceBus.UnitTests.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;net46</TargetFrameworks>
     <AssemblyOriginatorKeyFile>../../build/keyfile.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;portable-net46+win8</PackageTargetFallback>
+    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,6 +23,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
   </ItemGroup>
@@ -29,7 +32,7 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
     <PackageReference Include="ApiApprover">
       <Version>6.0.0</Version>
     </PackageReference>

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/SenderReceiverClientTestBase.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/SenderReceiverClientTestBase.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             TestUtility.Log("Sleeping 5 seconds...");
             await Task.Delay(TimeSpan.FromSeconds(5));
 
-            await messageReceiver.RenewLockAsync(message.SystemProperties.LockToken);
+            await messageReceiver.RenewLockAsync(message);
             TestUtility.Log($"After Second Renewal: {message.SystemProperties.LockedUntilUtc}");
             Assert.True(message.SystemProperties.LockedUntilUtc >= firstLockedUntilUtcTime + TimeSpan.FromSeconds(5));
 

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/SenderReceiverTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/SenderReceiverTests.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             {
                 quickTask = Task.Run(async () =>
                 {
-                    try
+                    await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
                     {
                         await receiver.ReceiveAsync(TimeSpan.FromSeconds(40));
                     }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/SenderReceiverTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/SenderReceiverTests.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
     using System.Text;
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using Core;
+    using Microsoft.Azure.ServiceBus.Core;
     using Xunit;
 
     public class SenderReceiverTests : SenderReceiverClientTestBase
@@ -217,87 +217,6 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             TestUtility.Log("Waiting for maximum 10 Secs");
             var waitingTask = Task.Delay(10000);
             Assert.Equal(quickTask, await Task.WhenAny(quickTask, waitingTask));
-        }
-
-        [Fact]
-        [DisplayTestMethodName]
-        public async Task DeadLetterReasonShouldPropagateToTheReceivedMessage()
-        {
-            var queueName = TestConstants.NonPartitionedQueueName;
-
-            var sender = new MessageSender(TestUtility.NamespaceConnectionString, queueName);
-            var receiver = new MessageReceiver(TestUtility.NamespaceConnectionString, queueName);
-            var dlqReceiver = new MessageReceiver(TestUtility.NamespaceConnectionString, EntityNameHelper.FormatDeadLetterPath(queueName), ReceiveMode.ReceiveAndDelete);
-
-            try
-            {
-                await sender.SendAsync(new Message(Encoding.UTF8.GetBytes("deadLetterTest2")));
-                var message = await receiver.ReceiveAsync();
-                Assert.NotNull(message);
-
-                await receiver.DeadLetterAsync(
-                    message.SystemProperties.LockToken,
-                    "deadLetterReason",
-                    "deadLetterDescription");
-                var dlqMessage = await dlqReceiver.ReceiveAsync();
-
-                Assert.NotNull(dlqMessage);
-                Assert.True(dlqMessage.UserProperties.ContainsKey(Message.DeadLetterReasonHeader));
-                Assert.True(dlqMessage.UserProperties.ContainsKey(Message.DeadLetterErrorDescriptionHeader));
-                Assert.Equal(dlqMessage.UserProperties[Message.DeadLetterReasonHeader], "deadLetterReason");
-                Assert.Equal(dlqMessage.UserProperties[Message.DeadLetterErrorDescriptionHeader], "deadLetterDescription");
-            }
-            finally
-            {
-                await sender.CloseAsync();
-                await receiver.CloseAsync();
-                await dlqReceiver.CloseAsync();
-            }
-        }
-
-        [Fact]
-        [DisplayTestMethodName]
-        public async Task DispositionWithUpdatedPropertiesShouldPropagateToReceivedMessage()
-        {
-            var queueName = TestConstants.NonPartitionedQueueName;
-
-            var sender = new MessageSender(TestUtility.NamespaceConnectionString, queueName);
-            var receiver = new MessageReceiver(TestUtility.NamespaceConnectionString, queueName);
-
-            try
-            {
-                await sender.SendAsync(new Message(Encoding.UTF8.GetBytes("propertiesToUpdate")));
-
-                var message = await receiver.ReceiveAsync();
-                Assert.NotNull(message);
-                await receiver.AbandonAsync(message.SystemProperties.LockToken, new Dictionary<string, object>
-                {
-                    {"key", "value1"}
-                });
-
-                message = await receiver.ReceiveAsync();
-                Assert.NotNull(message);
-                Assert.True(message.UserProperties.ContainsKey("key"));
-                Assert.Equal(message.UserProperties["key"], "value1");
-
-                long sequenceNumber = message.SystemProperties.SequenceNumber;
-                await receiver.DeferAsync(message.SystemProperties.LockToken, new Dictionary<string, object>
-                {
-                    {"key", "value2"}
-                });
-
-                message = await receiver.ReceiveDeferredMessageAsync(sequenceNumber);
-                Assert.NotNull(message);
-                Assert.True(message.UserProperties.ContainsKey("key"));
-                Assert.Equal(message.UserProperties["key"], "value2");
-
-                await receiver.CompleteAsync(message.SystemProperties.LockToken);
-            }
-            finally
-            {
-                await sender.CloseAsync();
-                await receiver.CloseAsync();
-            }
         }
     }
 }


### PR DESCRIPTION
Reverting #331 #309 #334 and #341 which change the interface. 
The idea is to release 1.1.0 with all the bug fixes and then work on 2.0 with all the interface changes as a separate release. Customers who do not wish to have breaking changes but still are blocked on the bug fixes can use 1.1.0 and customers waiting for the updated APIs can use 2.0. 