### PR TITLE
Expose public constructors on exception classes

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/MessageLockLostException.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageLockLostException.cs
@@ -10,12 +10,12 @@ namespace Microsoft.Azure.ServiceBus
     /// </summary>
     public sealed class MessageLockLostException : ServiceBusException
     {
-        internal MessageLockLostException(string message)
+        public MessageLockLostException(string message)
             : this(message, null)
         {
         }
 
-        internal MessageLockLostException(string message, Exception innerException)
+        public MessageLockLostException(string message, Exception innerException)
             : base(false, message, innerException)
         {
         }

--- a/src/Microsoft.Azure.ServiceBus/MessagingEntityDisabledException.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessagingEntityDisabledException.cs
@@ -10,12 +10,12 @@ namespace Microsoft.Azure.ServiceBus
     /// </summary>
     public sealed class MessagingEntityDisabledException : ServiceBusException
     {
-        internal MessagingEntityDisabledException(string message)
+        public MessagingEntityDisabledException(string message)
             : this(message, null)
         {
         }
 
-        internal MessagingEntityDisabledException(string message, Exception innerException)
+        public MessagingEntityDisabledException(string message, Exception innerException)
             : base(false, message, innerException)
         {
         }

--- a/src/Microsoft.Azure.ServiceBus/MessagingEntityNotFoundException.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessagingEntityNotFoundException.cs
@@ -10,12 +10,12 @@ namespace Microsoft.Azure.ServiceBus
     /// </summary>
     public sealed class MessagingEntityNotFoundException : ServiceBusException
     {
-        internal MessagingEntityNotFoundException(string message)
+        public MessagingEntityNotFoundException(string message)
             : this(message, null)
         {
         }
 
-        internal MessagingEntityNotFoundException(string message, Exception innerException)
+        public MessagingEntityNotFoundException(string message, Exception innerException)
             : base(false, message, innerException)
         {
         }

--- a/src/Microsoft.Azure.ServiceBus/QuotaExceededException.cs
+++ b/src/Microsoft.Azure.ServiceBus/QuotaExceededException.cs
@@ -11,12 +11,12 @@ namespace Microsoft.Azure.ServiceBus
     /// </summary>
     public sealed class QuotaExceededException : ServiceBusException
     {
-        internal QuotaExceededException(string message)
+        public QuotaExceededException(string message)
             : this(message, null)
         {
         }
 
-        internal QuotaExceededException(string message, Exception innerException)
+        public QuotaExceededException(string message, Exception innerException)
             : base(false, message, innerException)
         {
         }

--- a/src/Microsoft.Azure.ServiceBus/ServerBusyException.cs
+++ b/src/Microsoft.Azure.ServiceBus/ServerBusyException.cs
@@ -10,12 +10,12 @@ namespace Microsoft.Azure.ServiceBus
     /// </summary>
     public sealed class ServerBusyException : ServiceBusException
     {
-        internal ServerBusyException(string message)
+        public ServerBusyException(string message)
             : this(message, null)
         {
         }
 
-        internal ServerBusyException(string message, Exception innerException)
+        public ServerBusyException(string message, Exception innerException)
             : base(true, message, innerException)
         {
         }

--- a/src/Microsoft.Azure.ServiceBus/ServiceBusTimeoutException.cs
+++ b/src/Microsoft.Azure.ServiceBus/ServiceBusTimeoutException.cs
@@ -10,11 +10,11 @@ namespace Microsoft.Azure.ServiceBus
     /// </summary>
     public class ServiceBusTimeoutException : ServiceBusException
     {
-        internal ServiceBusTimeoutException(string message) : this(message, null)
+        public ServiceBusTimeoutException(string message) : this(message, null)
         {
         }
 
-        internal ServiceBusTimeoutException(string message, Exception innerException) : base(true, message, innerException)
+        public ServiceBusTimeoutException(string message, Exception innerException) : base(true, message, innerException)
         {
         }
     }

--- a/src/Microsoft.Azure.ServiceBus/SessionLockLostException.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionLockLostException.cs
@@ -10,12 +10,12 @@ namespace Microsoft.Azure.ServiceBus
     /// </summary>
     public sealed class SessionLockLostException : ServiceBusException
     {
-        internal SessionLockLostException(string message)
+        public SessionLockLostException(string message)
             : this(message, null)
         {
         }
 
-        internal SessionLockLostException(string message, Exception innerException)
+        public SessionLockLostException(string message, Exception innerException)
             : base(false, message, innerException)
         {
         }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -168,9 +168,21 @@ namespace Microsoft.Azure.ServiceBus
         public System.TimeSpan MaxAutoRenewDuration { get; set; }
         public int MaxConcurrentCalls { get; set; }
     }
-    public sealed class MessageLockLostException : Microsoft.Azure.ServiceBus.ServiceBusException { }
-    public sealed class MessagingEntityDisabledException : Microsoft.Azure.ServiceBus.ServiceBusException { }
-    public sealed class MessagingEntityNotFoundException : Microsoft.Azure.ServiceBus.ServiceBusException { }
+    public sealed class MessageLockLostException : Microsoft.Azure.ServiceBus.ServiceBusException
+    {
+        public MessageLockLostException(string message) { }
+        public MessageLockLostException(string message, System.Exception innerException) { }
+    }
+    public sealed class MessagingEntityDisabledException : Microsoft.Azure.ServiceBus.ServiceBusException
+    {
+        public MessagingEntityDisabledException(string message) { }
+        public MessagingEntityDisabledException(string message, System.Exception innerException) { }
+    }
+    public sealed class MessagingEntityNotFoundException : Microsoft.Azure.ServiceBus.ServiceBusException
+    {
+        public MessagingEntityNotFoundException(string message) { }
+        public MessagingEntityNotFoundException(string message, System.Exception innerException) { }
+    }
     public sealed class NoRetry : Microsoft.Azure.ServiceBus.RetryPolicy
     {
         public NoRetry() { }
@@ -202,7 +214,11 @@ namespace Microsoft.Azure.ServiceBus
         public System.Threading.Tasks.Task SendAsync(System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Message> messageList) { }
         public override void UnregisterPlugin(string serviceBusPluginName) { }
     }
-    public sealed class QuotaExceededException : Microsoft.Azure.ServiceBus.ServiceBusException { }
+    public sealed class QuotaExceededException : Microsoft.Azure.ServiceBus.ServiceBusException
+    {
+        public QuotaExceededException(string message) { }
+        public QuotaExceededException(string message, System.Exception innerException) { }
+    }
     public enum ReceiveMode
     {
         PeekLock = 0,
@@ -239,7 +255,11 @@ namespace Microsoft.Azure.ServiceBus
         public Microsoft.Azure.ServiceBus.Filter Filter { get; set; }
         public string Name { get; set; }
     }
-    public sealed class ServerBusyException : Microsoft.Azure.ServiceBus.ServiceBusException { }
+    public sealed class ServerBusyException : Microsoft.Azure.ServiceBus.ServiceBusException
+    {
+        public ServerBusyException(string message) { }
+        public ServerBusyException(string message, System.Exception innerException) { }
+    }
     public class ServiceBusCommunicationException : Microsoft.Azure.ServiceBus.ServiceBusException
     {
         protected internal ServiceBusCommunicationException(string message) { }
@@ -273,7 +293,11 @@ namespace Microsoft.Azure.ServiceBus
         public override string Message { get; }
         public string ServiceBusNamespace { get; }
     }
-    public class ServiceBusTimeoutException : Microsoft.Azure.ServiceBus.ServiceBusException { }
+    public class ServiceBusTimeoutException : Microsoft.Azure.ServiceBus.ServiceBusException
+    {
+        public ServiceBusTimeoutException(string message) { }
+        public ServiceBusTimeoutException(string message, System.Exception innerException) { }
+    }
     public sealed class SessionClient : Microsoft.Azure.ServiceBus.ClientEntity, Microsoft.Azure.ServiceBus.IClientEntity, Microsoft.Azure.ServiceBus.ISessionClient
     {
         public SessionClient(Microsoft.Azure.ServiceBus.ServiceBusConnectionStringBuilder connectionStringBuilder, Microsoft.Azure.ServiceBus.ReceiveMode receiveMode = 0, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null, int prefetchCount = 0) { }
@@ -298,7 +322,11 @@ namespace Microsoft.Azure.ServiceBus
         public int MaxConcurrentSessions { get; set; }
         public System.TimeSpan MessageWaitTimeout { get; set; }
     }
-    public sealed class SessionLockLostException : Microsoft.Azure.ServiceBus.ServiceBusException { }
+    public sealed class SessionLockLostException : Microsoft.Azure.ServiceBus.ServiceBusException
+    {
+        public SessionLockLostException(string message) { }
+        public SessionLockLostException(string message, System.Exception innerException) { }
+    }
     public class SqlFilter : Microsoft.Azure.ServiceBus.Filter
     {
         public SqlFilter(string sqlExpression) { }


### PR DESCRIPTION
## Description

As discussed in https://github.com/Azure/azure-service-bus-dotnet/issues/373, this makes the constructors for exception classes public, so that when interfaces such as `IQueueClient` are mocked for unit testing, the mocks can throw the correct exceptions.

The API approval tests have been updated to reflect this change.