### PR TITLE
Message TTL always had a value set

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
             amqpMessage.Properties.GroupId = sbMessage.SessionId;
             amqpMessage.Properties.ReplyToGroupId = sbMessage.ReplyToSessionId;
 
-            if (sbMessage.TimeToLive != null)
+            if (sbMessage.TimeToLive != TimeSpan.MaxValue)
             {
                 amqpMessage.Header.Ttl = (uint)sbMessage.TimeToLive.TotalMilliseconds;
                 amqpMessage.Properties.CreationTime = DateTime.UtcNow;

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/AmqpConverterTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/AmqpConverterTests.cs
@@ -84,6 +84,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             var replyTo = Guid.NewGuid().ToString();
             var replyToSessionId = Guid.NewGuid().ToString();
             var publisher = Guid.NewGuid().ToString();
+            var timeToLive = TimeSpan.FromDays(5);
 
             var sbMessage = new Message(messageBody)
             {
@@ -95,7 +96,8 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 To = to,
                 ContentType = contentType,
                 ReplyTo = replyTo,
-                ReplyToSessionId = replyToSessionId
+                ReplyToSessionId = replyToSessionId,
+                TimeToLive = timeToLive
             };
             sbMessage.UserProperties.Add("UserProperty", "SomeUserProperty");
 
@@ -113,6 +115,18 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             Assert.Equal(contentType, convertedSbMessage.ContentType);
             Assert.Equal(replyTo, convertedSbMessage.ReplyTo);
             Assert.Equal(replyToSessionId, convertedSbMessage.ReplyToSessionId);
+            Assert.Equal(timeToLive, convertedSbMessage.TimeToLive);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        void SB_message_with_no_TTL_results_in_empty_Ampq_TTL()
+        {
+            var sbMessage = new Message();
+
+            var amqpMessage = AmqpMessageConverter.SBMessageToAmqpMessage(sbMessage);
+
+            Assert.Null(amqpMessage.Header.Ttl);
         }
     }
 }


### PR DESCRIPTION
This broke the ability to use the default TTL value on the underlying entity.

This fixes #424
