### PR TITLE
Message tostring issue 407

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Message.cs
+++ b/src/Microsoft.Azure.ServiceBus/Message.cs
@@ -290,7 +290,7 @@ namespace Microsoft.Azure.ServiceBus
         /// <returns>The string representation of the current message.</returns>
         public override string ToString()
         {
-            return string.Format(CultureInfo.CurrentCulture, $"{{MessageId:{this.MessageId}}}");
+            return string.Format(CultureInfo.CurrentCulture, "{{MessageId:{0}}}", this.MessageId);
         }
 
         /// <summary>Clones a message, so that it is possible to send a clone of an already received 

--- a/src/Microsoft.Azure.ServiceBus/Primitives/SharedAccessSignatureToken.cs
+++ b/src/Microsoft.Azure.ServiceBus/Primitives/SharedAccessSignatureToken.cs
@@ -105,9 +105,8 @@ namespace Microsoft.Azure.ServiceBus.Primitives
 
         static string GetAudienceFromToken(string token)
         {
-            string audience;
             IDictionary<string, string> decodedToken = Decode(token, Decoder, Decoder, SasKeyValueSeparator, SasPairSeparator);
-            if (!decodedToken.TryGetValue(SignedResourceFullFieldName, out audience))
+            if (!decodedToken.TryGetValue(SignedResourceFullFieldName, out var audience))
             {
                 throw new FormatException(Resources.TokenMissingAudience);
             }
@@ -117,9 +116,8 @@ namespace Microsoft.Azure.ServiceBus.Primitives
 
         static DateTime GetExpirationDateTimeUtcFromToken(string token)
         {
-            string expiresIn;
             IDictionary<string, string> decodedToken = Decode(token, Decoder, Decoder, SasKeyValueSeparator, SasPairSeparator);
-            if (!decodedToken.TryGetValue(SignedExpiry, out expiresIn))
+            if (!decodedToken.TryGetValue(SignedExpiry, out var expiresIn))
             {
                 throw new FormatException(Resources.TokenMissingExpiresOn);
             }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/MessageTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/MessageTests.cs
@@ -145,5 +145,21 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 }
             }
         }
+
+        [Theory]
+        [DisplayTestMethodName]
+        [InlineData(null)]
+        [InlineData("123")]
+        [InlineData("jøbber-nå")]
+        public void Should_return_string_representation_of_message(string id)
+        {
+            var message = new Message();
+            if (id != null)
+            {
+                message.MessageId = id;
+            }
+            var result = message.ToString();
+            Assert.Equal($"{{MessageId:{id}}}", result);
+        }
     }
 }


### PR DESCRIPTION
Fixes #407 by replacing string interpolation with regular `string.Format()` and `CultureInfo.CurrentCulture`.

Added unit test to cover a few scenarios, including no message ID.