### PR TITLE
Fix infinite loop in ConcurrentExpiringSet and slow down cleanup to prevent a pegged CPU.

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Primitives/ConcurrentExpiringSet.cs
+++ b/src/Microsoft.Azure.ServiceBus/Primitives/ConcurrentExpiringSet.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.ServiceBus.Primitives
         {
             lock (this.cleanupSynObject)
             {
-                if (this.cleanupScheduled)
+                if (this.cleanupScheduled || this.dictionary.Count <= 0)
                 {
                     return;
                 }
@@ -51,6 +51,8 @@ namespace Microsoft.Azure.ServiceBus.Primitives
 
         async Task CollectExpiredEntries()
         {
+            await Task.Delay(TimeSpan.FromSeconds(30));
+
             lock (this.cleanupSynObject)
             {
                 this.cleanupScheduled = false;
@@ -64,13 +66,6 @@ namespace Microsoft.Azure.ServiceBus.Primitives
                     this.dictionary.TryRemove(key, out entry);
                 }
             }
-
-            if (this.dictionary.Count <= 0)
-            {
-                return;
-            }
-
-            await Task.Delay(1000);
 
             this.ScheduleCleanup();
         }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Primitives/ConcurrentExpiringSetTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Primitives/ConcurrentExpiringSetTests.cs
@@ -1,0 +1,31 @@
+﻿// ----------------------------------------------------------------------------
+// <copyright company="Microsoft Corporation" file="ConcurrentExpiringSetTests.cs">
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// ----------------------------------------------------------------------------
+
+namespace Microsoft.Azure.ServiceBus.UnitTests.Primitives
+{
+    using Microsoft.Azure.ServiceBus.Primitives;
+    using System;
+    using Xunit;
+
+    public class ConcurrentExpiringSetTests
+    {
+        [Fact]
+        public void Contains_returns_true_for_valid_entry()
+        {
+            var set = new ConcurrentExpiringSet<string>();
+            set.AddOrUpdate("testKey", DateTime.UtcNow + TimeSpan.FromSeconds(5));
+            Assert.True(set.Contains("testKey"), "The set should return true for a valid entry.");
+        }
+
+        [Fact]
+        public void Contains_returns_false_for_expired_entry()
+        {
+            var set = new ConcurrentExpiringSet<string>();
+            set.AddOrUpdate("testKey", DateTime.UtcNow - TimeSpan.FromSeconds(5));
+            Assert.False(set.Contains("testKey"), "The set should return false for an expired entry.");
+        }
+    }
+}


### PR DESCRIPTION
See issue for more details.

* Added 1000ms as the default delay between loops. Looking for guidance on if that's the right number.

* Also wasn't super sure on how best to test this so I tested the two external use cases and manually tested the exit strategy to prevent an infinite loop.
