### PR TITLE
Add a range to AMQP dependency package

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
+++ b/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
@@ -30,7 +30,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.1.3" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="[2.1.3, 3.0.0)" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.1.0-preview" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.17.2" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.1" />

--- a/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
+++ b/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Amqp" Version="[2.1.3, 3.0.0)" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.1.0-preview" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.17.2" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="[3.17.2, 4.0.0)" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.2.0-preview2-41113220915" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />


### PR DESCRIPTION
Fixes #432 (Microsoft.Azure.Amqp tight to a specific version).

I'm not sure about other dependecies, but those are also hardcoded to specific versions rather than a range. That doesn't look right IMO.

For example:
`Microsoft.Azure.Services.AppAuthentication` is using `1.1.0-preview`. The moment there's a preview2, this will be broken. Same with the rest. Thoughts?