### PR TITLE
Added UnauthorizedException, MessageNotFoundException and SessionCannotBeLockedException

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpExceptionHelper.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpExceptionHelper.cs
@@ -115,7 +115,8 @@ namespace Microsoft.Azure.ServiceBus.Amqp
                 return new InvalidOperationException(message);
             }
 
-            if (string.Equals(condition, AmqpErrorCode.UnauthorizedAccess.Value))
+            if (string.Equals(condition, AmqpErrorCode.UnauthorizedAccess.Value) ||
+                string.Equals(condition, AmqpClientConstants.AuthorizationFailedError.Value))
             {
                 return new UnauthorizedAccessException(message);
             }
@@ -158,6 +159,11 @@ namespace Microsoft.Azure.ServiceBus.Amqp
             if (string.Equals(condition, AmqpErrorCode.MessageSizeExceeded.Value))
             {
                 return new MessageSizeExceededException(message);
+            }
+
+            if (string.Equals(condition, AmqpClientConstants.MessageNotFoundError.Value))
+            {
+                return new MessageNotFoundException(message);
             }
 
             return new ServiceBusException(true, message);

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpExceptionHelper.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpExceptionHelper.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
             { AmqpClientConstants.PartitionNotOwnedError.Value, AmqpResponseStatusCode.Gone },
             { AmqpClientConstants.EntityDisabledError.Value, AmqpResponseStatusCode.BadRequest },
             { AmqpClientConstants.PublisherRevokedError.Value, AmqpResponseStatusCode.Unauthorized },
+            { AmqpClientConstants.AuthorizationFailedError.Value, AmqpResponseStatusCode.Unauthorized},
             { AmqpErrorCode.Stolen.Value, AmqpResponseStatusCode.Gone }
         };
 
@@ -118,7 +119,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
             if (string.Equals(condition, AmqpErrorCode.UnauthorizedAccess.Value) ||
                 string.Equals(condition, AmqpClientConstants.AuthorizationFailedError.Value))
             {
-                return new UnauthorizedAccessException(message);
+                return new UnauthorizedException(message);
             }
 
             if (string.Equals(condition, AmqpClientConstants.ServerBusyError.Value))

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpExceptionHelper.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpExceptionHelper.cs
@@ -167,6 +167,11 @@ namespace Microsoft.Azure.ServiceBus.Amqp
                 return new MessageNotFoundException(message);
             }
 
+            if (string.Equals(condition, AmqpClientConstants.SessionCannotBeLockedError.Value))
+            {
+                return new SessionCannotBeLockedException(message);
+            }
+
             return new ServiceBusException(true, message);
         }
 

--- a/src/Microsoft.Azure.ServiceBus/MessageNotFoundException.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageNotFoundException.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.ServiceBus
+{
+    using System;
+
+    /// <summary>
+    /// The exception that is thrown when the requested message is not found.
+    /// </summary>
+    public sealed class MessageNotFoundException : ServiceBusException
+    {
+        public MessageNotFoundException(string message)
+            : this(message, null)
+        {
+        }
+
+        public MessageNotFoundException(string message, Exception innerException)
+            : base(false, message, innerException)
+        {
+        }
+    }
+}

--- a/src/Microsoft.Azure.ServiceBus/SessionCannotBeLockedException.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionCannotBeLockedException.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.ServiceBus
+{
+    using System;
+
+    /// <summary>
+    /// The exception that is thrown when a session cannot be locked.
+    /// </summary>
+    public sealed class SessionCannotBeLockedException : ServiceBusException
+    {
+        public SessionCannotBeLockedException(string message)
+            : this(message, null)
+        {
+        }
+
+        public SessionCannotBeLockedException(string message, Exception innerException)
+            : base(false, message, innerException)
+        {
+        }
+    }
+}

--- a/src/Microsoft.Azure.ServiceBus/UnauthorizedException.cs
+++ b/src/Microsoft.Azure.ServiceBus/UnauthorizedException.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.ServiceBus
+{
+    using System;
+
+    /// <summary>
+    /// The exception that is thrown when user doesn't have access to the entity.
+    /// </summary>
+    public sealed class UnauthorizedException : ServiceBusException
+    {
+        public UnauthorizedException(string message)
+            : this(message, null)
+        {
+        }
+
+        public UnauthorizedException(string message, Exception innerException)
+            : base(false, message, innerException)
+        {
+        }
+    }
+}

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -175,6 +175,11 @@ namespace Microsoft.Azure.ServiceBus
         public MessageLockLostException(string message) { }
         public MessageLockLostException(string message, System.Exception innerException) { }
     }
+    public sealed class MessageNotFoundException : Microsoft.Azure.ServiceBus.ServiceBusException
+    {
+        public MessageNotFoundException(string message) { }
+        public MessageNotFoundException(string message, System.Exception innerException) { }
+    }
     public sealed class MessageSizeExceededException : Microsoft.Azure.ServiceBus.ServiceBusException
     {
         public MessageSizeExceededException(string message) { }
@@ -321,6 +326,11 @@ namespace Microsoft.Azure.ServiceBus
         public ServiceBusTimeoutException(string message) { }
         public ServiceBusTimeoutException(string message, System.Exception innerException) { }
     }
+    public sealed class SessionCannotBeLockedException : Microsoft.Azure.ServiceBus.ServiceBusException
+    {
+        public SessionCannotBeLockedException(string message) { }
+        public SessionCannotBeLockedException(string message, System.Exception innerException) { }
+    }
     public sealed class SessionClient : Microsoft.Azure.ServiceBus.ClientEntity, Microsoft.Azure.ServiceBus.IClientEntity, Microsoft.Azure.ServiceBus.ISessionClient
     {
         public SessionClient(Microsoft.Azure.ServiceBus.ServiceBusConnectionStringBuilder connectionStringBuilder, Microsoft.Azure.ServiceBus.ReceiveMode receiveMode = 0, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null, int prefetchCount = 0) { }
@@ -427,6 +437,11 @@ namespace Microsoft.Azure.ServiceBus
     {
         public TrueFilter() { }
         public override string ToString() { }
+    }
+    public sealed class UnauthorizedException : Microsoft.Azure.ServiceBus.ServiceBusException
+    {
+        public UnauthorizedException(string message) { }
+        public UnauthorizedException(string message, System.Exception innerException) { }
     }
 }
 namespace Microsoft.Azure.ServiceBus.Core

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/QueueSessionTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/QueueSessionTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         [Theory]
         [MemberData(nameof(TestPermutations))]
         [DisplayTestMethodName]
-        async Task SessionTest(string queueName)
+        public async Task SessionTest(string queueName)
         {
             var sender = new MessageSender(TestUtility.NamespaceConnectionString, queueName);
             var sessionClient = new SessionClient(TestUtility.NamespaceConnectionString, queueName);
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         [Theory]
         [MemberData(nameof(TestPermutations))]
         [DisplayTestMethodName]
-        async Task GetAndSetSessionStateTest(string queueName)
+        public async Task GetAndSetSessionStateTest(string queueName)
         {
             var sender = new MessageSender(TestUtility.NamespaceConnectionString, queueName);
             var sessionClient = new SessionClient(TestUtility.NamespaceConnectionString, queueName);
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         [Theory]
         [MemberData(nameof(TestPermutations))]
         [DisplayTestMethodName]
-        async Task SessionRenewLockTest(string queueName)
+        public async Task SessionRenewLockTest(string queueName)
         {
             var sender = new MessageSender(TestUtility.NamespaceConnectionString, queueName);
             var sessionClient = new SessionClient(TestUtility.NamespaceConnectionString, queueName);
@@ -173,7 +173,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         [Theory]
         [MemberData(nameof(TestPermutations))]
         [DisplayTestMethodName]
-        async Task PeekSessionAsyncTest(string queueName)
+        public async Task PeekSessionAsyncTest(string queueName)
         {
             var sender = new MessageSender(TestUtility.NamespaceConnectionString, queueName);
             var sessionClient = new SessionClient(TestUtility.NamespaceConnectionString, queueName, ReceiveMode.ReceiveAndDelete);
@@ -203,6 +203,26 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             }
         }
 
+        [Fact]
+        [DisplayTestMethodName]
+        public async Task AcceptSessionThrowsSessionCannotBeLockedException()
+        {
+            var sessionClient = new SessionClient(TestUtility.NamespaceConnectionString, TestConstants.SessionNonPartitionedQueueName);
+            var someSessionId = "someSessionId";
+            IMessageSession session = null;
+
+            try
+            {
+                session = await sessionClient.AcceptMessageSessionAsync(someSessionId);
+                await Assert.ThrowsAsync<SessionCannotBeLockedException>(async () =>
+                    session = await sessionClient.AcceptMessageSessionAsync(someSessionId));
+            }
+            finally
+            {
+                await sessionClient.CloseAsync().ConfigureAwait(false);
+                await session?.CloseAsync();
+            }
+        }
 
         async Task AcceptAndCompleteSessionsAsync(SessionClient sessionClient, string sessionId, string messageId)
         {

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/SenderReceiverTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/SenderReceiverTests.cs
@@ -316,5 +316,23 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 await receiver.CloseAsync();
             }
         }
+
+        [Fact]
+        [DisplayTestMethodName]
+        public async Task CancelScheduledMessageShouldThrowMessageNotFoundException()
+        {
+            var sender = new MessageSender(TestUtility.NamespaceConnectionString, TestConstants.NonPartitionedQueueName);
+
+            try
+            {
+                long nonExistingSequenceNumber = 1000;
+                await Assert.ThrowsAsync<MessageNotFoundException>(
+                    async () => await sender.CancelScheduledMessageAsync(nonExistingSequenceNumber));
+            }
+            finally
+            {
+                await sender.CloseAsync().ConfigureAwait(false);
+            }
+        }
     }
 }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/SenderReceiverTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/SenderReceiverTests.cs
@@ -334,5 +334,30 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 await sender.CloseAsync().ConfigureAwait(false);
             }
         }
+
+        [Fact]
+        [DisplayTestMethodName]
+        public async Task ClientThrowsUnauthorizedExceptionWhenUserDoesntHaveAccess()
+        {
+            var csb = new ServiceBusConnectionStringBuilder(TestUtility.NamespaceConnectionString);
+            csb.SasKeyName = "nonExistingKey";
+            csb.EntityPath = TestConstants.NonPartitionedQueueName;
+
+            var sender = new MessageSender(csb);
+
+            try
+            {
+                await Assert.ThrowsAsync<UnauthorizedException>(
+                    async () => await sender.SendAsync(new Message()));
+
+                long nonExistingSequenceNumber = 1000;
+                await Assert.ThrowsAsync<UnauthorizedException>(
+                    async () => await sender.CancelScheduledMessageAsync(nonExistingSequenceNumber));
+            }
+            finally
+            {
+                await sender.CloseAsync().ConfigureAwait(false);
+            }
+        }
     }
 }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/SubscriptionClientTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/SubscriptionClientTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         [Theory]
         [MemberData(nameof(TestPermutations))]
         [DisplayTestMethodName]
-        async Task CorrelationFilterTestCase(string topicName)
+        public async Task CorrelationFilterTestCase(string topicName)
         {
             var topicClient = new TopicClient(TestUtility.NamespaceConnectionString, topicName);
             var subscriptionClient = new SubscriptionClient(
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         [Theory]
         [MemberData(nameof(TestPermutations))]
         [DisplayTestMethodName]
-        async Task SqlFilterTestCase(string topicName)
+        public async Task SqlFilterTestCase(string topicName)
         {
             var topicClient = new TopicClient(TestUtility.NamespaceConnectionString, topicName);
             var subscriptionClient = new SubscriptionClient(
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         [Theory]
         [MemberData(nameof(TestPermutations))]
         [DisplayTestMethodName]
-        async Task SqlActionTestCase(string topicName)
+        public async Task SqlActionTestCase(string topicName)
         {
             var topicClient = new TopicClient(TestUtility.NamespaceConnectionString, topicName);
             var subscriptionClient = new SubscriptionClient(
@@ -303,7 +303,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
 
         [Fact]
         [DisplayTestMethodName]
-        async Task UpdatingPrefetchCountOnSubscriptionClientUpdatesTheReceiverPrefetchCount()
+        public async Task UpdatingPrefetchCountOnSubscriptionClientUpdatesTheReceiverPrefetchCount()
         {
             var subscriptionClient = new SubscriptionClient(
                 TestUtility.NamespaceConnectionString,


### PR DESCRIPTION
## Description

Introduction of `MessageNotFoundException` and `SessionCannotBeLockedException` brings more parity of this client with the older .net client.

`UnauthorizedException` is being introduced to replace `System.UnauthorizedAccessException` so that all the exceptions are derived from `ServiceBusException`. This is a breaking change.
