### PR TITLE
expose the inner MessageReceiver  / MessageSender

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/QueueClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/QueueClient.cs
@@ -210,7 +210,7 @@ namespace Microsoft.Azure.ServiceBus
         /// </summary>
         public override IList<ServiceBusPlugin> RegisteredPlugins => this.InnerSender.RegisteredPlugins;
 
-        internal MessageSender InnerSender
+        public MessageSender InnerSender
         {
             get
             {
@@ -235,7 +235,7 @@ namespace Microsoft.Azure.ServiceBus
             }
         }
 
-        internal MessageReceiver InnerReceiver
+        public MessageReceiver InnerReceiver
         {
             get
             {


### PR DESCRIPTION
 In our remakrs
<remarks>Use <see cref="MessageSender"/> or <see cref="MessageReceiver"/> for advanced set of functionality.

so these should be exposed ?

Otherwise there is no way to renew a message lock

## Description

This following list is used to make sure that common guidelines for a pull request are followed.

- **Read the [contribution guidelines](./CONTRIBUTING.md).** 
- Make title of the pull request clear and informative. 
- Link to appropriate [issue](https://github.com/Azure/azure-service-bus-dotnet/issues).
- Include test coverage for the changes.
