### PR TITLE
Bump dependencies to support ApiApprovals for .NETStandard

### DIFF
--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/APIApprovals.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/APIApprovals.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Linq;
-
-namespace Microsoft.Azure.ServiceBus.UnitTests.API
+﻿namespace Microsoft.Azure.ServiceBus.UnitTests.API
 {
+    using System;
+    using System.Linq;
     using ApprovalTests;
     using Xunit;
 

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/APIApprovals.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/APIApprovals.cs
@@ -1,6 +1,4 @@
-﻿#if NET461
-
-namespace Microsoft.Azure.ServiceBus.UnitTests.API
+﻿namespace Microsoft.Azure.ServiceBus.UnitTests.API
 {
     using System.Runtime.CompilerServices;
     using ApprovalTests;
@@ -10,14 +8,11 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.API
     public class ApiApprovals
     {
         [Fact]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        [UseReporter(typeof(DiffReporter), typeof(ClipboardReporter))]
         public void ApproveAzureServiceBus()
         {
             var assembly = typeof(Message).Assembly;
-            var publicApi = PublicApiGenerator.ApiGenerator.GeneratePublicApi(assembly, whitelistedNamespacePrefixes: new [] { "Microsoft.Azure.ServiceBus." });
+            var publicApi = PublicApiGenerator.ApiGenerator.GeneratePublicApi(assembly, whitelistedNamespacePrefixes: new[] { "Microsoft.Azure.ServiceBus." });
             Approvals.Verify(publicApi);
         }
     }
 }
-#endif

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/APIApprovals.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/APIApprovals.cs
@@ -1,8 +1,9 @@
-﻿namespace Microsoft.Azure.ServiceBus.UnitTests.API
+﻿using System;
+using System.Linq;
+
+namespace Microsoft.Azure.ServiceBus.UnitTests.API
 {
-    using System.Runtime.CompilerServices;
     using ApprovalTests;
-    using ApprovalTests.Reporters;
     using Xunit;
 
     public class ApiApprovals
@@ -11,8 +12,15 @@
         public void ApproveAzureServiceBus()
         {
             var assembly = typeof(Message).Assembly;
-            var publicApi = PublicApiGenerator.ApiGenerator.GeneratePublicApi(assembly, whitelistedNamespacePrefixes: new[] { "Microsoft.Azure.ServiceBus." });
+            var publicApi = Filter(PublicApiGenerator.ApiGenerator.GeneratePublicApi(assembly, whitelistedNamespacePrefixes: new[] { "Microsoft.Azure.ServiceBus." }));
             Approvals.Verify(publicApi);
+        }
+
+        string Filter(string text)
+        {
+            return string.Join(Environment.NewLine, text.Split(new[] {Environment.NewLine}, StringSplitOptions.RemoveEmptyEntries)
+                .Where(l => !l.StartsWith("[assembly: System.Runtime.Versioning.TargetFrameworkAttribute"))
+            );
         }
     }
 }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -1,8 +1,6 @@
 ﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute(@"Microsoft.Azure.ServiceBus.UnitTests,PublicKey=0024000004800000940000000602000000240000525341310004000001000100fdf4acac3b2244dd8a96737e5385b31414369dc3e42f371172127252856a0650793e1f5673a16d5d78e2ac852a104bc51e6f018dca44fdd26a219c27cb2b263956a80620223c8e9c2f8913c3c903e1e453e9e4e84098afdad5f4badb8c1ebe0a7b0a4b57a08454646a65886afe3e290a791ff3260099ce0edf0bdbccafadfeb6")]
 [assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
 [assembly: System.Runtime.InteropServices.GuidAttribute("a042adf0-ef65-4f87-b634-322a409f3d61")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.6.1", FrameworkDisplayName=".NET Framework 4.6.1")]
-
 namespace Microsoft.Azure.ServiceBus
 {
     

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApprovalTestConfig.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApprovalTestConfig.cs
@@ -1,7 +1,7 @@
 ﻿using ApprovalTests.Reporters;
 
 #if NET461
-[assembly: UseReporter(typeof(DiffReporter), typeof(AllFailingTestsClipboardReporter))]
+[assembly: UseReporter(typeof(XUnit2Reporter), typeof(AllFailingTestsClipboardReporter))]
 #else
-[assembly: UseReporter(typeof(DiffReporter))]
+[assembly: UseReporter(typeof(XUnit2Reporter))]
 #endif

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApprovalTestConfig.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApprovalTestConfig.cs
@@ -1,0 +1,7 @@
+﻿using ApprovalTests.Reporters;
+
+#if NET461
+[assembly: UseReporter(typeof(DiffReporter), typeof(AllFailingTestsClipboardReporter))]
+#else
+[assembly: UseReporter(typeof(DiffReporter))]
+#endif

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Microsoft.Azure.ServiceBus.UnitTests.csproj
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Microsoft.Azure.ServiceBus.UnitTests.csproj
@@ -18,11 +18,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="PublicApiGenerator" Version="6.5.0" />
+    <PackageReference Include="ApprovalTests" Version="3.0.13" NoWarn="NU1701" />
+    <PackageReference Include="ApprovalUtilities" Version="3.0.13" NoWarn="NU1701" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
   </ItemGroup>
 
@@ -31,8 +34,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="ApprovalTests" Version="3.0.13" />
-    <PackageReference Include="PublicApiGenerator" Version="6.4.0" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.1.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Enable running API approvals against .NET Standard as well.
