### PR TITLE
Instruments operations on ServiceBus with DiagnosticsSource and introduces correlation between producer and consumer

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -383,7 +383,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             MessagingEventSource.Log.MessageReceiveDeferredMessageStart(this.ClientId, sequenceNumberList.Length, sequenceNumberList);
 
             bool isDiagnosticsEnabled = ServiceBusDiagnosticSource.IsEnabled();
-            Activity activity = isDiagnosticsEnabled ? this.diagnosticSource.ReceiveDefferedStart(sequenceNumberList) : null;
+            Activity activity = isDiagnosticsEnabled ? this.diagnosticSource.ReceiveDeferredStart(sequenceNumberList) : null;
             Task receiveTask = null;
 
             IList<Message> messages = null;
@@ -407,7 +407,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
             finally
             {
-                this.diagnosticSource.ReceiveDefferedStop(activity, sequenceNumberList, receiveTask?.Status, messages);
+                this.diagnosticSource.ReceiveDeferredStop(activity, sequenceNumberList, receiveTask?.Status, messages);
             }
             MessagingEventSource.Log.MessageReceiveDeferredMessageStop(this.ClientId, messages?.Count ?? 0);
 

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -300,8 +300,8 @@ namespace Microsoft.Azure.ServiceBus.Core
 
             MessagingEventSource.Log.MessageReceiveStart(this.ClientId, maxMessageCount);
 
-            bool isDiagnosticsEnabled = ServiceBusDiagnosticSource.IsEnabled();
-            Activity activity = isDiagnosticsEnabled ? this.diagnosticSource.ReceiveStart(maxMessageCount) : null;
+            bool isDiagnosticSourceEnabled = ServiceBusDiagnosticSource.IsEnabled();
+            Activity activity = isDiagnosticSourceEnabled ? this.diagnosticSource.ReceiveStart(maxMessageCount) : null;
             Task receiveTask = null;
 
             IList<Message> unprocessedMessageList = null;
@@ -318,11 +318,12 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
             catch (Exception exception)
             {
-                MessagingEventSource.Log.MessageReceiveException(this.ClientId, exception);
-                if (isDiagnosticsEnabled)
+                if (isDiagnosticSourceEnabled)
                 {
                     this.diagnosticSource.ReportException(exception);
                 }
+
+                MessagingEventSource.Log.MessageReceiveException(this.ClientId, exception);
                 throw;
             }
             finally
@@ -382,8 +383,8 @@ namespace Microsoft.Azure.ServiceBus.Core
 
             MessagingEventSource.Log.MessageReceiveDeferredMessageStart(this.ClientId, sequenceNumberList.Length, sequenceNumberList);
 
-            bool isDiagnosticsEnabled = ServiceBusDiagnosticSource.IsEnabled();
-            Activity activity = isDiagnosticsEnabled ? this.diagnosticSource.ReceiveDeferredStart(sequenceNumberList) : null;
+            bool isDiagnosticSourceEnabled = ServiceBusDiagnosticSource.IsEnabled();
+            Activity activity = isDiagnosticSourceEnabled ? this.diagnosticSource.ReceiveDeferredStart(sequenceNumberList) : null;
             Task receiveTask = null;
 
             IList<Message> messages = null;
@@ -398,11 +399,12 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
             catch (Exception exception)
             {
-                MessagingEventSource.Log.MessageReceiveDeferredMessageException(this.ClientId, exception);
-                if (isDiagnosticsEnabled)
+                if (isDiagnosticSourceEnabled)
                 {
                     this.diagnosticSource.ReportException(exception);
                 }
+
+                MessagingEventSource.Log.MessageReceiveDeferredMessageException(this.ClientId, exception);
                 throw;
             }
             finally
@@ -452,8 +454,8 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
 
             MessagingEventSource.Log.MessageCompleteStart(this.ClientId, lockTokenList.Count, lockTokenList);
-            bool isDiagnosticsEnabled = ServiceBusDiagnosticSource.IsEnabled();
-            Activity activity = isDiagnosticsEnabled ? this.diagnosticSource.CompleteStart(lockTokenList) : null;
+            bool isDiagnosticSourceEnabled = ServiceBusDiagnosticSource.IsEnabled();
+            Activity activity = isDiagnosticSourceEnabled ? this.diagnosticSource.CompleteStart(lockTokenList) : null;
             Task completeTask = null;
 
             try
@@ -464,11 +466,12 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
             catch (Exception exception)
             {
-                MessagingEventSource.Log.MessageCompleteException(this.ClientId, exception);
-                if (isDiagnosticsEnabled)
+                if (isDiagnosticSourceEnabled)
                 {
                     this.diagnosticSource.ReportException(exception);
                 }
+
+                MessagingEventSource.Log.MessageCompleteException(this.ClientId, exception);
 
                 throw;
             }
@@ -496,8 +499,8 @@ namespace Microsoft.Azure.ServiceBus.Core
             this.ThrowIfNotPeekLockMode();
 
             MessagingEventSource.Log.MessageAbandonStart(this.ClientId, 1, lockToken);
-            bool isDiagnosticsEnabled = ServiceBusDiagnosticSource.IsEnabled();
-            Activity activity = isDiagnosticsEnabled ? this.diagnosticSource.DisposeStart("Abandon", lockToken) : null;
+            bool isDiagnosticSourceEnabled = ServiceBusDiagnosticSource.IsEnabled();
+            Activity activity = isDiagnosticSourceEnabled ? this.diagnosticSource.DisposeStart("Abandon", lockToken) : null;
             Task abandonTask = null;
 
             try
@@ -508,11 +511,12 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
             catch (Exception exception)
             {
-                MessagingEventSource.Log.MessageAbandonException(this.ClientId, exception);
-                if (isDiagnosticsEnabled)
+                if (isDiagnosticSourceEnabled)
                 {
                     this.diagnosticSource.ReportException(exception);
                 }
+
+                MessagingEventSource.Log.MessageAbandonException(this.ClientId, exception);
                 throw;
             }
             finally
@@ -541,8 +545,8 @@ namespace Microsoft.Azure.ServiceBus.Core
             this.ThrowIfNotPeekLockMode();
 
             MessagingEventSource.Log.MessageDeferStart(this.ClientId, 1, lockToken);
-            bool isDiagnosticsEnabled = ServiceBusDiagnosticSource.IsEnabled();
-            Activity activity = isDiagnosticsEnabled ? this.diagnosticSource.DisposeStart("Defer", lockToken) : null;
+            bool isDiagnosticSourceEnabled = ServiceBusDiagnosticSource.IsEnabled();
+            Activity activity = isDiagnosticSourceEnabled ? this.diagnosticSource.DisposeStart("Defer", lockToken) : null;
             Task deferTask = null;
 
             try
@@ -553,11 +557,12 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
             catch (Exception exception)
             {
-                MessagingEventSource.Log.MessageDeferException(this.ClientId, exception);
-                if (isDiagnosticsEnabled)
+                if (isDiagnosticSourceEnabled)
                 {
                     this.diagnosticSource.ReportException(exception);
                 }
+
+                MessagingEventSource.Log.MessageDeferException(this.ClientId, exception);
                 throw;
             }
             finally
@@ -585,8 +590,8 @@ namespace Microsoft.Azure.ServiceBus.Core
             this.ThrowIfNotPeekLockMode();
 
             MessagingEventSource.Log.MessageDeadLetterStart(this.ClientId, 1, lockToken);
-            bool isDiagnosticsEnabled = ServiceBusDiagnosticSource.IsEnabled();
-            Activity activity = isDiagnosticsEnabled ? this.diagnosticSource.DisposeStart("DeadLetter", lockToken) : null;
+            bool isDiagnosticSourceEnabled = ServiceBusDiagnosticSource.IsEnabled();
+            Activity activity = isDiagnosticSourceEnabled ? this.diagnosticSource.DisposeStart("DeadLetter", lockToken) : null;
             Task deadLetterTask = null;
 
             try
@@ -597,11 +602,12 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
             catch (Exception exception)
             {
-                MessagingEventSource.Log.MessageDeadLetterException(this.ClientId, exception);
-                if (isDiagnosticsEnabled)
+                if (isDiagnosticSourceEnabled)
                 {
                     this.diagnosticSource.ReportException(exception);
                 }
+
+                MessagingEventSource.Log.MessageDeadLetterException(this.ClientId, exception);
                 throw;
             }
             finally
@@ -630,8 +636,8 @@ namespace Microsoft.Azure.ServiceBus.Core
             this.ThrowIfNotPeekLockMode();
 
             MessagingEventSource.Log.MessageDeadLetterStart(this.ClientId, 1, lockToken);
-            bool isDiagnosticsEnabled = ServiceBusDiagnosticSource.IsEnabled();
-            Activity activity = isDiagnosticsEnabled ? this.diagnosticSource.DisposeStart("DeadLetter", lockToken) : null;
+            bool isDiagnosticSourceEnabled = ServiceBusDiagnosticSource.IsEnabled();
+            Activity activity = isDiagnosticSourceEnabled ? this.diagnosticSource.DisposeStart("DeadLetter", lockToken) : null;
             Task deadLetterTask = null;
 
             try
@@ -644,11 +650,12 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
             catch (Exception exception)
             {
-                MessagingEventSource.Log.MessageDeadLetterException(this.ClientId, exception);
-                if (isDiagnosticsEnabled)
+                if (isDiagnosticSourceEnabled)
                 {
                     this.diagnosticSource.ReportException(exception);
                 }
+
+                MessagingEventSource.Log.MessageDeadLetterException(this.ClientId, exception);
                 throw;
             }
             finally
@@ -690,8 +697,8 @@ namespace Microsoft.Azure.ServiceBus.Core
             this.ThrowIfNotPeekLockMode();
 
             MessagingEventSource.Log.MessageRenewLockStart(this.ClientId, 1, lockToken);
-            bool isDiagnosticsEnabled = ServiceBusDiagnosticSource.IsEnabled();
-            Activity activity = isDiagnosticsEnabled ? this.diagnosticSource.RenewLockStart(lockToken) : null;
+            bool isDiagnosticSourceEnabled = ServiceBusDiagnosticSource.IsEnabled();
+            Activity activity = isDiagnosticSourceEnabled ? this.diagnosticSource.RenewLockStart(lockToken) : null;
             Task renewTask = null;
 
             var lockedUntilUtc = DateTime.MinValue;
@@ -705,11 +712,12 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
             catch (Exception exception)
             {
-                MessagingEventSource.Log.MessageRenewLockException(this.ClientId, exception);
-                if (isDiagnosticsEnabled)
+                if (isDiagnosticSourceEnabled)
                 {
                     this.diagnosticSource.ReportException(exception);
                 }
+
+                MessagingEventSource.Log.MessageRenewLockException(this.ClientId, exception);
                 throw;
             }
             finally
@@ -772,8 +780,8 @@ namespace Microsoft.Azure.ServiceBus.Core
             IList<Message> messages = null;
 
             MessagingEventSource.Log.MessagePeekStart(this.ClientId, fromSequenceNumber, messageCount);
-            bool isDiagnosticsEnabled = ServiceBusDiagnosticSource.IsEnabled();
-            Activity activity = isDiagnosticsEnabled ? this.diagnosticSource.PeekStart(fromSequenceNumber, messageCount) : null;
+            bool isDiagnosticSourceEnabled = ServiceBusDiagnosticSource.IsEnabled();
+            Activity activity = isDiagnosticSourceEnabled ? this.diagnosticSource.PeekStart(fromSequenceNumber, messageCount) : null;
             Task peekTask = null;
 
             try
@@ -788,11 +796,12 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
             catch (Exception exception)
             {
-                MessagingEventSource.Log.MessagePeekException(this.ClientId, exception);
-                if (isDiagnosticsEnabled)
+                if (isDiagnosticSourceEnabled)
                 {
                     this.diagnosticSource.ReportException(exception);
                 }
+
+                MessagingEventSource.Log.MessagePeekException(this.ClientId, exception);
                 throw;
             }
             finally

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
@@ -151,8 +151,8 @@ namespace Microsoft.Azure.ServiceBus.Core
             var count = MessageSender.ValidateMessages(messageList);
             MessagingEventSource.Log.MessageSendStart(this.ClientId, count);
 
-            bool isDiagnosticsEnabled = ServiceBusDiagnosticSource.IsEnabled();
-            Activity activity = isDiagnosticsEnabled ? this.diagnosticSource.SendStart(messageList) : null;
+            bool isDiagnosticSourceEnabled = ServiceBusDiagnosticSource.IsEnabled();
+            Activity activity = isDiagnosticSourceEnabled ? this.diagnosticSource.SendStart(messageList) : null;
             Task sendTask = null;
 
             try
@@ -164,11 +164,12 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
             catch (Exception exception)
             {
-                MessagingEventSource.Log.MessageSendException(this.ClientId, exception);
-                if (isDiagnosticsEnabled)
+                if (isDiagnosticSourceEnabled)
                 {
                     this.diagnosticSource.ReportException(exception);
                 }
+
+                MessagingEventSource.Log.MessageSendException(this.ClientId, exception);
                 throw;
             }
             finally
@@ -206,8 +207,8 @@ namespace Microsoft.Azure.ServiceBus.Core
             MessagingEventSource.Log.ScheduleMessageStart(this.ClientId, scheduleEnqueueTimeUtc);
             long result = 0;
 
-            bool isDiagnosticsEnabled = ServiceBusDiagnosticSource.IsEnabled();
-            Activity activity = isDiagnosticsEnabled ? this.diagnosticSource.ScheduleStart(message, scheduleEnqueueTimeUtc) : null;
+            bool isDiagnosticSourceEnabled = ServiceBusDiagnosticSource.IsEnabled();
+            Activity activity = isDiagnosticSourceEnabled ? this.diagnosticSource.ScheduleStart(message, scheduleEnqueueTimeUtc) : null;
             Task scheduleTask = null;
 
             try
@@ -223,11 +224,12 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
             catch (Exception exception)
             {
-                MessagingEventSource.Log.ScheduleMessageException(this.ClientId, exception);
-                if (isDiagnosticsEnabled)
+                if (isDiagnosticSourceEnabled)
                 {
                     this.diagnosticSource.ReportException(exception);
                 }
+
+                MessagingEventSource.Log.ScheduleMessageException(this.ClientId, exception);
                 throw;
             }
             finally
@@ -248,8 +250,8 @@ namespace Microsoft.Azure.ServiceBus.Core
             this.ThrowIfClosed();
             MessagingEventSource.Log.CancelScheduledMessageStart(this.ClientId, sequenceNumber);
 
-            bool isDiagnosticsEnabled = ServiceBusDiagnosticSource.IsEnabled();
-            Activity activity = isDiagnosticsEnabled ? this.diagnosticSource.CancelStart(sequenceNumber) : null;
+            bool isDiagnosticSourceEnabled = ServiceBusDiagnosticSource.IsEnabled();
+            Activity activity = isDiagnosticSourceEnabled ? this.diagnosticSource.CancelStart(sequenceNumber) : null;
             Task cancelTask = null;
 
             try
@@ -260,11 +262,12 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
             catch (Exception exception)
             {
-                MessagingEventSource.Log.CancelScheduledMessageException(this.ClientId, exception);
-                if (isDiagnosticsEnabled)
+                if (isDiagnosticSourceEnabled)
                 {
                     this.diagnosticSource.ReportException(exception);
                 }
+
+                MessagingEventSource.Log.CancelScheduledMessageException(this.ClientId, exception);
                 throw;
             }
             finally

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
@@ -179,7 +179,6 @@ namespace Microsoft.Azure.ServiceBus.Core
             MessagingEventSource.Log.MessageSendStop(this.ClientId);
         }
 
-
         /// <summary>
         /// Schedules a message to appear on Service Bus at a later time.
         /// </summary>

--- a/src/Microsoft.Azure.ServiceBus/Extensions/MessageDiagnosticsExtensions.cs
+++ b/src/Microsoft.Azure.ServiceBus/Extensions/MessageDiagnosticsExtensions.cs
@@ -1,0 +1,153 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.ServiceBus.Diagnostics
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+
+    public static class MessageExtensions
+    {
+        /// <summary>
+        /// Creates <see cref="Activity"/> based on the tracing context stored in the <see cref="Message"/>
+        /// <param name="activityName">Optional Activity name</param>
+        /// <returns>New <see cref="Activity"/> with tracing context</returns>
+        /// </summary>
+        /// <remarks>
+        /// Tracing context is used to correlate telemetry between producer and consumer and 
+        /// represented by 'Diagnostic-Id' and 'Correlation-Context' properties in <see cref="Message.UserProperties"/>.
+        /// 
+        /// .NET SDK automatically injects context when sending message to the ServiceBus (if diagnostics is enabled by tracing system).
+        /// 
+        /// <para>
+        /// 'Diagnostic-Id' uniquely identifies operation that enqueued message
+        /// </para>
+        /// <para>
+        /// 'Correlation-Context' is comma separated list of sting key value pairs represeting optional context for the operation.
+        /// </para>
+        /// 
+        /// If there is no tracing context in the message, this method returns <see cref="Activity"/> without parent.
+        /// 
+        /// Returned <see cref="Activity"/> needs to be started before it can be used (see example below)
+        /// </remarks>
+        /// <example>
+        /// <code>
+        /// async Task ProcessAsync()
+        /// {
+        ///    var message = await messageReceiver.ReceiveAsync();
+        ///    var activity = message.ExtractActivity();
+        ///    activity.Start();
+        ///    Logger.LogInformation($"Message received, Id = {Activity.Current.Id}")
+        ///    try 
+        ///    {
+        ///       // process message
+        ///    }
+        ///    catch (Exception ex)
+        ///    {
+        ///         Logger.LogError($"Exception {ex}, Id = {Activity.Current.Id}")
+        ///    }
+        ///    finally 
+        ///    {
+        ///         activity.Stop();
+        ///         // Activity is stopped, we no longer have it in Activity.Current, let's user activity now
+        ///         Logger.LogInformation($"Message processed, Id = {activity.Id}, Duration = {activity.Duration}")
+        ///    }
+        /// }
+        /// </code>
+        /// 
+        /// Note that every log is stamped with <see cref="Activity.Current"/>.Id, that could be used within 
+        /// any nested method call (sync or async) - <see cref="Activity.Current"/> is an ambient context that flows with async method calls.
+        /// 
+        /// </example>
+
+        public static Activity ExtractActivity(this Message message, string activityName = null)
+        {
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            if (activityName == null)
+            {
+                activityName = ServiceBusDiagnosticSource.ProcessActivityName;
+            }
+
+            var activity = new Activity(activityName);
+
+            if (TryExtractId(message, out string id))
+            {
+                activity.SetParentId(id);
+
+                if (message.TryExtractContext(out IList<KeyValuePair<string, string>> ctx))
+                {
+                    foreach (var kvp in ctx)
+                    {
+                        activity.AddBaggage(kvp.Key, kvp.Value);
+                    }
+                }
+            }
+
+            return activity;
+        }
+
+        internal static bool TryExtractId(this Message message, out string id)
+        {
+            id = null;
+            if (message.UserProperties.TryGetValue(ServiceBusDiagnosticSource.RequestIdPropertyName,
+                out object requestId))
+            {
+                var tmp = requestId as string;
+                if (tmp != null && tmp.Trim().Length > 0)
+                {
+                    id = tmp;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        internal static bool TryExtractContext(this Message message, out IList<KeyValuePair<string, string>> context)
+        {
+            context = null;
+            try
+            {
+                if (message.UserProperties.TryGetValue(ServiceBusDiagnosticSource.CorrelationContextPropertyName,
+                    out object ctxObj))
+                {
+                    string ctxStr = ctxObj as string;
+                    if (string.IsNullOrEmpty(ctxStr))
+                    {
+                        return false;
+                    }
+
+                    var ctxList = ctxStr.Split(',');
+                    if (ctxList.Length == 0)
+                    {
+                        return false;
+                    }
+
+                    context = new List<KeyValuePair<string, string>>();
+                    foreach (string item in ctxList)
+                    {
+                        var kvp = item.Split('=');
+                        if (kvp.Length == 2)
+                        {
+                            context.Add(new KeyValuePair<string, string>(kvp[0], kvp[1]));
+                        }
+                    }
+
+                    return true;
+                }
+            }
+            catch (Exception)
+            {
+                // ignored, if context is invalid, there nothing we can do:
+                // invalid context was created by consumer, but if we throw here, it will break message processing on producer
+                // and producer does not control which context it receives
+            }
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.Azure.ServiceBus/Extensions/MessageDiagnosticsExtensions.cs
+++ b/src/Microsoft.Azure.ServiceBus/Extensions/MessageDiagnosticsExtensions.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.ServiceBus.Diagnostics
         internal static bool TryExtractId(this Message message, out string id)
         {
             id = null;
-            if (message.UserProperties.TryGetValue(ServiceBusDiagnosticSource.RequestIdPropertyName,
+            if (message.UserProperties.TryGetValue(ServiceBusDiagnosticSource.ActivityIdPropertyName,
                 out object requestId))
             {
                 var tmp = requestId as string;

--- a/src/Microsoft.Azure.ServiceBus/MessageSession.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageSession.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Azure.ServiceBus
             {
                 getStateTask = this.OnGetStateAsync();
                 state = await getStateTask.ConfigureAwait(false);
-                return getStateTask.Result;
+                return state;
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
+++ b/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
@@ -31,6 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Amqp" Version="2.1.2" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.0" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Microsoft.Azure.ServiceBus/QueueClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/QueueClient.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Azure.ServiceBus
     {
         readonly bool ownsConnection;
         readonly object syncLock;
+
         int prefetchCount;
         MessageSender innerSender;
         MessageReceiver innerReceiver;
@@ -276,7 +277,7 @@ namespace Microsoft.Azure.ServiceBus
                                 this.ClientId,
                                 this.ReceiveMode,
                                 this.SessionClient,
-                                this.ServiceBusConnection.Endpoint.Authority);
+                                this.ServiceBusConnection.Endpoint);
                         }
                     }
                 }
@@ -305,6 +306,7 @@ namespace Microsoft.Azure.ServiceBus
         public Task SendAsync(IList<Message> messageList)
         {
             this.ThrowIfClosed();
+
             return this.InnerSender.SendAsync(messageList);
         }
 

--- a/src/Microsoft.Azure.ServiceBus/ServiceBusDiagnosticsSource.cs
+++ b/src/Microsoft.Azure.ServiceBus/ServiceBusDiagnosticsSource.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.ServiceBus
 
         public const string BaseActivityName = "Microsoft.Azure.ServiceBus.";
 
-        public const string RequestIdPropertyName = "Diagnostic-Id";
+        public const string ActivityIdPropertyName = "Diagnostic-Id";
         public const string CorrelationContextPropertyName = "Correlation-Context";
         public const string RelatedToTag = "RelatedTo";
 
@@ -675,10 +675,13 @@ namespace Microsoft.Azure.ServiceBus
 
         private void Inject(Message message, string id, string correlationContext)
         {
-            message.UserProperties[RequestIdPropertyName] = id;
-            if (correlationContext != null)
+            if (!message.UserProperties.ContainsKey(ActivityIdPropertyName))
             {
-                message.UserProperties[CorrelationContextPropertyName] = correlationContext;
+                message.UserProperties[ActivityIdPropertyName] = id;
+                if (correlationContext != null)
+                {
+                    message.UserProperties[CorrelationContextPropertyName] = correlationContext;
+                }
             }
         }
 

--- a/src/Microsoft.Azure.ServiceBus/ServiceBusDiagnosticsSource.cs
+++ b/src/Microsoft.Azure.ServiceBus/ServiceBusDiagnosticsSource.cs
@@ -1,0 +1,768 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.ServiceBus
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    using Microsoft.Azure.ServiceBus.Diagnostics;
+
+    internal class ServiceBusDiagnosticSource
+    {
+        public const string DiagnosticListenerName = "Microsoft.Azure.ServiceBus";
+
+        public const string ExceptionEventName = "Microsoft.Azure.ServiceBus.Exception";
+        public const string ProcessActivityName = "Microsoft.Azure.ServiceBus.Process";
+        public const string ProcessActivityStartName = "Microsoft.Azure.ServiceBus.Process.Start";
+        public const string ProcessSessionActivityName = "Microsoft.Azure.ServiceBus.ProcessSession";
+        public const string ProcessSessionActivityStartName = "Microsoft.Azure.ServiceBus.ProcessSession.Start";
+
+        public const string BaseActivityName = "Microsoft.Azure.ServiceBus.";
+
+        public const string RequestIdPropertyName = "Diagnostic-Id";
+        public const string CorrelationContextPropertyName = "Correlation-Context";
+        public const string RelatedToTag = "RelatedTo";
+
+        private static readonly DiagnosticListener DiagnosticListener = new DiagnosticListener(DiagnosticListenerName);
+        private readonly string entityPath;
+        private readonly Uri endpoint;
+
+        public ServiceBusDiagnosticSource(string entityPath, Uri endpoint)
+        {
+            this.entityPath = entityPath;
+            this.endpoint = endpoint;
+        }
+
+        public static bool IsEnabled()
+        {
+            return DiagnosticListener.IsEnabled();
+        }
+
+
+        #region Send
+
+        internal Activity SendStart(IList<Message> messageList)
+        {
+            Activity activity = Start("Send", () => new
+                {
+                    Messages = messageList,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint
+                },
+                a => SetTags(a, messageList)
+            );
+
+            Inject(messageList);
+
+            return activity;
+        }
+
+        internal void SendStop(Activity activity, IList<Message> messageList, TaskStatus? status)
+        {
+            if (activity != null)
+            {
+                DiagnosticListener.StopActivity(activity, new
+                {
+                    Messages = messageList,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint,
+                    Status = status ?? TaskStatus.Faulted
+                });
+            }
+        }
+
+        #endregion
+
+
+        #region Process
+
+        internal Activity ProcessStart(Message message)
+        {
+            return ProcessStart("Process", message, () => new
+                {
+                    Message = message,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint
+                },
+                a => SetTags(a, message));
+        }
+
+        internal void ProcessStop(Activity activity, Message message, TaskStatus? status)
+        {
+            if (activity != null)
+            {
+                DiagnosticListener.StopActivity(activity, new
+                {
+                    Message = message,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint,
+                    Status = status ?? TaskStatus.Faulted
+                });
+            }
+        }
+
+        #endregion
+
+
+        #region ProcessSession
+
+        internal Activity ProcessSessionStart(IMessageSession session, Message message)
+        {
+            return ProcessStart("ProcessSession", message, () => new
+                {
+                    Session = session,
+                    Message = message,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint
+                },
+                a => SetTags(a, message));
+        }
+
+        internal void ProcessSessionStop(Activity activity, IMessageSession session, Message message, TaskStatus? status)
+        {
+            if (activity != null)
+            {
+                DiagnosticListener.StopActivity(activity, new
+                {
+                    Session = session,
+                    Message = message,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint,
+                    Status = status ?? TaskStatus.Faulted
+                });
+            }
+        }
+
+        #endregion
+
+
+        #region Schedule
+
+        internal Activity ScheduleStart(Message message, DateTimeOffset scheduleEnqueueTimeUtc)
+        {
+            Activity activity = Start("Schedule", () => new
+                {
+                    Message = message,
+                    ScheduleEnqueueTimeUtc = scheduleEnqueueTimeUtc,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint
+                },
+                a => SetTags(a, message));
+
+            Inject(message);
+
+            return activity;
+        }
+
+        internal void ScheduleStop(Activity activity, Message message, DateTimeOffset scheduleEnqueueTimeUtc, TaskStatus? status, long sequenceNumber)
+        {
+            if (activity != null)
+            {
+                DiagnosticListener.StopActivity(activity, new
+                {
+                    Message = message,
+                    ScheduleEnqueueTimeUtc = scheduleEnqueueTimeUtc,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint,
+                    SequenceNumber = sequenceNumber,
+                    Status = status ?? TaskStatus.Faulted
+                });
+            }
+        }
+
+        #endregion
+
+
+        #region Cancel
+
+        internal Activity CancelStart(long sequenceNumber)
+        {
+            return Start("Cancel", () => new
+            {
+                SequenceNumber = sequenceNumber,
+                Entity = this.entityPath,
+                Endpoint = this.endpoint
+            },
+            null);
+        }
+
+        internal void CancelStop(Activity activity, long sequenceNumber, TaskStatus? status)
+        {
+            if (activity != null)
+            {
+                DiagnosticListener.StopActivity(activity, new
+                {
+                    SequenceNumber = sequenceNumber,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint,
+                    Status = status ?? TaskStatus.Faulted
+                });
+            }
+        }
+
+        #endregion
+
+
+        #region Receive
+
+        internal Activity ReceiveStart(int messageCount)
+        {
+            return Start("Receive", () => new
+            {
+                MessageCount = messageCount,
+                Entity = this.entityPath,
+                Endpoint = this.endpoint
+            },
+            null);
+        }
+
+        internal void ReceiveStop(Activity activity, int messageCount, TaskStatus? status, IList<Message> messageList)
+        {
+            if (activity != null)
+            {
+                SetRelatedOperations(activity, messageList);
+                SetTags(activity, messageList);
+                DiagnosticListener.StopActivity(activity, new
+                {
+                    MessageCount = messageCount,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint,
+                    Status = status ?? TaskStatus.Faulted,
+                    Messages = messageList
+                });
+            }
+        }
+
+        #endregion
+
+
+        #region Peek
+
+        internal Activity PeekStart(long fromSequenceNumber, int messageCount)
+        {
+            return Start("Peek", () => new
+            {
+                FromSequenceNumber = fromSequenceNumber,
+                MessageCount = messageCount,
+                Entity = this.entityPath,
+                Endpoint = this.endpoint
+            },
+            null);
+        }
+
+        internal void PeekStop(Activity activity, long fromSequenceNumber, int messageCount, TaskStatus? status, IList<Message> messageList)
+        {
+            if (activity != null)
+            {
+                SetRelatedOperations(activity, messageList);
+                SetTags(activity, messageList);
+
+                DiagnosticListener.StopActivity(activity, new
+                {
+                    FromSequenceNumber = fromSequenceNumber,
+                    MessageCount = messageCount,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint,
+                    Status = status ?? TaskStatus.Faulted,
+                    Messages = messageList
+                });
+            }
+        }
+
+        #endregion
+
+
+        #region ReceiveDeffered
+
+        internal Activity ReceiveDefferedStart(IEnumerable<long> sequenceNumbers)
+        {
+            return Start("ReceiveDeffered", () => new
+            {
+                SequenceNumbers = sequenceNumbers,
+                Entity = this.entityPath,
+                Endpoint = this.endpoint
+            },
+            null);
+        }
+
+        internal void ReceiveDefferedStop(Activity activity, IEnumerable<long> sequenceNumbers, TaskStatus? status, IList<Message> messageList)
+        {
+            if (activity != null)
+            {
+                SetRelatedOperations(activity, messageList);
+                SetTags(activity, messageList);
+
+                DiagnosticListener.StopActivity(activity, new
+                {
+                    SequenceNumbers = sequenceNumbers,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint,
+                    Messages = messageList,
+                    Status = status ?? TaskStatus.Faulted
+                });
+            }
+        }
+
+        #endregion
+
+
+        #region  Complete
+
+        internal Activity CompleteStart(IList<string> lockTokens)
+        {
+            return Start("Complete", () => new
+            {
+                LockTokens = lockTokens,
+                Entity = this.entityPath,
+                Endpoint = this.endpoint
+            },
+            null);
+        }
+
+        internal void CompleteStop(Activity activity, IList<string> lockTokens, TaskStatus? status)
+        {
+            if (activity != null)
+            {
+                DiagnosticListener.StopActivity(activity, new
+                {
+                    LockTokens = lockTokens,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint,
+                    Status = status ?? TaskStatus.Faulted
+                });
+            }
+        }
+
+        #endregion
+
+
+        #region Dispose
+
+        internal Activity DisposeStart(string operationName, string lockToken)
+        {
+            return Start(operationName, () => new
+            {
+                LockToken = lockToken,
+                Entity = this.entityPath,
+                Endpoint = this.endpoint
+            },
+            null);
+        }
+
+        internal void DisposeStop(Activity activity, string lockToken, TaskStatus? status)
+        {
+            if (activity != null)
+            {
+                DiagnosticListener.StopActivity(activity, new
+                {
+                    LockToken = lockToken,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint,
+                    Status = status ?? TaskStatus.Faulted
+                });
+            }
+        }
+
+        #endregion
+
+ 
+        #region RenewLock
+
+        internal Activity RenewLockStart(string lockToken)
+        {
+            return Start("RenewLock", () => new
+            {
+                LockToken = lockToken,
+                Entity = this.entityPath,
+                Endpoint = this.endpoint
+            },
+            null);
+        }
+
+        internal void RenewLockStop(Activity activity, string lockToken, TaskStatus? status, DateTime lockedUntilUtc)
+        {
+            if (activity != null)
+            {
+                DiagnosticListener.StopActivity(activity, new
+                {
+                    LockToken = lockToken,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint,
+                    Status = status ?? TaskStatus.Faulted,
+                    LockedUntilUtc = lockedUntilUtc
+                });
+            }
+        }
+
+        #endregion
+
+
+        #region AddRule
+
+        internal Activity AddRuleStart(RuleDescription description)
+        {
+            return Start("AddRule", () => new
+            {
+                Rule = description,
+                Entity = this.entityPath,
+                Endpoint = this.endpoint
+            },
+            null);
+        }
+
+        internal void AddRuleStop(Activity activity, RuleDescription description, TaskStatus? status)
+        {
+            if (activity != null)
+            {
+                DiagnosticListener.StopActivity(activity, new
+                {
+                    Rule = description,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint,
+                    Status = status ?? TaskStatus.Faulted
+                });
+            }
+        }
+
+        #endregion
+
+
+        #region RemoveRule
+
+        internal Activity RemoveRuleStart(string ruleName)
+        {
+            return Start("RemoveRule", () => new
+            {
+                RuleName = ruleName,
+                Entity = this.entityPath,
+                Endpoint = this.endpoint
+            },
+            null);
+        }
+
+        internal void RemoveRuleStop(Activity activity, string ruleName, TaskStatus? status)
+        {
+            if (activity != null)
+            {
+                DiagnosticListener.StopActivity(activity, new
+                {
+                    RuleName = ruleName,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint,
+                    Status = status ?? TaskStatus.Faulted
+                });
+            }
+        }
+
+        #endregion
+
+
+        #region GetRules
+
+        internal Activity GetRulesStart()
+        {
+            return Start("GetRules", () => new
+            {
+                Entity = this.entityPath,
+                Endpoint = this.endpoint
+            },
+            null);
+        }
+
+        internal void GetRulesStop(Activity activity, IEnumerable<RuleDescription> rules, TaskStatus? status)
+        {
+            if (activity != null)
+            {
+                DiagnosticListener.StopActivity(activity, new
+                {
+                    Rules = rules,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint,
+                    Status = status ?? TaskStatus.Faulted
+                });
+            }
+        }
+
+        #endregion
+
+
+        #region AcceptMessageSession
+
+        internal Activity AcceptMessageSessionStart(string sessionId)
+        {
+            return Start("AcceptMessageSession", () => new
+                {
+                    SessionId = sessionId,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint
+                },
+                a => a.AddTag("SessionId", sessionId));
+        }
+
+        internal void AcceptMessageSessionStop(Activity activity, string sessionId, TimeSpan serverWaitTime, IMessageSession session, TaskStatus? status)
+        {
+            if (activity != null)
+            {
+                DiagnosticListener.StopActivity(activity, new
+                {
+                    SessionId = sessionId,
+                    ServerWaitTime = serverWaitTime,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint,
+                    Status = status ?? TaskStatus.Faulted,
+                    Session = session
+                });
+            }
+        }
+
+        #endregion
+
+
+        #region GetSessionStateAsync
+
+        internal Activity GetSessionStateStart(string sessionId)
+        {
+            return Start("GetSessionState", () => new
+                {
+                    SessionId = sessionId,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint
+                },
+                a => a.AddTag("SessionId", sessionId));
+        }
+
+        internal void GetSessionStateStop(Activity activity, string sessionId, byte[] state, TaskStatus? status)
+        {
+            if (activity != null)
+            {
+                DiagnosticListener.StopActivity(activity, new
+                {
+                    SessionId = sessionId,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint,
+                    Status = status ?? TaskStatus.Faulted,
+                    State = state
+                });
+            }
+        }
+
+        #endregion
+
+
+        #region SetSessionState
+
+        internal Activity SetSessionStateStart(string sessionId, byte[] state)
+        {
+            return Start("SetSessionState", () => new
+                {
+                    State = state,
+                    SessionId = sessionId,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint
+                },
+                a => a.AddTag("SessionId", sessionId));
+        }
+
+        internal void SetSessionStateStop(Activity activity, byte[] state, string sessionId, TaskStatus? status)
+        {
+            if (activity != null)
+            {
+                DiagnosticListener.StopActivity(activity, new
+                {
+                    State = state,
+                    SessionId = sessionId,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint,
+                    Status = status ?? TaskStatus.Faulted
+                });
+            }
+        }
+
+        #endregion
+
+
+        #region RenewSessionLock
+
+        internal Activity RenewSessionLockStart(string sessionId)
+        {
+            return Start("RenewSessionLock", () => new
+            {
+                SessionId = sessionId,
+                Entity = this.entityPath,
+                Endpoint = this.endpoint
+            },
+            a => a.AddTag("SessionId", sessionId));
+        }
+
+        internal void RenewSessionLockStop(Activity activity, string sessionId, TaskStatus? status)
+        {
+            if (activity != null)
+            {
+                DiagnosticListener.StopActivity(activity, new
+                {
+                    SessionId = sessionId,
+                    Entity = this.entityPath,
+                    Endpoint = this.endpoint,
+                    Status = status ?? TaskStatus.Faulted
+                });
+            }
+        }
+
+        #endregion
+
+        internal void ReportException(Exception ex)
+        {
+            if (DiagnosticListener.IsEnabled(ExceptionEventName))
+            {
+                DiagnosticListener.Write(ExceptionEventName,
+                    new
+                    {
+                        Exception = ex,
+                        Entity = this.entityPath,
+                        Endpoint = this.endpoint
+                    });
+            }
+        }
+
+        private Activity Start(string operationName, Func<object> getPayload, Action<Activity> setTags)
+        {
+            Activity activity = null;
+            string activityName = BaseActivityName + operationName;
+            if (DiagnosticListener.IsEnabled(activityName, this.entityPath))
+            {
+                activity = new Activity(activityName);
+                setTags?.Invoke(activity);
+
+                if (DiagnosticListener.IsEnabled(activityName + ".Start"))
+                {
+                    DiagnosticListener.StartActivity(activity, getPayload());
+                }
+                else
+                {
+                    activity.Start();
+                }
+            }
+
+            return activity;
+        }
+
+        private void Inject(IList<Message> messageList)
+        {
+            var currentActivity = Activity.Current;
+            if (currentActivity != null)
+            {
+                var correlationContext = SerializeCorrelationContext(currentActivity.Baggage.ToList());
+
+                foreach (var message in messageList)
+                {
+                    Inject(message, currentActivity.Id, correlationContext);
+                }
+            }
+        }
+
+        private void Inject(Message message)
+        {
+            var currentActivity = Activity.Current;
+            if (currentActivity != null)
+            {
+                Inject(message, currentActivity.Id, SerializeCorrelationContext(currentActivity.Baggage.ToList()));
+            }
+        }
+
+        private void Inject(Message message, string id, string correlationContext)
+        {
+            message.UserProperties[RequestIdPropertyName] = id;
+            if (correlationContext != null)
+            {
+                message.UserProperties[CorrelationContextPropertyName] = correlationContext;
+            }
+        }
+
+        private string SerializeCorrelationContext(IList<KeyValuePair<string,string>> baggage)
+        {
+            if (baggage.Any())
+            {
+                return string.Join(",", baggage.Select(kvp => kvp.Key + "=" + kvp.Value));
+            }
+            return null;
+        }
+
+        private void SetRelatedOperations(Activity activity, IList<Message> messageList)
+        {
+            if (messageList != null && messageList.Count > 0)
+            {
+                var relatedTo = new List<string>();
+                foreach (var message in messageList)
+                {
+                    if (message.TryExtractId(out string id))
+                    {
+                        relatedTo.Add(id);
+                    }
+                }
+
+                if (relatedTo.Count > 0)
+                {
+                    activity.AddTag(RelatedToTag, string.Join(",", relatedTo.Distinct()));
+                }
+            }
+        }
+
+        private Activity ProcessStart(string operationName, Message message, Func<object> getPayload, Action<Activity> setTags)
+        {
+            Activity activity = null;
+            string activityName = BaseActivityName + operationName;
+
+            if (DiagnosticListener.IsEnabled(activityName, entityPath))
+            {
+                var tmpActivity = message.ExtractActivity(activityName);
+                setTags?.Invoke(tmpActivity);
+                
+                if (DiagnosticListener.IsEnabled(activityName, entityPath, tmpActivity))
+                {
+                    activity = tmpActivity;
+                    if (DiagnosticListener.IsEnabled(activityName + "Start"))
+                    {
+                        DiagnosticListener.StartActivity(activity, getPayload());
+                    }
+                    else
+                    {
+                        activity.Start();
+                    }
+                }
+            }
+            return activity;
+        }
+
+        private void SetTags(Activity activity, IList<Message> messageList)
+        {
+            var messageIds = messageList.Where(m => m.MessageId != null).Select(m => m.MessageId).ToArray();
+            if (messageIds.Any())
+            {
+                activity.AddTag("MessageId", string.Join(",", messageIds));
+            }
+
+            var sessionIds = messageList.Where(m => m.SessionId != null).Select(m => m.SessionId).Distinct().ToArray();
+            if (sessionIds.Any())
+            {
+                activity.AddTag("SessionId", string.Join(",", sessionIds));
+            }
+        }
+
+        private void SetTags(Activity activity, Message message)
+        {
+            if (message.MessageId != null)
+            {
+                activity.AddTag("MessageId", string.Join(",", message.MessageId));
+            }
+
+            if (message.SessionId != null)
+            {
+                activity.AddTag("SessionId", string.Join(",", message.SessionId));
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.ServiceBus/ServiceBusDiagnosticsSource.cs
+++ b/src/Microsoft.Azure.ServiceBus/ServiceBusDiagnosticsSource.cs
@@ -724,7 +724,7 @@ namespace Microsoft.Azure.ServiceBus
                 if (DiagnosticListener.IsEnabled(activityName, entityPath, tmpActivity))
                 {
                     activity = tmpActivity;
-                    if (DiagnosticListener.IsEnabled(activityName + "Start"))
+                    if (DiagnosticListener.IsEnabled(activityName + ".Start"))
                     {
                         DiagnosticListener.StartActivity(activity, getPayload());
                     }

--- a/src/Microsoft.Azure.ServiceBus/ServiceBusDiagnosticsSource.cs
+++ b/src/Microsoft.Azure.ServiceBus/ServiceBusDiagnosticsSource.cs
@@ -211,7 +211,7 @@ namespace Microsoft.Azure.ServiceBus
         {
             return Start("Receive", () => new
             {
-                MessageCount = messageCount,
+                RequestedMessageCount = messageCount,
                 Entity = this.entityPath,
                 Endpoint = this.endpoint
             },
@@ -226,7 +226,7 @@ namespace Microsoft.Azure.ServiceBus
                 SetTags(activity, messageList);
                 DiagnosticListener.StopActivity(activity, new
                 {
-                    MessageCount = messageCount,
+                    RequestedMessageCount = messageCount,
                     Entity = this.entityPath,
                     Endpoint = this.endpoint,
                     Status = status ?? TaskStatus.Faulted,
@@ -245,7 +245,7 @@ namespace Microsoft.Azure.ServiceBus
             return Start("Peek", () => new
             {
                 FromSequenceNumber = fromSequenceNumber,
-                MessageCount = messageCount,
+                RequestedMessageCount = messageCount,
                 Entity = this.entityPath,
                 Endpoint = this.endpoint
             },
@@ -262,7 +262,7 @@ namespace Microsoft.Azure.ServiceBus
                 DiagnosticListener.StopActivity(activity, new
                 {
                     FromSequenceNumber = fromSequenceNumber,
-                    MessageCount = messageCount,
+                    RequestedMessageCount = messageCount,
                     Entity = this.entityPath,
                     Endpoint = this.endpoint,
                     Status = status ?? TaskStatus.Faulted,
@@ -278,7 +278,7 @@ namespace Microsoft.Azure.ServiceBus
 
         internal Activity ReceiveDeferredStart(IEnumerable<long> sequenceNumbers)
         {
-            return Start("ReceiveDefered", () => new
+            return Start("ReceiveDeferred", () => new
             {
                 SequenceNumbers = sequenceNumbers,
                 Entity = this.entityPath,

--- a/src/Microsoft.Azure.ServiceBus/ServiceBusDiagnosticsSource.cs
+++ b/src/Microsoft.Azure.ServiceBus/ServiceBusDiagnosticsSource.cs
@@ -274,11 +274,11 @@ namespace Microsoft.Azure.ServiceBus
         #endregion
 
 
-        #region ReceiveDeffered
+        #region ReceiveDeferred
 
-        internal Activity ReceiveDefferedStart(IEnumerable<long> sequenceNumbers)
+        internal Activity ReceiveDeferredStart(IEnumerable<long> sequenceNumbers)
         {
-            return Start("ReceiveDeffered", () => new
+            return Start("ReceiveDefered", () => new
             {
                 SequenceNumbers = sequenceNumbers,
                 Entity = this.entityPath,
@@ -287,7 +287,7 @@ namespace Microsoft.Azure.ServiceBus
             null);
         }
 
-        internal void ReceiveDefferedStop(Activity activity, IEnumerable<long> sequenceNumbers, TaskStatus? status, IList<Message> messageList)
+        internal void ReceiveDeferredStop(Activity activity, IEnumerable<long> sequenceNumbers, TaskStatus? status, IList<Message> messageList)
         {
             if (activity != null)
             {

--- a/src/Microsoft.Azure.ServiceBus/SessionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionClient.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.ServiceBus
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Linq;
     using System.Threading.Tasks;
     using Amqp;
@@ -45,6 +46,7 @@ namespace Microsoft.Azure.ServiceBus
     {
         const int DefaultPrefetchCount = 0;
         readonly bool ownsConnection;
+        readonly ServiceBusDiagnosticSource diagnosticSource;
 
         /// <summary>
         /// Creates a new SessionClient from a <see cref="ServiceBusConnectionStringBuilder"/>
@@ -123,6 +125,7 @@ namespace Microsoft.Azure.ServiceBus
             this.ReceiveMode = receiveMode;
             this.PrefetchCount = prefetchCount;
             this.CbsTokenProvider = cbsTokenProvider;
+            this.diagnosticSource = new ServiceBusDiagnosticSource(entityPath, serviceBusConnection.Endpoint);
 
             // Register plugins on the message session.
             if (registeredPlugins != null)
@@ -213,6 +216,10 @@ namespace Microsoft.Azure.ServiceBus
                 this.PrefetchCount,
                 sessionId);
 
+            bool isDiagnosticsEnabled = ServiceBusDiagnosticSource.IsEnabled();
+            Activity activity = isDiagnosticsEnabled ? this.diagnosticSource.AcceptMessageSessionStart(sessionId) : null;
+            Task acceptMessageSessionTask = null;
+
             var session = new MessageSession(
                 this.EntityPath,
                 this.EntityType,
@@ -226,8 +233,10 @@ namespace Microsoft.Azure.ServiceBus
 
             try
             {
-                await this.RetryPolicy.RunOperation(() => session.GetSessionReceiverLinkAsync(serverWaitTime), serverWaitTime)
-                    .ConfigureAwait(false);
+                acceptMessageSessionTask = this.RetryPolicy.RunOperation(
+                    () => session.GetSessionReceiverLinkAsync(serverWaitTime),
+                    serverWaitTime);
+                await acceptMessageSessionTask.ConfigureAwait(false);
             }
             catch (Exception exception)
             {
@@ -236,8 +245,17 @@ namespace Microsoft.Azure.ServiceBus
                     this.EntityPath,
                     exception);
 
+                if (isDiagnosticsEnabled)
+                {
+                    this.diagnosticSource.ReportException(exception);
+                }
+
                 await session.CloseAsync().ConfigureAwait(false);
                 throw AmqpExceptionHelper.GetClientException(exception);
+            }
+            finally
+            {
+                this.diagnosticSource.AcceptMessageSessionStop(activity, sessionId, serverWaitTime, session, acceptMessageSessionTask?.Status);
             }
 
             MessagingEventSource.Log.AmqpSessionClientAcceptMessageSessionStop(

--- a/src/Microsoft.Azure.ServiceBus/SessionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionClient.cs
@@ -255,7 +255,7 @@ namespace Microsoft.Azure.ServiceBus
             }
             finally
             {
-                this.diagnosticSource.AcceptMessageSessionStop(activity, sessionId, serverWaitTime, session, acceptMessageSessionTask?.Status);
+                this.diagnosticSource.AcceptMessageSessionStop(activity, session.SessionId, acceptMessageSessionTask?.Status);
             }
 
             MessagingEventSource.Log.AmqpSessionClientAcceptMessageSessionStop(

--- a/src/Microsoft.Azure.ServiceBus/SessionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionClient.cs
@@ -216,8 +216,8 @@ namespace Microsoft.Azure.ServiceBus
                 this.PrefetchCount,
                 sessionId);
 
-            bool isDiagnosticsEnabled = ServiceBusDiagnosticSource.IsEnabled();
-            Activity activity = isDiagnosticsEnabled ? this.diagnosticSource.AcceptMessageSessionStart(sessionId) : null;
+            bool isDiagnosticSourceEnabled = ServiceBusDiagnosticSource.IsEnabled();
+            Activity activity = isDiagnosticSourceEnabled ? this.diagnosticSource.AcceptMessageSessionStart(sessionId) : null;
             Task acceptMessageSessionTask = null;
 
             var session = new MessageSession(
@@ -240,15 +240,15 @@ namespace Microsoft.Azure.ServiceBus
             }
             catch (Exception exception)
             {
+                if (isDiagnosticSourceEnabled)
+                {
+                    this.diagnosticSource.ReportException(exception);
+                }
+
                 MessagingEventSource.Log.AmqpSessionClientAcceptMessageSessionException(
                     this.ClientId,
                     this.EntityPath,
                     exception);
-
-                if (isDiagnosticsEnabled)
-                {
-                    this.diagnosticSource.ReportException(exception);
-                }
 
                 await session.CloseAsync().ConfigureAwait(false);
                 throw AmqpExceptionHelper.GetClientException(exception);

--- a/src/Microsoft.Azure.ServiceBus/SessionPumpHost.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionPumpHost.cs
@@ -12,9 +12,9 @@ namespace Microsoft.Azure.ServiceBus
         readonly object syncLock;
         SessionReceivePump sessionReceivePump;
         CancellationTokenSource sessionPumpCancellationTokenSource;
-        readonly string endpoint;
+        readonly Uri endpoint;
 
-        public SessionPumpHost(string clientId, ReceiveMode receiveMode, ISessionClient sessionClient, string endpoint)
+        public SessionPumpHost(string clientId, ReceiveMode receiveMode, ISessionClient sessionClient, Uri endpoint)
         {
             this.syncLock = new object();
             this.ClientId = clientId;

--- a/src/Microsoft.Azure.ServiceBus/SessionReceivePump.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionReceivePump.cs
@@ -210,8 +210,8 @@ namespace Microsoft.Azure.ServiceBus
                         break;
                     }
 
-                    bool isDiagnosticsEnabled = ServiceBusDiagnosticSource.IsEnabled();
-                    Activity activity = isDiagnosticsEnabled ? this.diagnosticSource.ProcessSessionStart(session, message) : null;
+                    bool isDiagnosticSourceEnabled = ServiceBusDiagnosticSource.IsEnabled();
+                    Activity activity = isDiagnosticSourceEnabled ? this.diagnosticSource.ProcessSessionStart(session, message) : null;
                     Task processTask = null;
 
                     try
@@ -227,14 +227,13 @@ namespace Microsoft.Azure.ServiceBus
                         }
                         catch (Exception exception)
                         {
-                            MessagingEventSource.Log.MessageReceivePumpTaskException(this.clientId, session.SessionId,
-                                exception);
-                            if (isDiagnosticsEnabled)
+                            if (isDiagnosticSourceEnabled)
                             {
                                 this.diagnosticSource.ReportException(exception);
                             }
-                            await this.RaiseExceptionReceived(exception, ExceptionReceivedEventArgsAction.UserCallback)
-                                .ConfigureAwait(false);
+
+                            MessagingEventSource.Log.MessageReceivePumpTaskException(this.clientId, session.SessionId, exception);
+                            await this.RaiseExceptionReceived(exception, ExceptionReceivedEventArgsAction.UserCallback).ConfigureAwait(false);
                             callbackExceptionOccurred = true;
                             if (!(exception is MessageLockLostException || exception is SessionLockLostException))
                             {

--- a/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
@@ -448,8 +448,8 @@ namespace Microsoft.Azure.ServiceBus
             description.ValidateDescriptionName();
             MessagingEventSource.Log.AddRuleStart(this.ClientId, description.Name);
 
-            bool isDiagnosticsEnabled = ServiceBusDiagnosticSource.IsEnabled();
-            Activity activity = isDiagnosticsEnabled ? this.diagnosticSource.AddRuleStart(description) : null;
+            bool isDiagnosticSourceEnabled = ServiceBusDiagnosticSource.IsEnabled();
+            Activity activity = isDiagnosticSourceEnabled ? this.diagnosticSource.AddRuleStart(description) : null;
             Task addRuleTask = null;
 
             try
@@ -459,11 +459,12 @@ namespace Microsoft.Azure.ServiceBus
             }
             catch (Exception exception)
             {
-                MessagingEventSource.Log.AddRuleException(this.ClientId, exception);
-                if (isDiagnosticsEnabled)
+                if (isDiagnosticSourceEnabled)
                 {
                     this.diagnosticSource.ReportException(exception);
                 }
+
+                MessagingEventSource.Log.AddRuleException(this.ClientId, exception);
                 throw;
             }
             finally
@@ -488,8 +489,8 @@ namespace Microsoft.Azure.ServiceBus
             }
 
             MessagingEventSource.Log.RemoveRuleStart(this.ClientId, ruleName);
-            bool isDiagnosticsEnabled = ServiceBusDiagnosticSource.IsEnabled();
-            Activity activity = isDiagnosticsEnabled ? this.diagnosticSource.RemoveRuleStart(ruleName) : null;
+            bool isDiagnosticSourceEnabled = ServiceBusDiagnosticSource.IsEnabled();
+            Activity activity = isDiagnosticSourceEnabled ? this.diagnosticSource.RemoveRuleStart(ruleName) : null;
             Task removeRuleTask = null;
 
             try
@@ -499,11 +500,12 @@ namespace Microsoft.Azure.ServiceBus
             }
             catch (Exception exception)
             {
-                MessagingEventSource.Log.RemoveRuleException(this.ClientId, exception);
-                if (isDiagnosticsEnabled)
+                if (isDiagnosticSourceEnabled)
                 {
                     this.diagnosticSource.ReportException(exception);
                 }
+
+                MessagingEventSource.Log.RemoveRuleException(this.ClientId, exception);
 
                 throw;
             }
@@ -523,8 +525,8 @@ namespace Microsoft.Azure.ServiceBus
             this.ThrowIfClosed();
 
             MessagingEventSource.Log.GetRulesStart(this.ClientId);
-            bool isDiagnosticsEnabled = ServiceBusDiagnosticSource.IsEnabled();
-            Activity activity = isDiagnosticsEnabled ? this.diagnosticSource.GetRulesStart() : null;
+            bool isDiagnosticSourceEnabled = ServiceBusDiagnosticSource.IsEnabled();
+            Activity activity = isDiagnosticSourceEnabled ? this.diagnosticSource.GetRulesStart() : null;
             Task<IEnumerable<RuleDescription>> getRulesTask = null;
 
             var skip = 0;
@@ -538,11 +540,12 @@ namespace Microsoft.Azure.ServiceBus
             }
             catch (Exception exception)
             {
-                MessagingEventSource.Log.GetRulesException(this.ClientId, exception);
-                if (isDiagnosticsEnabled)
+                if (isDiagnosticSourceEnabled)
                 {
                     this.diagnosticSource.ReportException(exception);
                 }
+
+                MessagingEventSource.Log.GetRulesException(this.ClientId, exception);
 
                 throw;
             }

--- a/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.ServiceBus
             this.ReceiveMode = receiveMode;
             this.TokenProvider = this.ServiceBusConnection.CreateTokenProvider();
             this.CbsTokenProvider = new TokenProviderAdapter(this.TokenProvider, serviceBusConnection.OperationTimeout);
-            this.diagnosticSource = new ServiceBusDiagnosticSource($"{topicPath}/{subscriptionName}", serviceBusConnection.Endpoint);
+            this.diagnosticSource = new ServiceBusDiagnosticSource(this.Path, serviceBusConnection.Endpoint);
 
             MessagingEventSource.Log.SubscriptionClientCreateStop(serviceBusConnection.Endpoint.Authority, topicPath, subscriptionName, this.ClientId);
         }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -476,6 +476,14 @@ namespace Microsoft.Azure.ServiceBus.Core
         public virtual System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.Message> BeforeMessageSend(Microsoft.Azure.ServiceBus.Message message) { }
     }
 }
+namespace Microsoft.Azure.ServiceBus.Diagnostics
+{
+    
+    public class static MessageExtensions
+    {
+        public static System.Diagnostics.Activity ExtractActivity(this Microsoft.Azure.ServiceBus.Message message, string activityName = null) { }
+    }
+}
 namespace Microsoft.Azure.ServiceBus.InteropExtensions
 {
     

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/DiagnosticsTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/DiagnosticsTests.cs
@@ -1,0 +1,535 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Reflection;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public abstract class DiagnosticsTests : IDisposable
+    {
+        protected ConcurrentQueue<(string eventName, object payload, Activity activity)> events;
+        protected FakeDiagnosticListener listener;
+        protected IDisposable subscription;
+        protected const int maxWaitSec = 10;
+
+        protected abstract string EntityName { get; }
+        private bool disposed = false;
+
+        internal DiagnosticsTests()
+        {
+            this.events = new ConcurrentQueue<(string eventName, object payload, Activity activity)>();
+            this.listener = new FakeDiagnosticListener(kvp =>
+            {
+                TestUtility.Log($"Diagnostics event: {kvp.Key}, Activity Id: {Activity.Current?.Id}");
+                if (kvp.Key.Contains("Exception"))
+                {
+                    TestUtility.Log($"Exception {kvp.Value}");
+                }
+
+                this.events.Enqueue((kvp.Key, kvp.Value, Activity.Current));
+            });
+            this.subscription = DiagnosticListener.AllListeners.Subscribe(this.listener);
+        }
+
+        #region Send
+
+        protected void AssertSendStart(string name, object payload, Activity activity, Activity parentActivity, int messageCount = 1)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.Send.Start", name);
+            AssertCommonPayloadProperties(payload);
+            var messages = GetPropertyValueFromAnonymousTypeInstance<IList<Message>>(payload, "Messages");
+            Assert.Equal(messageCount, messages.Count);
+
+            Assert.NotNull(activity);
+            Assert.Equal(parentActivity, activity.Parent);
+
+            AssertTags(messages, activity);
+        }
+
+        protected void AssertSendStop(string name, object payload, Activity activity, Activity sendActivity, int messageCount = 1)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.Send.Stop", name);
+            AssertCommonStopPayloadProperties(payload);
+
+            if (sendActivity != null)
+            {
+                Assert.Equal(sendActivity, activity);
+            }
+
+            var messages = GetPropertyValueFromAnonymousTypeInstance<IList<Message>>(payload, "Messages");
+            Assert.Equal(messageCount, messages.Count);
+        }
+
+        #endregion
+
+        #region Complete
+
+        protected void AssertCompleteStart(string name, object payload, Activity activity, Activity parentActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.Complete.Start", name);
+            AssertCommonPayloadProperties(payload);
+            GetPropertyValueFromAnonymousTypeInstance<IList<string>>(payload, "LockTokens");
+
+            Assert.NotNull(activity);
+            Assert.Equal(parentActivity, activity.Parent);
+        }
+
+        protected void AssertCompleteStop(string name, object payload, Activity activity, Activity completeActivity, Activity parentActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.Complete.Stop", name);
+            AssertCommonStopPayloadProperties(payload);
+
+            if (completeActivity != null)
+            {
+                Assert.Equal(completeActivity, activity);
+            }
+
+            var tokens = GetPropertyValueFromAnonymousTypeInstance<IList<string>>(payload, "LockTokens");
+            Assert.Equal(1, tokens.Count);
+        }
+
+        #endregion
+
+
+        #region Abandon
+
+        protected void AssertAbandonStart(string name, object payload, Activity activity, Activity parentActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.Abandon.Start", name);
+            AssertCommonPayloadProperties(payload);
+            GetPropertyValueFromAnonymousTypeInstance<string>(payload, "LockToken");
+
+            Assert.NotNull(activity);
+            Assert.Equal(parentActivity, activity.Parent);
+        }
+
+        protected void AssertAbandonStop(string name, object payload, Activity activity, Activity abandonActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.Abandon.Stop", name);
+            AssertCommonStopPayloadProperties(payload);
+
+            if (abandonActivity != null)
+            {
+                Assert.Equal(abandonActivity, activity);
+            }
+
+            GetPropertyValueFromAnonymousTypeInstance<string>(payload, "LockToken");
+        }
+
+        #endregion
+
+
+        #region Defer
+
+        protected void AssertDeferStart(string name, object payload, Activity activity, Activity parentActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.Defer.Start", name);
+            AssertCommonPayloadProperties(payload);
+            GetPropertyValueFromAnonymousTypeInstance<string>(payload, "LockToken");
+
+            Assert.NotNull(activity);
+            Assert.Equal(parentActivity, activity.Parent);
+        }
+
+        protected void AssertDeferStop(string name, object payload, Activity activity, Activity deferActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.Defer.Stop", name);
+            AssertCommonStopPayloadProperties(payload);
+
+            if (deferActivity != null)
+            {
+                Assert.Equal(deferActivity, activity);
+            }
+
+            GetPropertyValueFromAnonymousTypeInstance<string>(payload, "LockToken");
+        }
+
+        #endregion
+
+        #region DeadLetter
+
+        protected void AssertDeadLetterStart(string name, object payload, Activity activity, Activity parentActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.DeadLetter.Start", name);
+            AssertCommonPayloadProperties(payload);
+            GetPropertyValueFromAnonymousTypeInstance<string>(payload, "LockToken");
+
+            Assert.NotNull(activity);
+            Assert.Equal(parentActivity, activity.Parent);
+        }
+
+        protected void AssertDeadLetterStop(string name, object payload, Activity activity, Activity deadLetterActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.DeadLetter.Stop", name);
+            AssertCommonStopPayloadProperties(payload);
+
+            if (deadLetterActivity != null)
+            {
+                Assert.Equal(deadLetterActivity, activity);
+            }
+
+            GetPropertyValueFromAnonymousTypeInstance<string>(payload, "LockToken");
+        }
+
+        #endregion
+
+        #region Schedule
+
+        protected void AssertScheduleStart(string name, object payload, Activity activity, Activity parentActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.Schedule.Start", name);
+            AssertCommonPayloadProperties(payload);
+            var message = GetPropertyValueFromAnonymousTypeInstance<Message>(payload, "Message");
+            GetPropertyValueFromAnonymousTypeInstance<DateTimeOffset>(payload, "ScheduleEnqueueTimeUtc");
+
+            Assert.NotNull(activity);
+            Assert.Equal(parentActivity, activity.Parent);
+            AssertTags(message, activity);
+        }
+
+        protected void AssertScheduleStop(string name, object payload, Activity activity, Activity scheduleActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.Schedule.Stop", name);
+            AssertCommonStopPayloadProperties(payload);
+
+            Assert.Equal(scheduleActivity, activity);
+            var message = GetPropertyValueFromAnonymousTypeInstance<Message>(payload, "Message");
+            GetPropertyValueFromAnonymousTypeInstance<DateTimeOffset>(payload, "ScheduleEnqueueTimeUtc");
+            GetPropertyValueFromAnonymousTypeInstance<long>(payload, "SequenceNumber");
+            Assert.NotNull(message);
+            Assert.Contains("Diagnostic-Id", message.UserProperties.Keys);
+            if (scheduleActivity.Baggage.Any())
+            {
+                Assert.Contains("Correlation-Context", message.UserProperties.Keys);
+            }
+        }
+
+        #endregion
+
+        #region Cancel
+
+        protected void AssertCancelStart(string name, object payload, Activity activity, Activity parentActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.Cancel.Start", name);
+            AssertCommonPayloadProperties(payload);
+            GetPropertyValueFromAnonymousTypeInstance<long>(payload, "SequenceNumber");
+
+            Assert.NotNull(activity);
+            Assert.Equal(parentActivity, activity.Parent);
+        }
+
+        protected void AssertCancelStop(string name, object payload, Activity activity, Activity scheduleActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.Cancel.Stop", name);
+            AssertCommonStopPayloadProperties(payload);
+
+            Assert.Equal(scheduleActivity, activity);
+            GetPropertyValueFromAnonymousTypeInstance<long>(payload, "SequenceNumber");
+        }
+
+        #endregion
+
+        #region Receive
+
+        protected int AssertReceiveStart(string name, object payload, Activity activity, int messagesCount = 1)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.Receive.Start", name);
+            AssertCommonPayloadProperties(payload);
+
+            var count = GetPropertyValueFromAnonymousTypeInstance<int>(payload, "MessageCount");
+            if (messagesCount != -1)
+            {
+                Assert.Equal(messagesCount, count);
+            }
+            Assert.NotNull(activity);
+            Assert.Null(activity.Parent);
+
+            return count;
+        }
+
+        protected int AssertReceiveStop(string name, object payload, Activity activity, Activity receiveActivity, Activity sendActivity, int sentMessagesCount = 1, int receivedMessagesCount = 1)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.Receive.Stop", name);
+            AssertCommonStopPayloadProperties(payload);
+
+            if (receiveActivity != null)
+            {
+                Assert.Equal(receiveActivity, activity);
+            }
+
+            Assert.Equal(sentMessagesCount, GetPropertyValueFromAnonymousTypeInstance<int>(payload, "MessageCount"));
+            var messages = GetPropertyValueFromAnonymousTypeInstance<IList<Message>>(payload, "Messages");
+
+            if (receivedMessagesCount != -1)
+            {
+                Assert.Equal(receivedMessagesCount, messages.Count);
+            }
+
+            if (sendActivity != null)
+            {
+                Assert.Contains(sendActivity.Id, activity.Tags.Single(t => t.Key == "RelatedTo").Value);
+            }
+
+            AssertTags(messages, activity);
+            return messages.Count;
+        }
+
+        #endregion
+
+        #region ReceiveDeffered
+
+        protected void AssertReceiveDefferedStart(string name, object payload, Activity activity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.ReceiveDeffered.Start", name);
+            AssertCommonPayloadProperties(payload);
+
+            Assert.Single(GetPropertyValueFromAnonymousTypeInstance<IEnumerable<long>>(payload, "SequenceNumbers"));
+
+            Assert.NotNull(activity);
+            Assert.Null(activity.Parent);
+        }
+
+        protected void AssertReceiveDefferedStop(string name, object payload, Activity activity, Activity receiveActivity, Activity sendActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.ReceiveDeffered.Stop", name);
+            AssertCommonStopPayloadProperties(payload);
+
+            if (receiveActivity != null)
+            {
+                Assert.Equal(receiveActivity, activity);
+            }
+
+            var messages = GetPropertyValueFromAnonymousTypeInstance<IList<Message>>(payload, "Messages");
+            Assert.Equal(1, messages.Count);
+            Assert.Single(GetPropertyValueFromAnonymousTypeInstance<IEnumerable<long>>(payload, "SequenceNumbers"));
+
+            Assert.Equal(sendActivity.Id, activity.Tags.Single(t => t.Key == "RelatedTo").Value);
+
+            AssertTags(messages, activity);
+        }
+
+        #endregion
+
+
+        #region Process
+
+        protected void AssertProcessStart(string name, object payload, Activity activity, Activity sendActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.Process.Start", name);
+            AssertCommonPayloadProperties(payload);
+
+            var message = GetPropertyValueFromAnonymousTypeInstance<Message>(payload, "Message");
+
+            Assert.NotNull(activity);
+            Assert.Null(activity.Parent);
+            Assert.Equal(sendActivity.Id, activity.ParentId);
+            Assert.Equal(sendActivity.Baggage.OrderBy(p => p.Key), activity.Baggage.OrderBy(p => p.Key));
+
+            AssertTags(message, activity);
+        }
+
+        protected void AssertProcessStop(string name, object payload, Activity activity, Activity processActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.Process.Stop", name);
+            AssertCommonStopPayloadProperties(payload);
+
+            if (processActivity != null)
+            {
+                Assert.Equal(processActivity, activity);
+            }
+        }
+
+        #endregion
+
+
+        #region Peek
+
+        protected void AssertPeekStart(string name, object payload, Activity activity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.Peek.Start", name);
+            AssertCommonPayloadProperties(payload);
+
+            GetPropertyValueFromAnonymousTypeInstance<long>(payload, "FromSequenceNumber");
+            Assert.Equal(1, GetPropertyValueFromAnonymousTypeInstance<int>(payload, "MessageCount"));
+
+            Assert.NotNull(activity);
+            Assert.Null(activity.Parent);
+        }
+
+        protected void AssertPeekStop(string name, object payload, Activity activity, Activity peekActivity, Activity sendActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.Peek.Stop", name);
+            AssertCommonStopPayloadProperties(payload);
+
+            if (peekActivity != null)
+            {
+                Assert.Equal(peekActivity, activity);
+            }
+
+            GetPropertyValueFromAnonymousTypeInstance<long>(payload, "FromSequenceNumber");
+            Assert.Equal(1, GetPropertyValueFromAnonymousTypeInstance<int>(payload, "MessageCount"));
+            var messages = GetPropertyValueFromAnonymousTypeInstance<IList<Message>>(payload, "Messages");
+            AssertTags(messages, activity);
+
+            Assert.Equal(sendActivity.Id, activity.Tags.Single(t => t.Key == "RelatedTo").Value);
+        }
+
+        #endregion
+
+
+        #region RenewLock
+
+        protected void AssertRenewLockStart(string name, object payload, Activity activity, Activity parentActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.RenewLock.Start", name);
+            AssertCommonPayloadProperties(payload);
+            GetPropertyValueFromAnonymousTypeInstance<string>(payload, "LockToken");
+
+            Assert.NotNull(activity);
+            Assert.Equal(parentActivity, activity.Parent);
+        }
+
+        protected void AssertRenewLockStop(string name, object payload, Activity activity, Activity renewLockActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.RenewLock.Stop", name);
+            AssertCommonStopPayloadProperties(payload);
+
+            if (renewLockActivity != null)
+            {
+                Assert.Equal(renewLockActivity, activity);
+            }
+
+            GetPropertyValueFromAnonymousTypeInstance<string>(payload, "LockToken");
+            GetPropertyValueFromAnonymousTypeInstance<DateTime>(payload, "LockedUntilUtc");
+        }
+
+        #endregion
+
+        protected void AssertTags(IList<Message> messageList, Activity activity)
+        {
+            var messagesWithId = messageList.Where(m => m.MessageId != null).ToArray();
+            if (messagesWithId.Any())
+            {
+                Assert.Contains("MessageId", activity.Tags.Select(t => t.Key));
+
+                string messageIdTag = activity.Tags.Single(t => t.Key == "MessageId").Value;
+                foreach (var m in messagesWithId)
+                {
+                    Assert.Contains(m.MessageId, messageIdTag);
+                }
+            }
+
+            var messagesWithSessionId = messageList.Where(m => m.SessionId != null).ToArray();
+            if (messagesWithSessionId.Any())
+            {
+                Assert.Contains("SessionId", activity.Tags.Select(t => t.Key));
+
+                string sessionIdTag = activity.Tags.Single(t => t.Key == "SessionId").Value;
+                foreach (var m in messagesWithSessionId)
+                {
+                    Assert.Contains(m.SessionId, sessionIdTag);
+                }
+            }
+        }
+
+        protected void AssertTags(Message message, Activity activity)
+        {
+            if (message.MessageId != null)
+            {
+                Assert.Contains("MessageId", activity.Tags.Select(t => t.Key));
+                Assert.Equal(message.MessageId, activity.Tags.Single(t => t.Key == "MessageId").Value);
+            }
+
+            if (message.SessionId != null)
+            {
+                Assert.Contains("SessionId", activity.Tags.Select(t => t.Key));
+                Assert.Equal(message.SessionId, activity.Tags.Single(t => t.Key == "SessionId").Value);
+            }
+        }
+
+        protected void AssertException(string name, object payload, Activity activity, Activity parentActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.Exception", name);
+            AssertCommonPayloadProperties(payload);
+
+            GetPropertyValueFromAnonymousTypeInstance<Exception>(payload, "Exception");
+
+            Assert.NotNull(activity);
+            if (parentActivity != null)
+            {
+                Assert.Equal(parentActivity, activity.Parent);
+            }
+        }
+
+        protected void AssertCommonPayloadProperties(object eventPayload)
+        {
+            var entity = GetPropertyValueFromAnonymousTypeInstance<string>(eventPayload, "Entity");
+            GetPropertyValueFromAnonymousTypeInstance<Uri>(eventPayload, "Endpoint");
+
+            Assert.Equal(this.EntityName, entity);
+        }
+
+        protected void AssertCommonStopPayloadProperties(object eventPayload)
+        {
+            AssertCommonPayloadProperties(eventPayload);
+            var status = GetPropertyValueFromAnonymousTypeInstance<TaskStatus>(eventPayload, "Status");
+            Assert.Equal(TaskStatus.RanToCompletion, status);
+        }
+
+        protected T GetPropertyValueFromAnonymousTypeInstance<T>(object obj, string propertyName)
+        {
+            Type t = obj.GetType();
+
+            PropertyInfo p = t.GetRuntimeProperty(propertyName);
+
+            object propertyValue = p.GetValue(obj);
+            Assert.NotNull(propertyValue);
+            Assert.IsAssignableFrom<T>(propertyValue);
+
+            return (T)propertyValue;
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (this.disposed)
+                return;
+
+            if (disposing)
+            {
+                //Thread.Sleep(90000);
+                this.listener?.Disable();
+
+                while (this.events.TryDequeue(out var evnt))
+                {
+                }
+
+                while (Activity.Current != null)
+                {
+                    Activity.Current.Stop();
+                }
+
+                this.listener?.Dispose();
+                this.subscription?.Dispose();
+
+                this.events = null;
+                this.listener = null;
+                this.subscription = null;
+            }
+
+            this.disposed = true;
+        }
+    }
+}

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/DiagnosticsTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/DiagnosticsTests.cs
@@ -243,7 +243,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
             Assert.Equal("Microsoft.Azure.ServiceBus.Receive.Start", name);
             AssertCommonPayloadProperties(payload);
 
-            var count = GetPropertyValueFromAnonymousTypeInstance<int>(payload, "MessageCount");
+            var count = GetPropertyValueFromAnonymousTypeInstance<int>(payload, "RequestedMessageCount");
             if (messagesCount != -1)
             {
                 Assert.Equal(messagesCount, count);
@@ -264,7 +264,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
                 Assert.Equal(receiveActivity, activity);
             }
 
-            Assert.Equal(sentMessagesCount, GetPropertyValueFromAnonymousTypeInstance<int>(payload, "MessageCount"));
+            Assert.Equal(sentMessagesCount, GetPropertyValueFromAnonymousTypeInstance<int>(payload, "RequestedMessageCount"));
             var messages = GetPropertyValueFromAnonymousTypeInstance<IList<Message>>(payload, "Messages");
 
             if (receivedMessagesCount != -1)
@@ -357,7 +357,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
             AssertCommonPayloadProperties(payload);
 
             GetPropertyValueFromAnonymousTypeInstance<long>(payload, "FromSequenceNumber");
-            Assert.Equal(1, GetPropertyValueFromAnonymousTypeInstance<int>(payload, "MessageCount"));
+            Assert.Equal(1, GetPropertyValueFromAnonymousTypeInstance<int>(payload, "RequestedMessageCount"));
 
             Assert.NotNull(activity);
             Assert.Null(activity.Parent);
@@ -374,7 +374,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
             }
 
             GetPropertyValueFromAnonymousTypeInstance<long>(payload, "FromSequenceNumber");
-            Assert.Equal(1, GetPropertyValueFromAnonymousTypeInstance<int>(payload, "MessageCount"));
+            Assert.Equal(1, GetPropertyValueFromAnonymousTypeInstance<int>(payload, "RequestedMessageCount"));
             var messages = GetPropertyValueFromAnonymousTypeInstance<IList<Message>>(payload, "Messages");
             AssertTags(messages, activity);
 

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/DiagnosticsTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/DiagnosticsTests.cs
@@ -283,11 +283,11 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
 
         #endregion
 
-        #region ReceiveDeffered
+        #region ReceiveDeferred
 
-        protected void AssertReceiveDefferedStart(string name, object payload, Activity activity)
+        protected void AssertReceiveDeferredStart(string name, object payload, Activity activity)
         {
-            Assert.Equal("Microsoft.Azure.ServiceBus.ReceiveDeffered.Start", name);
+            Assert.Equal("Microsoft.Azure.ServiceBus.ReceiveDeferred.Start", name);
             AssertCommonPayloadProperties(payload);
 
             Assert.Single(GetPropertyValueFromAnonymousTypeInstance<IEnumerable<long>>(payload, "SequenceNumbers"));
@@ -296,9 +296,9 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
             Assert.Null(activity.Parent);
         }
 
-        protected void AssertReceiveDefferedStop(string name, object payload, Activity activity, Activity receiveActivity, Activity sendActivity)
+        protected void AssertReceiveDeferredStop(string name, object payload, Activity activity, Activity receiveActivity, Activity sendActivity)
         {
-            Assert.Equal("Microsoft.Azure.ServiceBus.ReceiveDeffered.Stop", name);
+            Assert.Equal("Microsoft.Azure.ServiceBus.ReceiveDeferred.Stop", name);
             AssertCommonStopPayloadProperties(payload);
 
             if (receiveActivity != null)

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/ExtractActivityTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/ExtractActivityTests.cs
@@ -1,0 +1,131 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
+{
+    using System.Linq;
+    using Microsoft.Azure.ServiceBus.Diagnostics;
+    using Xunit;
+
+    public class ExtractActivityTests
+    {
+        [Fact]
+        [DisplayTestMethodName]
+        void ValidIdAndContextAreExtracted()
+        {
+            var message = new Message();
+            message.UserProperties["Diagnostic-Id"] = "diagnostic-id";
+            message.UserProperties["Correlation-Context"] = "k1=v1";
+
+            var activity = message.ExtractActivity();
+
+            Assert.Equal("diagnostic-id", activity.ParentId);
+            Assert.Equal("diagnostic-id", activity.RootId);
+            
+            Assert.Null(activity.Id);
+
+            var baggage = activity.Baggage.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            Assert.Equal(1, baggage.Count);
+            Assert.Contains("k1", baggage.Keys);
+            Assert.Equal("v1", baggage["k1"]);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        void ValidIdAndMultipleContextAreExtracted()
+        {
+            var message = new Message();
+            message.UserProperties["Diagnostic-Id"] = "diagnostic-id";
+            message.UserProperties["Correlation-Context"] = "k1=v1,k2=v2,k3=v3";
+
+            var activity = message.ExtractActivity();
+
+            Assert.Equal("diagnostic-id", activity.ParentId);
+            Assert.Equal("diagnostic-id", activity.RootId);
+
+            Assert.Null(activity.Id);
+
+            var baggage = activity.Baggage.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            Assert.Equal(3, baggage.Count);
+            Assert.Contains("k1", baggage.Keys);
+            Assert.Contains("k2", baggage.Keys);
+            Assert.Contains("k3", baggage.Keys);
+            Assert.Equal("v1", baggage["k1"]);
+            Assert.Equal("v2", baggage["k2"]);
+            Assert.Equal("v3", baggage["k3"]);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        void ActivityNameCouldBeChanged()
+        {
+            var message = new Message();
+            message.UserProperties["Diagnostic-Id"] = "diagnostic-id";
+
+            var activity = message.ExtractActivity("My activity");
+
+            Assert.Equal("My activity", activity.OperationName);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        void ValidIdAndNoContextAreExtracted()
+        {
+            var message = new Message();
+            message.UserProperties["Diagnostic-Id"] = "diagnostic-id";
+
+            var activity = message.ExtractActivity();
+
+            Assert.Equal("diagnostic-id", activity.ParentId);
+            Assert.Equal("diagnostic-id", activity.RootId);
+            Assert.Null(activity.Id);
+
+            var baggage = activity.Baggage.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            Assert.Equal(0, baggage.Count);
+        }
+
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("not valid context")]
+        [InlineData("not,valid,context")]
+        [DisplayTestMethodName]
+        void ValidIdAndInvalidContextAreExtracted(string context)
+        {
+            var message = new Message();
+            message.UserProperties["Diagnostic-Id"] = "diagnostic-id";
+            message.UserProperties["Correlation-Context"] = context;
+
+            var activity = message.ExtractActivity();
+
+            Assert.Equal("diagnostic-id", activity.ParentId);
+            Assert.Equal("diagnostic-id", activity.RootId);
+            Assert.Null(activity.Id);
+
+            var baggage = activity.Baggage.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            Assert.Equal(0, baggage.Count);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [DisplayTestMethodName]
+        void EmptyIdResultsInActivityWithoutParent(string id)
+        {
+            var message = new Message();
+            message.UserProperties["Diagnostic-Id"] = id;
+            message.UserProperties["Correlation-Context"] = "k1=v1,k2=v2";
+
+            var activity = message.ExtractActivity();
+
+            Assert.Null(activity.ParentId);
+            Assert.Null(activity.RootId);
+            Assert.Null(activity.Id);
+
+            var baggage = activity.Baggage.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            // baggage is ignored in absence of Id
+            Assert.Equal(0, baggage.Count);
+        }
+    }
+}

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/FakeDiagnosticListener.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/FakeDiagnosticListener.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+
+    public sealed class FakeDiagnosticListener : IObserver<DiagnosticListener>, IDisposable
+    {
+        private  IDisposable subscription;
+        private class FakeDiagnosticSourceWriteObserver : IObserver<KeyValuePair<string, object>>
+        {
+            private readonly Action<KeyValuePair<string, object>> writeCallback;
+
+            public FakeDiagnosticSourceWriteObserver(Action<KeyValuePair<string, object>> writeCallback)
+            {
+                this.writeCallback = writeCallback;
+            }
+
+            public void OnCompleted()
+            {
+            }
+
+            public void OnError(Exception error)
+            {
+            }
+
+            public void OnNext(KeyValuePair<string, object> value)
+            {
+                this.writeCallback(value);
+            }
+        }
+
+        private readonly Action<KeyValuePair<string, object>> writeCallback;
+
+        private Func<string, object, object, bool> writeObserverEnabled = (name, arg1, arg2) => false;
+
+        public FakeDiagnosticListener(Action<KeyValuePair<string, object>> writeCallback)
+        {
+            this.writeCallback = writeCallback;
+        }
+
+        public void OnCompleted()
+        {
+        }
+
+        public void OnError(Exception error)
+        {
+        }
+
+        public void OnNext(DiagnosticListener value)
+        {
+            if (value.Name.Equals("Microsoft.Azure.ServiceBus"))
+            {
+                this.subscription = value.Subscribe(new FakeDiagnosticSourceWriteObserver(this.writeCallback), this.IsEnabled);
+            }
+        }
+
+        public void Enable()
+        {
+            this.writeObserverEnabled = (name, arg1, arg2) => true;
+        }
+
+        public void Enable(Func<string, bool> writeObserverEnabled)
+        {
+            this.writeObserverEnabled = (name, arg1, arg2) => writeObserverEnabled(name);
+        }
+
+        public void Enable(Func<string, object, object, bool> writeObserverEnabled)
+        {
+            this.writeObserverEnabled = writeObserverEnabled;
+        }
+
+        public void Disable()
+        {
+            this.writeObserverEnabled = (name, arg1, arg2) => false;
+        }
+
+        private bool IsEnabled(string s, object arg1, object arg2)
+        {
+            return this.writeObserverEnabled.Invoke(s, arg1, arg2);
+        }
+
+        public void Dispose()
+        {
+            this.Disable();
+            this.subscription?.Dispose();
+        }
+    }
+}

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/QueueClientDiagnosticsTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/QueueClientDiagnosticsTests.cs
@@ -1,0 +1,498 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
+{
+    using System;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public sealed class QueueClientDiagnosticsTests : DiagnosticsTests
+    {
+        protected override string EntityName => TestConstants.NonPartitionedQueueName;
+        private QueueClient queueClient;
+        private bool disposed = false;
+
+        [Fact]
+        [DisplayTestMethodName]
+        async Task EventsAreNotFiredWhenDiagnosticsIsDisabled()
+        {
+            this.queueClient = new QueueClient(TestUtility.NamespaceConnectionString, TestConstants.NonPartitionedQueueName, ReceiveMode.ReceiveAndDelete);
+
+            Activity processActivity = null;
+
+            ManualResetEvent processingDone = new ManualResetEvent(false);
+            this.listener.Disable();
+
+            await TestUtility.SendMessagesAsync(this.queueClient.InnerSender, 1);
+            this.queueClient.RegisterMessageHandler((msg, ct) => {
+                    processActivity = Activity.Current;
+                    processingDone.Set();
+                    return Task.CompletedTask;
+                },
+                exArgs => Task.CompletedTask);
+
+            processingDone.WaitOne(TimeSpan.FromSeconds(maxWaitSec));
+            Assert.True(this.events.IsEmpty);
+            Assert.Null(processActivity);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        async Task EventsAreNotFiredWhenDiagnosticsIsDisabledForQueue()
+        {
+            this.queueClient = new QueueClient(TestUtility.NamespaceConnectionString, TestConstants.NonPartitionedQueueName,
+                ReceiveMode.ReceiveAndDelete);
+
+            Activity processActivity = null;
+
+            ManualResetEvent processingDone = new ManualResetEvent(false);
+            this.listener.Enable((name, queueName, arg) =>
+                queueName == null || queueName.ToString() != TestConstants.NonPartitionedQueueName);
+
+            await TestUtility.SendMessagesAsync(this.queueClient.InnerSender, 1);
+            this.queueClient.RegisterMessageHandler((msg, ct) =>
+                {
+                    processActivity = Activity.Current;
+                    processingDone.Set();
+                    return Task.CompletedTask;
+                },
+                exArgs => Task.CompletedTask);
+
+            processingDone.WaitOne(TimeSpan.FromSeconds(maxWaitSec));
+
+            Assert.True(this.events.IsEmpty);
+            Assert.Null(processActivity);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        async Task SendAndHandlerFireEvents()
+        {
+            this.queueClient = new QueueClient(TestUtility.NamespaceConnectionString, TestConstants.NonPartitionedQueueName,
+                ReceiveMode.PeekLock);
+
+            Activity parentActivity = new Activity("test").AddBaggage("k1", "v1").AddBaggage("k2", "v2");
+            Activity processActivity = null;
+            bool exceptionCalled = false;
+            ManualResetEvent processingDone = new ManualResetEvent(false);
+            this.listener.Enable((name, queueName, arg) => !name.Contains("Receive") && !name.Contains("Exception"));
+
+            parentActivity.Start();
+
+            await TestUtility.SendSessionMessagesAsync(this.queueClient.InnerSender, 1, 1);
+            parentActivity.Stop();
+
+            this.queueClient.RegisterMessageHandler((msg, ct) =>
+                {
+                    processActivity = Activity.Current;
+                    processingDone.Set();
+                    return Task.CompletedTask;
+                },
+                exArgs =>
+                {
+                    exceptionCalled = true;
+                    return Task.CompletedTask;
+                });
+
+            processingDone.WaitOne(TimeSpan.FromSeconds(maxWaitSec));
+
+            Assert.True(this.events.TryDequeue(out var sendStart));
+            AssertSendStart(sendStart.eventName, sendStart.payload, sendStart.activity, parentActivity);
+
+            Assert.True(this.events.TryDequeue(out var sendStop));
+            AssertSendStop(sendStop.eventName, sendStop.payload, sendStop.activity, sendStart.activity);
+
+            Assert.True(this.events.TryDequeue(out var processStart));
+            AssertProcessStart(processStart.eventName, processStart.payload, processStart.activity,
+                sendStart.activity);
+
+            // message is processed, but complete happens after that
+            // let's wat until Complete starts and ends and Process ends
+            int wait = 0;
+            while (wait++ < maxWaitSec && this.events.Count < 3)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1));
+            }
+
+            Assert.True(this.events.TryDequeue(out var completeStart));
+            AssertCompleteStart(completeStart.eventName, completeStart.payload, completeStart.activity,
+                processStart.activity);
+
+            Assert.True(this.events.TryDequeue(out var completeStop));
+            AssertCompleteStop(completeStop.eventName, completeStop.payload, completeStop.activity,
+                completeStart.activity, processStart.activity);
+
+            Assert.True(this.events.TryDequeue(out var processStop));
+            AssertProcessStop(processStop.eventName, processStop.payload, processStop.activity,
+                processStart.activity);
+
+            Assert.False(this.events.TryDequeue(out var evnt));
+
+            Assert.Equal(processStop.activity, processActivity);
+            Assert.False(exceptionCalled);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        async Task SendAndHandlerFireExceptionEvents()
+        {
+            this.queueClient = new QueueClient(TestUtility.NamespaceConnectionString, TestConstants.NonPartitionedQueueName,
+                ReceiveMode.PeekLock);
+
+            bool exceptionCalled = false;
+
+            ManualResetEvent processingDone = new ManualResetEvent(false);
+            await TestUtility.SendMessagesAsync(this.queueClient.InnerSender, 1);
+
+            this.listener.Enable((name, queueName, arg) => !name.EndsWith("Start") && !name.Contains("Receive") );
+
+            int count = 0;
+            this.queueClient.RegisterMessageHandler((msg, ct) =>
+                {
+                    if (count++ == 0)
+                    {
+                        throw new Exception("123");
+                    }
+
+                    processingDone.Set();
+                    return Task.CompletedTask;
+                },
+                exArgs =>
+                {
+                    exceptionCalled = true;
+                    return Task.CompletedTask;
+                });
+            processingDone.WaitOne(TimeSpan.FromSeconds(maxWaitSec));
+            Assert.True(exceptionCalled);
+
+            // message is processed, but abandon happens after that
+            // let's spin until Complete call starts and ends
+            int wait = 0;
+            while (wait++ < maxWaitSec && this.events.Count < 3)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1));
+            }
+
+            Assert.True(this.events.TryDequeue(out var abandonStop));
+            AssertAbandonStop(abandonStop.eventName, abandonStop.payload, abandonStop.activity, null);
+
+            Assert.True(this.events.TryDequeue(out var exception));
+            AssertException(exception.eventName, exception.payload, exception.activity, null);
+
+            Assert.True(this.events.TryDequeue(out var processStop));
+            AssertProcessStop(processStop.eventName, processStop.payload, processStop.activity, null);
+
+            Assert.Equal(processStop.activity, abandonStop.activity.Parent);
+            Assert.Equal(processStop.activity, exception.activity);
+
+            // message will be processed and compelted again
+            wait = 0;
+            while (wait++ < maxWaitSec && this.events.Count < 2 )
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1));
+            }
+
+            Assert.True(this.events.TryDequeue(out var completeStop));
+            AssertCompleteStop(completeStop.eventName, completeStop.payload, completeStop.activity, null, null);
+
+            Assert.True(this.events.TryDequeue(out processStop));
+            AssertProcessStop(processStop.eventName, processStop.payload, processStop.activity, null);
+
+            Assert.True(this.events.IsEmpty);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        async Task AbandonCompleteFireEvents()
+        {
+            this.queueClient = new QueueClient(TestUtility.NamespaceConnectionString, TestConstants.NonPartitionedQueueName,
+                ReceiveMode.PeekLock);
+
+            await TestUtility.SendMessagesAsync(this.queueClient.InnerSender, 1);
+            var messages = await TestUtility.ReceiveMessagesAsync(this.queueClient.InnerReceiver, 1);
+
+            this.listener.Enable((name, queueName, arg) => name.Contains("Abandon") || name.Contains("Complete"));
+            await TestUtility.AbandonMessagesAsync(this.queueClient.InnerReceiver, messages);
+
+            messages = await TestUtility.ReceiveMessagesAsync(this.queueClient.InnerReceiver, 1);
+
+            await TestUtility.CompleteMessagesAsync(this.queueClient.InnerReceiver, messages);
+
+            Assert.True(this.events.TryDequeue(out var abandonStart));
+            AssertAbandonStart(abandonStart.eventName, abandonStart.payload, abandonStart.activity, null);
+
+            Assert.True(this.events.TryDequeue(out var abandonStop));
+            AssertAbandonStop(abandonStop.eventName, abandonStop.payload, abandonStop.activity,
+                abandonStart.activity);
+
+            Assert.True(this.events.TryDequeue(out var completeStart));
+            AssertCompleteStart(completeStart.eventName, completeStart.payload, completeStart.activity, null);
+
+            Assert.True(this.events.TryDequeue(out var completeStop));
+            AssertCompleteStop(completeStop.eventName, completeStop.payload, completeStop.activity,
+                completeStart.activity, null);
+
+            Assert.True(this.events.IsEmpty);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        async Task BatchSendReceiveFireEvents()
+        {
+            this.queueClient = new QueueClient(TestUtility.NamespaceConnectionString, TestConstants.NonPartitionedQueueName,
+                ReceiveMode.ReceiveAndDelete);
+
+            this.listener.Enable( (name, queuName, arg) => name.Contains("Send") || name.Contains("Receive") );
+            await TestUtility.SendMessagesAsync(this.queueClient.InnerSender, 2);
+            await TestUtility.SendMessagesAsync(this.queueClient.InnerSender, 3);
+            var messages = await TestUtility.ReceiveMessagesAsync(this.queueClient.InnerReceiver, 5);
+
+            Assert.True(this.events.TryDequeue(out var sendStart1));
+            AssertSendStart(sendStart1.eventName, sendStart1.payload, sendStart1.activity, null, 2);
+
+            Assert.True(this.events.TryDequeue(out var sendStop1));
+            AssertSendStop(sendStop1.eventName, sendStop1.payload, sendStop1.activity, sendStop1.activity, 2);
+
+            Assert.True(this.events.TryDequeue(out var sendStart2));
+            AssertSendStart(sendStart2.eventName, sendStart2.payload, sendStart2.activity, null, 3);
+
+            Assert.True(this.events.TryDequeue(out var sendStop2));
+            AssertSendStop(sendStop2.eventName, sendStop2.payload, sendStop2.activity, sendStop2.activity, 3);
+
+            int receivedStopCount = 0;
+            string relatedTo = "";
+            while (this.events.TryDequeue(out var receiveStart))
+            {
+                var startCount = AssertReceiveStart(receiveStart.eventName, receiveStart.payload, receiveStart.activity,
+                    -1);
+
+                Assert.True(this.events.TryDequeue(out var receiveStop));
+                receivedStopCount += AssertReceiveStop(receiveStop.eventName, receiveStop.payload, receiveStop.activity,
+                    receiveStart.activity, null, startCount, -1);
+                relatedTo += receiveStop.activity.Tags.Single(t => t.Key == "RelatedTo").Value;
+            }
+
+            Assert.Equal(5, receivedStopCount);
+            Assert.Contains(sendStart1.activity.Id, relatedTo);
+            Assert.Contains(sendStart2.activity.Id, relatedTo);
+
+            Assert.True(this.events.IsEmpty);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        async Task PeekFireEvents()
+        {
+            this.queueClient = new QueueClient(TestUtility.NamespaceConnectionString, TestConstants.NonPartitionedQueueName, ReceiveMode.PeekLock);
+            this.listener.Enable((name, queuName, arg) => name.Contains("Send") || name.Contains("Peek"));
+
+            await TestUtility.SendMessagesAsync(this.queueClient.InnerSender, 1);
+            await TestUtility.PeekMessageAsync(this.queueClient.InnerReceiver);
+
+            this.listener.Disable();
+
+            var messages = await TestUtility.ReceiveMessagesAsync(this.queueClient.InnerReceiver, 1);
+            await TestUtility.CompleteMessagesAsync(this.queueClient.InnerReceiver, messages);
+
+            Assert.True(this.events.TryDequeue(out var sendStart));
+            AssertSendStart(sendStart.eventName, sendStart.payload, sendStart.activity, null);
+
+            Assert.True(this.events.TryDequeue(out var sendStop));
+            AssertSendStop(sendStop.eventName, sendStop.payload, sendStop.activity, sendStart.activity);
+
+            Assert.True(this.events.TryDequeue(out var peekStart));
+            AssertPeekStart(peekStart.eventName, peekStart.payload, peekStart.activity);
+
+            Assert.True(this.events.TryDequeue(out var peekStop));
+            AssertPeekStop(peekStop.eventName, peekStop.payload, peekStop.activity, peekStart.activity, sendStart.activity);
+
+            Assert.True(this.events.IsEmpty);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        async Task DeadLetterFireEvents()
+        {
+            this.queueClient = new QueueClient(TestUtility.NamespaceConnectionString, TestConstants.NonPartitionedQueueName,
+                ReceiveMode.PeekLock);
+            await TestUtility.SendMessagesAsync(this.queueClient.InnerSender, 1);
+            var messages = await TestUtility.ReceiveMessagesAsync(this.queueClient.InnerReceiver, 1);
+
+            this.listener.Enable((name, queuName, arg) => name.Contains("DeadLetter"));
+            await TestUtility.DeadLetterMessagesAsync(this.queueClient.InnerReceiver, messages);
+            this.listener.Disable();
+
+            QueueClient deadLetterQueueClient = null;
+            try
+            {
+                deadLetterQueueClient = new QueueClient(TestUtility.NamespaceConnectionString,
+                    EntityNameHelper.FormatDeadLetterPath(this.queueClient.QueueName), ReceiveMode.ReceiveAndDelete);
+                await TestUtility.ReceiveMessagesAsync(deadLetterQueueClient.InnerReceiver, 1);
+            }
+            finally
+            {
+                deadLetterQueueClient?.CloseAsync().Wait(TimeSpan.FromSeconds(maxWaitSec));
+            }
+
+            Assert.True(this.events.TryDequeue(out var deadLetterStart));
+            AssertDeadLetterStart(deadLetterStart.eventName, deadLetterStart.payload, deadLetterStart.activity, null);
+
+            Assert.True(this.events.TryDequeue(out var deadLetterStop));
+            AssertDeadLetterStop(deadLetterStop.eventName, deadLetterStop.payload, deadLetterStop.activity,
+                deadLetterStart.activity);
+
+            Assert.True(this.events.IsEmpty);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        async Task RenewLockFireEvents()
+        {
+            this.queueClient = new QueueClient(TestUtility.NamespaceConnectionString, TestConstants.NonPartitionedQueueName,
+                ReceiveMode.PeekLock);
+
+            await TestUtility.SendMessagesAsync(this.queueClient.InnerSender, 1);
+            var messages = await TestUtility.ReceiveMessagesAsync(this.queueClient.InnerReceiver, 1);
+
+            this.listener.Enable((name, queuName, arg) => name.Contains("RenewLock"));
+            await this.queueClient.InnerReceiver.RenewLockAsync(messages[0]);
+            this.listener.Disable();
+
+            await TestUtility.CompleteMessagesAsync(this.queueClient.InnerReceiver, messages);
+
+            Assert.True(this.events.TryDequeue(out var renewStart));
+            AssertRenewLockStart(renewStart.eventName, renewStart.payload, renewStart.activity, null);
+
+            Assert.True(this.events.TryDequeue(out var renewStop));
+            AssertRenewLockStop(renewStop.eventName, renewStop.payload, renewStop.activity, renewStart.activity);
+
+            Assert.True(this.events.IsEmpty);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        async Task DeferReceiveDefferedFireEvents()
+        {
+            this.queueClient = new QueueClient(TestUtility.NamespaceConnectionString, TestConstants.NonPartitionedQueueName,
+                ReceiveMode.PeekLock);
+
+            this.listener.Enable((name, queuName, arg) => name.Contains("Send") || name.Contains("Defer") || name.Contains("Receive"));
+
+            await TestUtility.SendMessagesAsync(this.queueClient.InnerSender, 1);
+            var messages = await TestUtility.ReceiveMessagesAsync(this.queueClient.InnerReceiver, 1);
+            await TestUtility.DeferMessagesAsync(this.queueClient.InnerReceiver, messages);
+            var message = await this.queueClient.InnerReceiver.ReceiveDeferredMessageAsync(messages[0]
+                .SystemProperties
+                .SequenceNumber);
+
+            this.listener.Disable();
+            await TestUtility.CompleteMessagesAsync(this.queueClient.InnerReceiver, new[] {message});
+
+            Assert.True(this.events.TryDequeue(out var sendStart));
+            Assert.True(this.events.TryDequeue(out var sendStop));
+            Assert.True(this.events.TryDequeue(out var receiveStart));
+            Assert.True(this.events.TryDequeue(out var receiveStop));
+
+            Assert.True(this.events.TryDequeue(out var deferStart));
+            AssertDeferStart(deferStart.eventName, deferStart.payload, deferStart.activity, null);
+
+            Assert.True(this.events.TryDequeue(out var deferStop));
+            AssertDeferStop(deferStop.eventName, deferStop.payload, deferStop.activity, deferStart.activity);
+
+            Assert.True(this.events.TryDequeue(out var receiveDefferedStart));
+            AssertReceiveDefferedStart(receiveDefferedStart.eventName, receiveDefferedStart.payload,
+                receiveDefferedStart.activity);
+
+            Assert.True(this.events.TryDequeue(out var receiveDefferedStop));
+            AssertReceiveDefferedStop(receiveDefferedStop.eventName, receiveDefferedStop.payload,
+                receiveDefferedStop.activity, receiveDefferedStart.activity, sendStart.activity);
+
+            Assert.True(this.events.IsEmpty);
+        }
+
+
+        [Fact]
+        [DisplayTestMethodName]
+        async Task SendAndHandlerFilterOutStartEvents()
+        {
+            this.queueClient = new QueueClient(TestUtility.NamespaceConnectionString, TestConstants.NonPartitionedQueueName, ReceiveMode.ReceiveAndDelete);
+
+            ManualResetEvent processingDone = new ManualResetEvent(false);
+            this.listener.Enable((name, queueName, arg) => !name.EndsWith("Start") && !name.Contains("Receive") && !name.Contains("Exception"));
+
+            await TestUtility.SendMessagesAsync(this.queueClient.InnerSender, 1);
+            this.queueClient.RegisterMessageHandler((msg, ct) =>
+                {
+                    processingDone.Set();
+                    return Task.CompletedTask;
+                },
+                exArgs => Task.CompletedTask);
+            processingDone.WaitOne(TimeSpan.FromSeconds(maxWaitSec));
+
+            Assert.True(this.events.TryDequeue(out var sendStop));
+            AssertSendStop(sendStop.eventName, sendStop.payload, sendStop.activity, null);
+
+            int wait = 0;
+            while (wait++ < maxWaitSec && this.events.Count < 1)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1));
+            }
+
+            Assert.True(this.events.TryDequeue(out var processStop));
+            AssertProcessStop(processStop.eventName, processStop.payload, processStop.activity, null);
+
+            Assert.True(this.events.IsEmpty);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        async Task ScheduleAndCancelFireEvents()
+        {
+            this.queueClient = new QueueClient(TestUtility.NamespaceConnectionString, TestConstants.NonPartitionedQueueName,
+                ReceiveMode.ReceiveAndDelete);
+
+            Activity parentActivity = new Activity("test");
+            this.listener.Enable((name, queuName, arg) => name.Contains("Schedule") || name.Contains("Cancel"));
+
+            parentActivity.Start();
+
+            var sequenceNumber = await this.queueClient.InnerSender.ScheduleMessageAsync(new Message(), DateTimeOffset.UtcNow.AddHours(1));
+            await this.queueClient.InnerSender.CancelScheduledMessageAsync(sequenceNumber);
+
+            Assert.True(this.events.TryDequeue(out var scheduleStart));
+            AssertScheduleStart(scheduleStart.eventName, scheduleStart.payload, scheduleStart.activity,
+                parentActivity);
+
+            Assert.True(this.events.TryDequeue(out var scheduleStop));
+            AssertScheduleStop(scheduleStop.eventName, scheduleStop.payload, scheduleStop.activity,
+                scheduleStart.activity);
+
+            Assert.True(this.events.TryDequeue(out var cancelStart));
+            AssertCancelStart(cancelStart.eventName, cancelStart.payload, cancelStart.activity, parentActivity);
+
+            Assert.True(this.events.TryDequeue(out var cancelStop));
+            AssertCancelStop(cancelStop.eventName, cancelStop.payload, cancelStop.activity, cancelStart.activity);
+
+            Assert.True(this.events.IsEmpty);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (this.disposed)
+                return;
+
+            if (disposing)
+            {
+                this.queueClient?.CloseAsync().Wait(TimeSpan.FromSeconds(maxWaitSec));
+            }
+
+            this.disposed = true;
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/QueueClientDiagnosticsTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/QueueClientDiagnosticsTests.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
             ManualResetEvent processingDone = new ManualResetEvent(false);
             await TestUtility.SendMessagesAsync(this.queueClient.InnerSender, 1);
 
-            this.listener.Enable((name, queueName, arg) => !name.EndsWith("Start") && !name.Contains("Receive") );
+            this.listener.Enable((name, queueName, arg) => !name.EndsWith(".Start") && !name.Contains("Receive") );
 
             int count = 0;
             this.queueClient.RegisterMessageHandler((msg, ct) =>

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/QueueClientDiagnosticsTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/QueueClientDiagnosticsTests.cs
@@ -375,7 +375,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
 
         [Fact]
         [DisplayTestMethodName]
-        async Task DeferReceiveDefferedFireEvents()
+        async Task DeferReceiveDeferredFireEvents()
         {
             this.queueClient = new QueueClient(TestUtility.NamespaceConnectionString, TestConstants.NonPartitionedQueueName,
                 ReceiveMode.PeekLock);
@@ -403,13 +403,13 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
             Assert.True(this.events.TryDequeue(out var deferStop));
             AssertDeferStop(deferStop.eventName, deferStop.payload, deferStop.activity, deferStart.activity);
 
-            Assert.True(this.events.TryDequeue(out var receiveDefferedStart));
-            AssertReceiveDefferedStart(receiveDefferedStart.eventName, receiveDefferedStart.payload,
-                receiveDefferedStart.activity);
+            Assert.True(this.events.TryDequeue(out var receiveDeferredStart));
+            AssertReceiveDeferredStart(receiveDeferredStart.eventName, receiveDeferredStart.payload,
+                receiveDeferredStart.activity);
 
-            Assert.True(this.events.TryDequeue(out var receiveDefferedStop));
-            AssertReceiveDefferedStop(receiveDefferedStop.eventName, receiveDefferedStop.payload,
-                receiveDefferedStop.activity, receiveDefferedStart.activity, sendStart.activity);
+            Assert.True(this.events.TryDequeue(out var receiveDeferredStop));
+            AssertReceiveDeferredStop(receiveDeferredStop.eventName, receiveDeferredStop.payload,
+                receiveDeferredStop.activity, receiveDeferredStart.activity, sendStart.activity);
 
             Assert.True(this.events.IsEmpty);
         }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/SessionDiagnosticsTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/SessionDiagnosticsTests.cs
@@ -1,0 +1,323 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
+{
+    using System;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using Microsoft.Azure.ServiceBus.Core;
+    using Xunit;
+
+    public class SessionDiagnosticsTests : DiagnosticsTests
+    {
+        protected override string EntityName => TestConstants.SessionNonPartitionedQueueName;
+        private IMessageSession messageSession;
+        private SessionClient sessionClient;
+        private MessageSender messageSender;
+        private QueueClient queueClient;
+        private bool disposed;
+
+        [Fact]
+        [DisplayTestMethodName]
+        async Task AcceptSetAndGetStateGetFireEvents()
+        {
+            this.messageSender = new MessageSender(TestUtility.NamespaceConnectionString,
+                TestConstants.SessionNonPartitionedQueueName);
+            this.sessionClient = new SessionClient(TestUtility.NamespaceConnectionString,
+                TestConstants.SessionNonPartitionedQueueName, ReceiveMode.ReceiveAndDelete);
+
+            this.listener.Enable();
+
+            var sessionId = Guid.NewGuid().ToString();
+            await this.messageSender.SendAsync(new Message
+            {
+                MessageId = "messageId",
+                SessionId = sessionId
+            });
+            this.messageSession = await this.sessionClient.AcceptMessageSessionAsync(sessionId);
+
+            await this.messageSession.SetStateAsync(new byte[] {1});
+            await this.messageSession.GetStateAsync();
+            await this.messageSession.SetStateAsync(new byte[] { });
+
+            await this.messageSession.ReceiveAsync();
+
+            Assert.True(events.TryDequeue(out var sendStart));
+            AssertSendStart(sendStart.eventName, sendStart.payload, sendStart.activity, null);
+
+            Assert.True(events.TryDequeue(out var sendStop));
+            AssertSendStop(sendStop.eventName, sendStop.payload, sendStop.activity, sendStart.activity);
+
+            Assert.True(events.TryDequeue(out var acceptStart));
+            AssertAcceptMessageSessionStart(acceptStart.eventName, acceptStart.payload, acceptStart.activity);
+
+            Assert.True(events.TryDequeue(out var acceptStop));
+            AssertAcceptMessageSessionStop(acceptStop.eventName, acceptStop.payload, acceptStop.activity,
+                acceptStart.activity);
+
+            Assert.True(events.TryDequeue(out var setStateStart));
+            AssertSetSessionStateStart(setStateStart.eventName, setStateStart.payload, setStateStart.activity);
+
+            Assert.True(events.TryDequeue(out var setStateStop));
+            AssertSetSessionStateStop(setStateStop.eventName, setStateStop.payload, setStateStop.activity,
+                setStateStart.activity);
+
+            Assert.True(events.TryDequeue(out var getStateStart));
+            AssertGetSessionStateStart(getStateStart.eventName, getStateStart.payload, getStateStart.activity);
+
+            Assert.True(events.TryDequeue(out var getStateStop));
+            AssertGetSessionStateStop(getStateStop.eventName, getStateStop.payload, getStateStop.activity,
+                getStateStop.activity);
+
+            Assert.True(events.TryDequeue(out var setStateStart2));
+            Assert.True(events.TryDequeue(out var setStateStop2));
+
+            Assert.True(events.TryDequeue(out var receiveStart));
+            AssertReceiveStart(receiveStart.eventName, receiveStart.payload, receiveStart.activity);
+
+            Assert.True(events.TryDequeue(out var receiveStop));
+            AssertReceiveStop(receiveStop.eventName, receiveStop.payload, receiveStop.activity, receiveStart.activity,
+                sendStart.activity);
+
+            Assert.True(events.IsEmpty);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        async Task EventsAreNotFiredWhenDiagnosticsIsDisabled()
+        {
+            this.messageSender = new MessageSender(TestUtility.NamespaceConnectionString,
+                TestConstants.SessionNonPartitionedQueueName);
+            this.sessionClient = new SessionClient(TestUtility.NamespaceConnectionString,
+                TestConstants.SessionNonPartitionedQueueName, ReceiveMode.ReceiveAndDelete);
+
+            this.listener.Disable();
+
+            var sessionId = Guid.NewGuid().ToString();
+            await this.messageSender.SendAsync(new Message
+            {
+                MessageId = "messageId",
+                SessionId = sessionId
+            });
+            this.messageSession = await sessionClient.AcceptMessageSessionAsync(sessionId);
+
+            await this.messageSession.SetStateAsync(new byte[] {1});
+            await this.messageSession.GetStateAsync();
+            await this.messageSession.SetStateAsync(new byte[] { });
+
+            await this.messageSession.ReceiveAsync();
+
+            Assert.True(events.IsEmpty);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        async Task SessionHandlerFireEvents()
+        {
+            this.queueClient = new QueueClient(TestUtility.NamespaceConnectionString,
+                TestConstants.SessionNonPartitionedQueueName, ReceiveMode.ReceiveAndDelete)
+            {
+                OperationTimeout = TimeSpan.FromSeconds(2)
+            };
+
+            this.queueClient.ServiceBusConnection.OperationTimeout = TimeSpan.FromSeconds(maxWaitSec);
+            this.queueClient.SessionClient.OperationTimeout = TimeSpan.FromSeconds(2);
+
+            ManualResetEvent processingDone = new ManualResetEvent(false);
+            this.listener.Enable((name, queueName, arg) => !name.Contains("AcceptMessageSession") &&
+                                                      !name.Contains("Receive") &&
+                                                      !name.Contains("Exception"));
+            var sessionId = Guid.NewGuid().ToString();
+            var message = new Message()
+            {
+                MessageId = "messageId",
+                SessionId = sessionId
+            };
+            await this.queueClient.SendAsync(message);
+
+            this.queueClient.RegisterSessionHandler((session, msg, ct) =>
+                {
+                    processingDone.Set();
+                    return Task.CompletedTask;
+                },
+                exArgs => Task.CompletedTask);
+
+            processingDone.WaitOne(TimeSpan.FromSeconds(maxWaitSec));
+
+            Assert.True(events.TryDequeue(out var sendStart));
+            AssertSendStart(sendStart.eventName, sendStart.payload, sendStart.activity, null);
+
+            Assert.True(events.TryDequeue(out var sendStop));
+            AssertSendStop(sendStop.eventName, sendStop.payload, sendStop.activity, sendStart.activity);
+
+            Assert.True(events.TryDequeue(out var processStart));
+            AssertProcessSessionStart(processStart.eventName, processStart.payload, processStart.activity,
+                sendStart.activity);
+
+            int wait = 0;
+            while (wait++ < maxWaitSec && events.Count < 1)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1));
+            }
+
+            Assert.True(events.TryDequeue(out var processStop));
+            AssertProcessSessionStop(processStop.eventName, processStop.payload, processStop.activity,
+                processStart.activity);
+
+            Assert.True(events.IsEmpty);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (this.disposed)
+                return;
+
+            if (disposing)
+            {
+                this.queueClient?.SessionPumpHost?.Close();
+                this.queueClient?.SessionClient.CloseAsync().Wait(TimeSpan.FromSeconds(maxWaitSec));
+                this.queueClient?.CloseAsync().Wait(TimeSpan.FromSeconds(maxWaitSec));
+                this.messageSession?.CloseAsync().Wait(TimeSpan.FromSeconds(maxWaitSec));
+                this.sessionClient?.CloseAsync().Wait(TimeSpan.FromSeconds(maxWaitSec));
+                this.messageSender?.CloseAsync().Wait(TimeSpan.FromSeconds(maxWaitSec));
+            }
+
+            this.disposed = true;
+
+            base.Dispose(disposing);
+        }
+
+        protected void AssertAcceptMessageSessionStart(string name, object payload, Activity activity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.AcceptMessageSession.Start", name);
+            this.AssertCommonPayloadProperties(payload);
+
+            var sessionId = this.GetPropertyValueFromAnonymousTypeInstance<string>(payload, "SessionId");
+            
+            Assert.NotNull(activity);
+            Assert.Null(activity.Parent);
+            Assert.Equal(sessionId, activity.Tags.Single(t => t.Key == "SessionId").Value);
+        }
+
+        protected void AssertAcceptMessageSessionStop(string name, object payload, Activity activity, Activity acceptActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.AcceptMessageSession.Stop", name);
+            this.AssertCommonStopPayloadProperties(payload);
+            this.GetPropertyValueFromAnonymousTypeInstance<string>(payload, "SessionId");
+            this.GetPropertyValueFromAnonymousTypeInstance<IMessageSession>(payload, "Session");
+
+            if (acceptActivity != null)
+            {
+                Assert.Equal(acceptActivity, activity);
+            }
+        }
+
+        protected void AssertGetSessionStateStart(string name, object payload, Activity activity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.GetSessionState.Start", name);
+            this.AssertCommonPayloadProperties(payload);
+
+            var sessionId = this.GetPropertyValueFromAnonymousTypeInstance<string>(payload, "SessionId");
+            
+            Assert.NotNull(activity);
+            Assert.Null(activity.Parent);
+            Assert.Equal(sessionId, activity.Tags.Single(t => t.Key == "SessionId").Value);
+        }
+
+        protected void AssertGetSessionStateStop(string name, object payload, Activity activity, Activity getStateActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.GetSessionState.Stop", name);
+            this.AssertCommonStopPayloadProperties(payload);
+            this.GetPropertyValueFromAnonymousTypeInstance<string>(payload, "SessionId");
+            this.GetPropertyValueFromAnonymousTypeInstance<byte[]>(payload, "State");
+
+            if (getStateActivity != null)
+            {
+                Assert.Equal(getStateActivity, activity);
+            }
+        }
+
+        protected void AssertSetSessionStateStart(string name, object payload, Activity activity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.SetSessionState.Start", name);
+            this.AssertCommonPayloadProperties(payload);
+            var sessionId = this.GetPropertyValueFromAnonymousTypeInstance<string>(payload, "SessionId");
+            this.GetPropertyValueFromAnonymousTypeInstance<byte[]>(payload, "State");
+
+            Assert.NotNull(activity);
+            Assert.Null(activity.Parent);
+            Assert.Equal(sessionId, activity.Tags.Single(t => t.Key == "SessionId").Value);
+        }
+
+        protected void AssertSetSessionStateStop(string name, object payload, Activity activity, Activity setStateActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.SetSessionState.Stop", name);
+
+            this.AssertCommonStopPayloadProperties(payload);
+            this.GetPropertyValueFromAnonymousTypeInstance<string>(payload, "SessionId");
+            this.GetPropertyValueFromAnonymousTypeInstance<byte[]>(payload, "State");
+
+            if (setStateActivity != null)
+            {
+                Assert.Equal(setStateActivity, activity);
+            }
+        }
+
+        protected void AssertRenewSessionLockStart(string name, object payload, Activity activity, Activity parentActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.RenewSessionLock.Start", name);
+            this.AssertCommonPayloadProperties(payload);
+            var sessionId= this.GetPropertyValueFromAnonymousTypeInstance<string>(payload, "SessionId");
+
+            Assert.NotNull(activity);
+            Assert.Null(activity.Parent);
+            Assert.Equal(sessionId, activity.Tags.Single(t => t.Key == "SessionId").Value);
+        }
+
+        protected void AssertRenewSessionLockStop(string name, object payload, Activity activity, Activity renewActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.RenewSessionLock.Stop", name);
+
+            this.AssertCommonStopPayloadProperties(payload);
+            this.GetPropertyValueFromAnonymousTypeInstance<string>(payload, "SessionId");
+
+            if (renewActivity != null)
+            {
+                Assert.Equal(renewActivity, activity);
+            }
+        }
+
+        protected void AssertProcessSessionStart(string name, object payload, Activity activity, Activity sendActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.ProcessSession.Start", name);
+            AssertCommonPayloadProperties(payload);
+
+            GetPropertyValueFromAnonymousTypeInstance<IMessageSession>(payload, "Session");
+            var message = GetPropertyValueFromAnonymousTypeInstance<Message>(payload, "Message");
+
+            Assert.NotNull(activity);
+            Assert.Null(activity.Parent);
+            Assert.Equal(sendActivity.Id, activity.ParentId);
+            Assert.Equal(sendActivity.Baggage.OrderBy(p => p.Key), activity.Baggage.OrderBy(p => p.Key));
+
+            AssertTags(message, activity);
+        }
+
+        protected void AssertProcessSessionStop(string name, object payload, Activity activity, Activity processActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.ProcessSession.Stop", name);
+            AssertCommonStopPayloadProperties(payload);
+            GetPropertyValueFromAnonymousTypeInstance<IMessageSession>(payload, "Session");
+            var message = GetPropertyValueFromAnonymousTypeInstance<Message>(payload, "Message");
+
+            if (processActivity != null)
+            {
+                Assert.Equal(processActivity, activity);
+            }
+        }
+    }
+}

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/SessionDiagnosticsTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/SessionDiagnosticsTests.cs
@@ -172,6 +172,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
 
             Assert.True(events.IsEmpty);
 
+            // workaround for https://github.com/Azure/azure-service-bus-dotnet/issues/372:
             // SessionPumpTaskAsync calls AcceptMessageSessionAsync() without cancellation token.
             // Even after SessionPump is stopped, this Task may still wait for session during operation timeout
             // It may interferee with other tests by acception it's sessions and throwing exceptions.

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/SessionDiagnosticsTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/SessionDiagnosticsTests.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
             this.queueClient = new QueueClient(TestUtility.NamespaceConnectionString,
                 TestConstants.SessionNonPartitionedQueueName, ReceiveMode.ReceiveAndDelete)
             {
-                OperationTimeout = TimeSpan.FromSeconds(2)
+                OperationTimeout = TimeSpan.FromSeconds(5)
             };
 
             this.queueClient.ServiceBusConnection.OperationTimeout = TimeSpan.FromSeconds(maxWaitSec);

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/SessionDiagnosticsTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/SessionDiagnosticsTests.cs
@@ -208,7 +208,6 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
             Assert.Equal("Microsoft.Azure.ServiceBus.AcceptMessageSession.Stop", name);
             this.AssertCommonStopPayloadProperties(payload);
             this.GetPropertyValueFromAnonymousTypeInstance<string>(payload, "SessionId");
-            this.GetPropertyValueFromAnonymousTypeInstance<IMessageSession>(payload, "Session");
 
             if (acceptActivity != null)
             {

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/SessionDiagnosticsTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/SessionDiagnosticsTests.cs
@@ -179,7 +179,11 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
             // So, let's wait for timeout and a bit more to make sure all created tasks are completed
             sw.Stop();
 
-            await Task.Delay((int)(timeout - sw.Elapsed).TotalMilliseconds + 1000);
+            var timeToWait = (timeout - sw.Elapsed).TotalMilliseconds + 1000;
+            if (timeToWait > 0)
+            {
+                await Task.Delay((int)timeToWait);
+            }
         }
 
         protected override void Dispose(bool disposing)

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/SubscriptionClientDiagnosticsTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/SubscriptionClientDiagnosticsTests.cs
@@ -1,0 +1,155 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public class SubscriptionClientDiagnosticsTests : DiagnosticsTests
+    {
+        protected override string EntityName => $"{TestConstants.NonPartitionedTopicName}/{TestConstants.SubscriptionName}";
+        private SubscriptionClient subscriptionClient;
+        private bool disposed;
+
+        [Fact]
+        [DisplayTestMethodName]
+        async Task AddRemoveGetFireEvents()
+        {
+            this.subscriptionClient = new SubscriptionClient(
+                TestUtility.NamespaceConnectionString,
+                TestConstants.NonPartitionedTopicName,
+                TestConstants.SubscriptionName,
+                ReceiveMode.ReceiveAndDelete);
+
+            this.listener.Enable((name, queueName, id) => name.Contains("Rule"));
+
+            var ruleName = Guid.NewGuid().ToString();
+            await this.subscriptionClient.AddRuleAsync(ruleName, new TrueFilter());
+            await this.subscriptionClient.GetRulesAsync();
+            await this.subscriptionClient.RemoveRuleAsync(ruleName);
+
+            Assert.True(this.events.TryDequeue(out var addRuleStart));
+            AssertAddRuleStart(addRuleStart.eventName, addRuleStart.payload, addRuleStart.activity);
+
+            Assert.True(this.events.TryDequeue(out var addRuleStop));
+            AssertAddRuleStop(addRuleStop.eventName, addRuleStop.payload, addRuleStop.activity, addRuleStart.activity);
+
+            Assert.True(this.events.TryDequeue(out var getRulesStart));
+            AssertGetRulesStart(getRulesStart.eventName, getRulesStart.payload, getRulesStart.activity);
+
+            Assert.True(this.events.TryDequeue(out var getRulesStop));
+            AssertGetRulesStop(getRulesStop.eventName, getRulesStop.payload, getRulesStop.activity, getRulesStart.activity);
+
+            Assert.True(this.events.TryDequeue(out var removeRuleStart));
+            AssertRemoveRuleStart(removeRuleStart.eventName, removeRuleStart.payload, removeRuleStart.activity);
+
+            Assert.True(this.events.TryDequeue(out var removeRuleStop));
+            AssertRemoveRuleStop(removeRuleStop.eventName, removeRuleStop.payload, removeRuleStop.activity, removeRuleStart.activity);
+
+            Assert.True(this.events.IsEmpty);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        async Task EventsAreNotFiredWhenDiagnosticsIsDisabled()
+        {
+            this.subscriptionClient = new SubscriptionClient(
+                TestUtility.NamespaceConnectionString,
+                TestConstants.NonPartitionedTopicName,
+                TestConstants.SubscriptionName,
+                ReceiveMode.ReceiveAndDelete);
+
+            this.listener.Disable();
+
+            var ruleName = Guid.NewGuid().ToString();
+            await this.subscriptionClient.AddRuleAsync(ruleName, new TrueFilter());
+            await this.subscriptionClient.GetRulesAsync();
+            await this.subscriptionClient.RemoveRuleAsync(ruleName);
+
+            Assert.True(this.events.IsEmpty);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (this.disposed)
+                return;
+
+            if (disposing)
+            {
+                this.subscriptionClient?.CloseAsync().Wait(TimeSpan.FromSeconds(maxWaitSec));
+            }
+
+            this.disposed = true;
+
+            base.Dispose(disposing);
+        }
+
+        protected void AssertAddRuleStart(string name, object payload, Activity activity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.AddRule.Start", name);
+            AssertCommonPayloadProperties(payload);
+            GetPropertyValueFromAnonymousTypeInstance<RuleDescription>(payload, "Rule");
+            Assert.NotNull(activity);
+            Assert.Null(activity.Parent);
+        }
+
+        protected void AssertAddRuleStop(string name, object payload, Activity activity, Activity addRuleActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.AddRule.Stop", name);
+            AssertCommonStopPayloadProperties(payload);
+            GetPropertyValueFromAnonymousTypeInstance<RuleDescription>(payload, "Rule");
+
+            if (addRuleActivity != null)
+            {
+                Assert.Equal(addRuleActivity, activity);
+            }
+        }
+
+        protected void AssertGetRulesStart(string name, object payload, Activity activity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.GetRules.Start", name);
+            AssertCommonPayloadProperties(payload);
+            Assert.NotNull(activity);
+            Assert.Null(activity.Parent);
+        }
+
+        protected void AssertGetRulesStop(string name, object payload, Activity activity, Activity getRulesActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.GetRules.Stop", name);
+            
+            AssertCommonStopPayloadProperties(payload);
+            GetPropertyValueFromAnonymousTypeInstance<IEnumerable<RuleDescription>>(payload, "Rules");
+
+            if (getRulesActivity != null)
+            {
+                Assert.Equal(getRulesActivity, activity);
+            }
+        }
+
+        protected void AssertRemoveRuleStart(string name, object payload, Activity activity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.RemoveRule.Start", name);
+            AssertCommonPayloadProperties(payload);
+            GetPropertyValueFromAnonymousTypeInstance<string>(payload, "RuleName");
+            Assert.NotNull(activity);
+            Assert.Null(activity.Parent);
+        }
+
+        protected void AssertRemoveRuleStop(string name, object payload, Activity activity, Activity removeRuleActivity)
+        {
+            Assert.Equal("Microsoft.Azure.ServiceBus.RemoveRule.Stop", name);
+
+            AssertCommonStopPayloadProperties(payload);
+            GetPropertyValueFromAnonymousTypeInstance<string>(payload, "RuleName");
+
+            if (removeRuleActivity != null)
+            {
+                Assert.Equal(removeRuleActivity, activity);
+            }
+        }
+    }
+}

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/SubscriptionClientDiagnosticsTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/SubscriptionClientDiagnosticsTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
 
     public class SubscriptionClientDiagnosticsTests : DiagnosticsTests
     {
-        protected override string EntityName => $"{TestConstants.NonPartitionedTopicName}/{TestConstants.SubscriptionName}";
+        protected override string EntityName => $"{TestConstants.NonPartitionedTopicName}/Subscriptions/{TestConstants.SubscriptionName}";
         private SubscriptionClient subscriptionClient;
         private bool disposed;
 

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Microsoft.Azure.ServiceBus.UnitTests.csproj
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Microsoft.Azure.ServiceBus.UnitTests.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />


### PR DESCRIPTION
This change adds instrumentation with `DiagnosticSource` for public ServiceBus APIs:
- `MessageSender` (i.e. `QueueClient` and `TopicClient`): `SendAsync`, `ScueduleMessage` and `Cancel`
- `MessageReceiver`: `Receive`, `ReceiveDeffered`, `Peek`, `Abandon`, `Defer`, `Complete`, `DeadLetter`, `RenewLock`
- `MessageSession`: `AcceptMessageSession`
- `SubscriptionClient` : `AddRule`, `RemoveRule`, `GetRules`
- Message and session handlers

Tracing system (e.g. ApplicationInsights) may subscribe to ServiceBus DiagnosticSource and receive events about these operations including tracing context needed to correlate events and log any important information.

In absence of tracing system, diagnostics is disabled and performance cost of having it is ~zero.

We also introduce here telemetry correlation between producer and consumer: when diagnostics is enabled on a consumer, tracing context is injected into the message. When a producer receives such message, it extracts and restores context making it available for tracing system.

This also adds `Message.ExtractActivity()` public extension method that allows extracting the context from a message that is useful when handler API is NOT used to process messages.

Note: this change introduces 'standard' fields to pass tracing context through the queues to correlate telemetry:
`Diagnostic-Id` - uniquely identifies operation that sent message(s) to the queue
`Correlation-Context` - optional extended context (empty by default)

This is pretty similar to [HTTP Correlation protocol](https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/HttpCorrelationProtocol.md) implemented in .NET HTTP stack.

Users are encouraged to use these properties on all platforms, not only .NET. 

As a result of this change, a tracing system may enable diagnostics information and receive events it's interested in making sure tracing context is propagated through the service bus, without ANY changes in user code (except for non-handler processing).

Test coverage for the changes: 62.05 %

-------

Instrumentation approach backgound:
-  [Activity UserGuide](https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md)
- [DiagnosticSource UserGuide](https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/DiagnosticSourceUsersGuide.md)
- [.NET HTTP Client instrumentation](https://github.com/dotnet/corefx/blob/master/src/System.Net.Http/src/HttpDiagnosticsGuide.md)
- [HTTP Correlation protocol](https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/HttpCorrelationProtocol.md)
- [EventHub .NET Client instrumentation (WIP)](https://github.com/Azure/azure-event-hubs-dotnet/commit/8f934200e93810bbd6fe76b647ed2e5073085cce)

@nemakam @TomMilos  @brahmnes 
