### PR TITLE
Feature - Send-Via / TransferSender to send messages across entities in a transaction

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Amqp/ActiveClientLinkManager.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/ActiveClientLinkManager.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
     using System;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.ServiceBus.Primitives;
 
     sealed class ActiveClientLinkManager
     {
@@ -81,25 +82,31 @@ namespace Microsoft.Azure.ServiceBus.Amqp
             try
             {
                 var cbsLink = activeClientLinkObject.Connection.Extensions.Find<AmqpCbsLink>() ?? new AmqpCbsLink(activeClientLinkObject.Connection);
+                DateTime cbsTokenExpiresAtUtc = DateTime.MaxValue;
 
-                MessagingEventSource.Log.AmqpSendAuthenticationTokenStart(activeClientLinkObject.EndpointUri, activeClientLinkObject.Audience, activeClientLinkObject.Audience, activeClientLinkObject.RequiredClaims);
+                foreach (var resource in activeClientLinkObject.Audience)
+                {
+                    MessagingEventSource.Log.AmqpSendAuthenticationTokenStart(activeClientLinkObject.EndpointUri, resource, resource, activeClientLinkObject.RequiredClaims);
 
-                var renewTokenTask = this.retryPolicy.RunOperation(
-                    async () =>
-                    {
-                        activeClientLinkObject.AuthorizationValidUntilUtc = await cbsLink.SendTokenAsync(
-                            this.cbsTokenProvider,
-                            activeClientLinkObject.EndpointUri,
-                            activeClientLinkObject.Audience,
-                            activeClientLinkObject.Audience,
-                            activeClientLinkObject.RequiredClaims,
-                            ActiveClientLinkManager.SendTokenTimeout).ConfigureAwait(false);
-                    }, ActiveClientLinkManager.SendTokenTimeout);
+                    await this.retryPolicy.RunOperation(
+                        async () =>
+                        {
+                            cbsTokenExpiresAtUtc = TimeoutHelper.Min(
+                                cbsTokenExpiresAtUtc, 
+                                await cbsLink.SendTokenAsync(
+                                    this.cbsTokenProvider,
+                                    activeClientLinkObject.EndpointUri,
+                                    resource,
+                                    resource,
+                                    activeClientLinkObject.RequiredClaims,
+                                    ActiveClientLinkManager.SendTokenTimeout).ConfigureAwait(false));
+                        }, ActiveClientLinkManager.SendTokenTimeout).ConfigureAwait(false);
 
-                await renewTokenTask.ConfigureAwait(false);
+                    MessagingEventSource.Log.AmqpSendAuthenticationTokenStop();
+                }
+
+                activeClientLinkObject.AuthorizationValidUntilUtc = cbsTokenExpiresAtUtc;
                 this.SetRenewCbsTokenTimer(activeClientLinkObject);
-
-                MessagingEventSource.Log.AmqpSendAuthenticationTokenStop();
             }
             catch (Exception e)
             {

--- a/src/Microsoft.Azure.ServiceBus/Amqp/ActiveClientLinkManager.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/ActiveClientLinkManager.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Azure.ServiceBus.Amqp
     using System;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.ServiceBus.Primitives;
 
     sealed class ActiveClientLinkManager
     {

--- a/src/Microsoft.Azure.ServiceBus/Amqp/ActiveClientLinkObject.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/ActiveClientLinkObject.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
     {
         readonly string[] requiredClaims;
 
-        protected ActiveClientLinkObject(AmqpObject amqpLinkObject,  Uri endpointUri, string audience, string[] requiredClaims, DateTime authorizationValidUntilUtc)
+        protected ActiveClientLinkObject(AmqpObject amqpLinkObject,  Uri endpointUri, string[] audience, string[] requiredClaims, DateTime authorizationValidUntilUtc)
         {
             this.LinkObject = amqpLinkObject;
             this.EndpointUri = endpointUri;
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
 
         public AmqpObject LinkObject { get; }
 
-        public string Audience { get; }
+        public string[] Audience { get; }
 
         public Uri EndpointUri { get; }
 

--- a/src/Microsoft.Azure.ServiceBus/Amqp/ActiveRequestResponseLink.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/ActiveRequestResponseLink.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
 
     sealed class ActiveRequestResponseLink : ActiveClientLinkObject
     {
-        public ActiveRequestResponseLink(RequestResponseAmqpLink link, Uri endpointUri, string audience, string[] requiredClaims, DateTime authorizationValidUntilUtc)
+        public ActiveRequestResponseLink(RequestResponseAmqpLink link, Uri endpointUri, string[] audience, string[] requiredClaims, DateTime authorizationValidUntilUtc)
             : base(link, endpointUri, audience, requiredClaims, authorizationValidUntilUtc)
         {
             this.Link = link;

--- a/src/Microsoft.Azure.ServiceBus/Amqp/ActiveSendReceiveClientLink.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/ActiveSendReceiveClientLink.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
 
     sealed class ActiveSendReceiveClientLink : ActiveClientLinkObject
     {
-        public ActiveSendReceiveClientLink(AmqpLink link, Uri endpointUri, string audience, string[] requiredClaims, DateTime authorizationValidUntilUtc)
+        public ActiveSendReceiveClientLink(AmqpLink link, Uri endpointUri, string[] audience, string[] requiredClaims, DateTime authorizationValidUntilUtc)
             : base(link, endpointUri, audience, requiredClaims, authorizationValidUntilUtc)
         {
             this.Link = link;

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpClientConstants.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpClientConstants.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
         public static readonly AmqpSymbol AttachEpoch = AmqpConstants.Vendor + ":epoch";
         public static readonly AmqpSymbol BatchFlushIntervalName = AmqpConstants.Vendor + ":batch-flush-interval";
         public static readonly AmqpSymbol EntityTypeName = AmqpConstants.Vendor + ":entity-type";
+        public static readonly AmqpSymbol TransferDestinationAddress = AmqpConstants.Vendor + ":transfer-destination-address";
         public static readonly AmqpSymbol TimeoutName = AmqpConstants.Vendor + ":timeout";
         public static readonly AmqpSymbol TrackingIdName = AmqpConstants.Vendor + ":tracking-id";
 

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
         const string PublisherName = "x-opt-publisher";
         const string PartitionKeyName = "x-opt-partition-key";
         const string PartitionIdName = "x-opt-partition-id";
+        const string ViaPartitionKeyName = "x-opt-via-partition-key";
         const string DeadLetterSourceName = "x-opt-deadletter-source";
         const string TimeSpanName = AmqpConstants.Vendor + ":timespan";
         const string UriName = AmqpConstants.Vendor + ":uri";
@@ -87,6 +88,12 @@ namespace Microsoft.Azure.ServiceBus.Amqp
                     firstMessage.PartitionKey;
             }
 
+            if (firstMessage.ViaPartitionKey != null)
+            {
+                amqpMessage.MessageAnnotations.Map[AmqpMessageConverter.ViaPartitionKeyName] =
+                    firstMessage.ViaPartitionKey;
+            }
+
             amqpMessage.Batchable = batchable;
             return amqpMessage;
         }
@@ -127,6 +134,11 @@ namespace Microsoft.Azure.ServiceBus.Amqp
             if (sbMessage.PartitionKey != null)
             {
                 amqpMessage.MessageAnnotations.Map.Add(PartitionKeyName, sbMessage.PartitionKey);
+            }
+
+            if (sbMessage.ViaPartitionKey != null)
+            {
+                amqpMessage.MessageAnnotations.Map.Add(ViaPartitionKeyName, sbMessage.ViaPartitionKey);
             }
 
             if (sbMessage.UserProperties != null && sbMessage.UserProperties.Count > 0)
@@ -304,6 +316,9 @@ namespace Microsoft.Azure.ServiceBus.Amqp
                             break;
                         case PartitionIdName:
                             sbMessage.SystemProperties.PartitionId = (short)pair.Value;
+                            break;
+                        case ViaPartitionKeyName:
+                            sbMessage.ViaPartitionKey = (string)pair.Value;
                             break;
                         case DeadLetterSourceName:
                             sbMessage.SystemProperties.DeadLetterSource = (string)pair.Value;

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpRequestResponseLinkCreator.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpRequestResponseLinkCreator.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Azure.ServiceBus.Amqp
     {
         readonly string entityPath;
 
-        public AmqpRequestResponseLinkCreator(string entityPath, ServiceBusConnection serviceBusConnection, Uri endpointAddress, string[] requiredClaims, ICbsTokenProvider cbsTokenProvider, AmqpLinkSettings linkSettings, string clientId)
-            : base(entityPath, serviceBusConnection, endpointAddress, requiredClaims, cbsTokenProvider, linkSettings, clientId)
+        public AmqpRequestResponseLinkCreator(string entityPath, ServiceBusConnection serviceBusConnection, Uri endpointAddress, string[] audience, string[] requiredClaims, ICbsTokenProvider cbsTokenProvider, AmqpLinkSettings linkSettings, string clientId)
+            : base(entityPath, serviceBusConnection, endpointAddress, audience, requiredClaims, cbsTokenProvider, linkSettings, clientId)
         {
             this.entityPath = entityPath;
         }

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpSendReceiveLinkCreator.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpSendReceiveLinkCreator.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Azure.ServiceBus.Amqp
 
     internal class AmqpSendReceiveLinkCreator : AmqpLinkCreator
     {
-        public AmqpSendReceiveLinkCreator(string entityPath, ServiceBusConnection serviceBusConnection, Uri endpointAddress, string[] requiredClaims, ICbsTokenProvider cbsTokenProvider, AmqpLinkSettings linkSettings, string clientId)
-            : base(entityPath, serviceBusConnection, endpointAddress, requiredClaims, cbsTokenProvider, linkSettings, clientId)
+        public AmqpSendReceiveLinkCreator(string entityPath, ServiceBusConnection serviceBusConnection, Uri endpointAddress, string[] audience, string[] requiredClaims, ICbsTokenProvider cbsTokenProvider, AmqpLinkSettings linkSettings, string clientId)
+            : base(entityPath, serviceBusConnection, endpointAddress, audience, requiredClaims, cbsTokenProvider, linkSettings, clientId)
         {
         }
 

--- a/src/Microsoft.Azure.ServiceBus/Amqp/ManagementConstants.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/ManagementConstants.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
             public static readonly MapKey SessionId = new MapKey("session-id");
             public static readonly MapKey MessageId = new MapKey("message-id");
             public static readonly MapKey PartitionKey = new MapKey("partition-key");
+            public static readonly MapKey ViaPartitionKey = new MapKey("via-partition-key");
 
             public static readonly MapKey ReceiverSettleMode = new MapKey("receiver-settle-mode");
             public static readonly MapKey Message = new MapKey("message");

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -1524,14 +1524,23 @@ namespace Microsoft.Azure.ServiceBus.Core
 
             var endpointUri = new Uri(this.ServiceBusConnection.Endpoint, this.Path);
             var claims = new[] { ClaimConstants.Listen };
-            var amqpSendReceiveLinkCreator = new AmqpSendReceiveLinkCreator(this.Path, this.ServiceBusConnection, endpointUri, claims, this.CbsTokenProvider, amqpLinkSettings, this.ClientId);
+            var amqpSendReceiveLinkCreator = new AmqpSendReceiveLinkCreator(
+                this.Path, 
+                this.ServiceBusConnection, 
+                endpointUri, 
+                new string[] { endpointUri.AbsoluteUri }, 
+                claims, 
+                this.CbsTokenProvider, 
+                amqpLinkSettings, 
+                this.ClientId);
+
             Tuple<AmqpObject, DateTime> linkDetails = await amqpSendReceiveLinkCreator.CreateAndOpenAmqpLinkAsync().ConfigureAwait(false);
 
             var receivingAmqpLink = (ReceivingAmqpLink) linkDetails.Item1;
             var activeSendReceiveClientLink = new ActiveSendReceiveClientLink(
                 receivingAmqpLink,
                 endpointUri,
-                endpointUri.AbsoluteUri,
+                new string[] { endpointUri.AbsoluteUri },
                 claims,
                 linkDetails.Item2);
 
@@ -1553,14 +1562,23 @@ namespace Microsoft.Azure.ServiceBus.Core
 
             var endpointUri = new Uri(this.ServiceBusConnection.Endpoint, entityPath);
             string[] claims = { ClaimConstants.Manage, ClaimConstants.Listen };
-            var amqpRequestResponseLinkCreator = new AmqpRequestResponseLinkCreator(entityPath, this.ServiceBusConnection, endpointUri, claims, this.CbsTokenProvider, amqpLinkSettings, this.ClientId);
+            var amqpRequestResponseLinkCreator = new AmqpRequestResponseLinkCreator(
+                entityPath, 
+                this.ServiceBusConnection, 
+                endpointUri,
+                new string[] { endpointUri.AbsoluteUri },
+                claims, 
+                this.CbsTokenProvider, 
+                amqpLinkSettings, 
+                this.ClientId);
+
             var linkDetails = await amqpRequestResponseLinkCreator.CreateAndOpenAmqpLinkAsync().ConfigureAwait(false);
 
             var requestResponseAmqpLink = (RequestResponseAmqpLink)linkDetails.Item1;
             var activeRequestResponseClientLink = new ActiveRequestResponseLink(
                 requestResponseAmqpLink,
                 endpointUri,
-                endpointUri.AbsoluteUri,
+                new string[] { endpointUri.AbsoluteUri },
                 claims,
                 linkDetails.Item2);
             this.clientLinkManager.SetActiveRequestResponseLink(activeRequestResponseClientLink);

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Azure.ServiceBus.Core
         readonly bool ownsConnection;
         readonly ActiveClientLinkManager clientLinkManager;
         readonly ServiceBusDiagnosticSource diagnosticSource;
+        readonly bool isViaSender;
+        readonly string transferDestinationPath;
 
         /// <summary>
         /// Creates a new AMQP MessageSender.
@@ -65,7 +67,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             string connectionString,
             string entityPath,
             RetryPolicy retryPolicy = null)
-            : this(entityPath, null, new ServiceBusConnection(connectionString), null, retryPolicy)
+            : this(entityPath, null, null, new ServiceBusConnection(connectionString), null, retryPolicy)
         {
             if (string.IsNullOrWhiteSpace(connectionString))
             {
@@ -90,7 +92,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             ITokenProvider tokenProvider,
             TransportType transportType = TransportType.Amqp,
             RetryPolicy retryPolicy = null)
-            : this(entityPath, null, new ServiceBusConnection(endpoint, transportType, retryPolicy) {TokenProvider = tokenProvider}, null, retryPolicy)
+            : this(entityPath, null, null, new ServiceBusConnection(endpoint, transportType, retryPolicy) {TokenProvider = tokenProvider}, null, retryPolicy)
         {
             this.ownsConnection = true;
         }
@@ -105,13 +107,37 @@ namespace Microsoft.Azure.ServiceBus.Core
             ServiceBusConnection serviceBusConnection,
             string entityPath,
             RetryPolicy retryPolicy = null)
-            : this(entityPath, null, serviceBusConnection, null, retryPolicy)
+            : this(entityPath, null, null, serviceBusConnection, null, retryPolicy)
+        {
+            this.ownsConnection = false;
+        }
+
+        /// <summary>
+        /// Creates a ViaMessageSender. This can be used to send messages to a destination entity via another another entity.
+        /// </summary>
+        /// <param name="serviceBusConnection">Connection object to the service bus namespace.</param>
+        /// <param name="entityPath">The final destination of the message.</param>
+        /// <param name="viaEntityPath">The first destination of the message.</param>
+        /// <param name="retryPolicy">The <see cref="RetryPolicy"/> that will be used when communicating with Service Bus. Defaults to <see cref="RetryPolicy.Default"/></param>
+        /// <remarks>
+        /// This is mainly to be used when sending messages in a transaction. 
+        /// When messages need to be sent across entities in a single transaction, this can be used to ensure
+        /// all the messages land initially in the same entity/partition for local transactions, and then 
+        /// let service bus handle transferring the message to the actual destination.
+        /// </remarks>
+        public MessageSender(
+            ServiceBusConnection serviceBusConnection,
+            string entityPath,
+            string viaEntityPath,
+            RetryPolicy retryPolicy = null)
+            :this(viaEntityPath, entityPath, null, serviceBusConnection, null, retryPolicy)
         {
             this.ownsConnection = false;
         }
 
         internal MessageSender(
             string entityPath,
+            string transferDestinationPath,
             MessagingEntityType? entityType,
             ServiceBusConnection serviceBusConnection,
             ICbsTokenProvider cbsTokenProvider,
@@ -146,6 +172,12 @@ namespace Microsoft.Azure.ServiceBus.Core
             this.RequestResponseLinkManager = new FaultTolerantAmqpObject<RequestResponseAmqpLink>(this.CreateRequestResponseLinkAsync, CloseRequestResponseSession);
             this.clientLinkManager = new ActiveClientLinkManager(this, this.CbsTokenProvider);
             this.diagnosticSource = new ServiceBusDiagnosticSource(entityPath, serviceBusConnection.Endpoint);
+
+            if (!string.IsNullOrWhiteSpace(transferDestinationPath))
+            {
+                this.isViaSender = true;
+                this.transferDestinationPath = transferDestinationPath;
+            }
 
             MessagingEventSource.Log.MessageSenderCreateStop(serviceBusConnection.Endpoint.Authority, entityPath, this.ClientId);
         }
@@ -252,6 +284,11 @@ namespace Microsoft.Azure.ServiceBus.Core
                     "Cannot schedule messages in the past");
             }
 
+            if (this.isViaSender && Transaction.Current != null)
+            {
+                throw new ServiceBusException(false, $"{nameof(ScheduleMessageAsync)} method is not supported in a Via-Sender.");
+            }
+
             message.ScheduledEnqueueTimeUtc = scheduleEnqueueTimeUtc.UtcDateTime;
             MessageSender.ValidateMessage(message);
             MessagingEventSource.Log.ScheduleMessageStart(this.ClientId, scheduleEnqueueTimeUtc);
@@ -298,6 +335,11 @@ namespace Microsoft.Azure.ServiceBus.Core
         public async Task CancelScheduledMessageAsync(long sequenceNumber)
         {
             this.ThrowIfClosed();
+            if (Transaction.Current != null)
+            {
+                throw new ServiceBusException(false, $"{nameof(CancelScheduledMessageAsync)} method is not supported within a transaction.");
+            }
+
             MessagingEventSource.Log.CancelScheduledMessageStart(this.ClientId, sequenceNumber);
 
             bool isDiagnosticSourceEnabled = ServiceBusDiagnosticSource.IsEnabled();
@@ -554,6 +596,11 @@ namespace Microsoft.Azure.ServiceBus.Core
                     {
                         entry[ManagementConstants.Properties.PartitionKey] = message.PartitionKey;
                     }
+
+                    if (!string.IsNullOrWhiteSpace(message.ViaPartitionKey))
+                    {
+                        entry[ManagementConstants.Properties.ViaPartitionKey] = message.ViaPartitionKey;
+                    }
                 }
 
                 request.Map[ManagementConstants.Properties.Messages] = new List<AmqpMap> { entry };
@@ -614,15 +661,28 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
 
             var endpointUri = new Uri(this.ServiceBusConnection.Endpoint, this.Path);
+
+            string[] audience;
+            if (this.isViaSender)
+            {
+                var transferDestinationEndpointUri = new Uri(this.ServiceBusConnection.Endpoint, this.transferDestinationPath);
+                audience = new string[] { endpointUri.AbsoluteUri, transferDestinationEndpointUri.AbsoluteUri };
+                amqpLinkSettings.AddProperty(AmqpClientConstants.TransferDestinationAddress, this.transferDestinationPath);
+            }
+            else
+            {
+                audience = new string[] { endpointUri.AbsoluteUri };
+            }
+
             string[] claims = {ClaimConstants.Send};
-            var amqpSendReceiveLinkCreator = new AmqpSendReceiveLinkCreator(this.Path, this.ServiceBusConnection, endpointUri, claims, this.CbsTokenProvider, amqpLinkSettings, this.ClientId);
+            var amqpSendReceiveLinkCreator = new AmqpSendReceiveLinkCreator(this.Path, this.ServiceBusConnection, endpointUri, audience, claims, this.CbsTokenProvider, amqpLinkSettings, this.ClientId);
             Tuple<AmqpObject, DateTime> linkDetails = await amqpSendReceiveLinkCreator.CreateAndOpenAmqpLinkAsync().ConfigureAwait(false);
 
             var sendingAmqpLink = (SendingAmqpLink) linkDetails.Item1;
             var activeSendReceiveClientLink = new ActiveSendReceiveClientLink(
                 sendingAmqpLink,
                 endpointUri,
-                endpointUri.AbsoluteUri,
+                audience,
                 claims,
                 linkDetails.Item2);
 
@@ -639,11 +699,25 @@ namespace Microsoft.Azure.ServiceBus.Core
             amqpLinkSettings.AddProperty(AmqpClientConstants.EntityTypeName, AmqpClientConstants.EntityTypeManagement);
 
             var endpointUri = new Uri(this.ServiceBusConnection.Endpoint, entityPath);
+
+            string[] audience;
+            if (this.isViaSender)
+            {
+                var transferDestinationEndpointUri = new Uri(this.ServiceBusConnection.Endpoint, this.transferDestinationPath);
+                audience = new string[] { endpointUri.AbsoluteUri, transferDestinationEndpointUri.AbsoluteUri };
+                amqpLinkSettings.AddProperty(AmqpClientConstants.TransferDestinationAddress, this.transferDestinationPath);
+            }
+            else
+            {
+                audience = new string[] { endpointUri.AbsoluteUri };
+            }
+
             string[] claims = { ClaimConstants.Manage, ClaimConstants.Send };
             var amqpRequestResponseLinkCreator = new AmqpRequestResponseLinkCreator(
                 entityPath,
                 this.ServiceBusConnection,
                 endpointUri,
+                audience,
                 claims,
                 this.CbsTokenProvider,
                 amqpLinkSettings,
@@ -656,7 +730,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             var activeRequestResponseClientLink = new ActiveRequestResponseLink(
                 requestResponseAmqpLink,
                 endpointUri,
-                endpointUri.AbsoluteUri,
+                audience,
                 claims,
                 linkDetails.Item2);
             this.clientLinkManager.SetActiveRequestResponseLink(activeRequestResponseClientLink);

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
@@ -286,7 +286,7 @@ namespace Microsoft.Azure.ServiceBus.Core
 
             if (this.isViaSender && Transaction.Current != null)
             {
-                throw new ServiceBusException(false, $"{nameof(ScheduleMessageAsync)} method is not supported in a Via-Sender.");
+                throw new ServiceBusException(false, $"{nameof(ScheduleMessageAsync)} method is not supported in a Via-Sender with transactions.");
             }
 
             message.ScheduledEnqueueTimeUtc = scheduleEnqueueTimeUtc.UtcDateTime;

--- a/src/Microsoft.Azure.ServiceBus/Primitives/TimeoutHelper.cs
+++ b/src/Microsoft.Azure.ServiceBus/Primitives/TimeoutHelper.cs
@@ -60,6 +60,16 @@ namespace Microsoft.Azure.ServiceBus.Primitives
             return Ticks.ToTimeSpan((Ticks.FromTimeSpan(timeout) / factor) + 1);
         }
 
+        public static DateTime Min(DateTime first, DateTime second)
+        {
+            if (first < second)
+            {
+                return first;
+            }
+
+            return second;
+        }
+
         public static void ThrowIfNegativeArgument(TimeSpan timeout)
         {
             ThrowIfNegativeArgument(timeout, nameof(timeout));

--- a/src/Microsoft.Azure.ServiceBus/QueueClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/QueueClient.cs
@@ -236,6 +236,7 @@ namespace Microsoft.Azure.ServiceBus
                         {
                             this.innerSender = new MessageSender(
                                 this.QueueName,
+                                null,
                                 MessagingEntityType.Queue,
                                 this.ServiceBusConnection,
                                 this.CbsTokenProvider,

--- a/src/Microsoft.Azure.ServiceBus/TopicClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/TopicClient.cs
@@ -151,6 +151,7 @@ namespace Microsoft.Azure.ServiceBus
                         {
                             this.innerSender = new MessageSender(
                                 this.TopicName,
+                                null,
                                 MessagingEntityType.Topic,
                                 this.ServiceBusConnection,
                                 this.CbsTokenProvider,

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -521,6 +521,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         public MessageSender(string connectionString, string entityPath, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null) { }
         public MessageSender(string endpoint, string entityPath, Microsoft.Azure.ServiceBus.Primitives.ITokenProvider tokenProvider, Microsoft.Azure.ServiceBus.TransportType transportType = 0, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null) { }
         public MessageSender(Microsoft.Azure.ServiceBus.ServiceBusConnection serviceBusConnection, string entityPath, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null) { }
+        public MessageSender(Microsoft.Azure.ServiceBus.ServiceBusConnection serviceBusConnection, string entityPath, string viaEntityPath, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null) { }
         public override System.TimeSpan OperationTimeout { get; set; }
         public override string Path { get; }
         public override System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin> RegisteredPlugins { get; }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/AmqpConverterTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/AmqpConverterTests.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             var messageBody = Encoding.UTF8.GetBytes("hello");
             var messageId = Guid.NewGuid().ToString();
             var partitionKey = Guid.NewGuid().ToString();
+            var viaPartitionKey = Guid.NewGuid().ToString();
             var sessionId = Guid.NewGuid().ToString();
             var correlationId = Guid.NewGuid().ToString();
             var label = Guid.NewGuid().ToString();
@@ -90,6 +91,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             {
                 MessageId = messageId,
                 PartitionKey = partitionKey,
+                ViaPartitionKey = viaPartitionKey,
                 SessionId = sessionId,
                 CorrelationId = correlationId,
                 Label = label,
@@ -108,6 +110,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             Assert.Equal(messageBody, convertedSbMessage.Body);
             Assert.Equal(messageId, convertedSbMessage.MessageId);
             Assert.Equal(partitionKey, convertedSbMessage.PartitionKey);
+            Assert.Equal(viaPartitionKey, convertedSbMessage.ViaPartitionKey);
             Assert.Equal(sessionId, convertedSbMessage.SessionId);
             Assert.Equal(correlationId, convertedSbMessage.CorrelationId);
             Assert.Equal(label, convertedSbMessage.Label);

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/MessageTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/MessageTests.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             var messageBody = Encoding.UTF8.GetBytes("test");
             var messageId = Guid.NewGuid().ToString();
             var partitionKey = Guid.NewGuid().ToString();
+            var viaPartitionKey = Guid.NewGuid().ToString();
             var sessionId = Guid.NewGuid().ToString();
             var correlationId = Guid.NewGuid().ToString();
             var label = Guid.NewGuid().ToString();
@@ -31,6 +32,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             {
                 MessageId = messageId,
                 PartitionKey = partitionKey,
+                ViaPartitionKey = viaPartitionKey,
                 SessionId = sessionId,
                 CorrelationId = correlationId,
                 Label = label,
@@ -49,6 +51,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             Assert.Equal("SomeUserProperty", clone.UserProperties["UserProperty"]);
             Assert.Equal(messageId, clone.MessageId);
             Assert.Equal(partitionKey, clone.PartitionKey);
+            Assert.Equal(viaPartitionKey, clone.ViaPartitionKey);
             Assert.Equal(sessionId, clone.SessionId);
             Assert.Equal(correlationId, clone.CorrelationId);
             Assert.Equal(label, clone.Label);

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/TestUtility.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/TestUtility.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             {
                 throw new InvalidOperationException($"'{TestConstants.ConnectionStringEnvironmentVariable}' environment variable was not found!");
             }
-            envConnectionString = "Endpoint=sb://contoso.servicebus.onebox.windows-int.net/;SharedAccessKeyName=DefaultNamespaceSasAllKeyName;SharedAccessKey=8864/auVd3qDC75iTjBL1GJ4D2oXC6bIttRd0jzDZ+g=";
+
             // Validate the connection string
             NamespaceConnectionString = new ServiceBusConnectionStringBuilder(envConnectionString).ToString();
             WebSocketsNamespaceConnectionString = new ServiceBusConnectionStringBuilder(envConnectionString){TransportType = TransportType.AmqpWebSockets}.ToString();

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/TestUtility.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/TestUtility.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             {
                 throw new InvalidOperationException($"'{TestConstants.ConnectionStringEnvironmentVariable}' environment variable was not found!");
             }
-
+            envConnectionString = "Endpoint=sb://contoso.servicebus.onebox.windows-int.net/;SharedAccessKeyName=DefaultNamespaceSasAllKeyName;SharedAccessKey=8864/auVd3qDC75iTjBL1GJ4D2oXC6bIttRd0jzDZ+g=";
             // Validate the connection string
             NamespaceConnectionString = new ServiceBusConnectionStringBuilder(envConnectionString).ToString();
             WebSocketsNamespaceConnectionString = new ServiceBusConnectionStringBuilder(envConnectionString){TransportType = TransportType.AmqpWebSockets}.ToString();


### PR DESCRIPTION
## Description
This feature lets a user send messages across entities in a single transaction.

A single transaction cannot theoretically span across entities. So as to support cross-entity transaction, you can now send a message to a `destination-queue` via another queue. The transaction will be performed on the `via-queue`, and once successful, the message will be forwarded/transferred to its intended destination.
Resolves #423 

Sample:
```csharp
var viaQueueSender = new MessageSender(connection, viaQueueName);
var viaQueueReceiver = new MessageReceiver(connection, viaQueueName);
var destinationViaSender = new MessageSender(connection, destinationQueueName, viaQueueName);

var message1 = new Message(body) { MessageId = "1", PartitionKey = "pk1" };
var message2 = new Message(body) { MessageId = "2", PartitionKey = "pk2", ViaPartitionKey = "pk1" };

await viaQueueSender.SendAsync(message1);
var receivedMessage = await viaQueueReceiver.ReceiveAsync();

using (new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
{
	await viaQueueReceiver.CompleteAsync(receivedMessage.SystemProperties.LockToken);
	await destinationViaSender.SendAsync(message2);
}
```

In the above example, operations on both `message1` and `message2` (intended for different entities) are being performed within the same entity (i.e., the `via-queue`)