### PR TITLE
Allow MessageSender to expose TransferDestinationPath it's using

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
@@ -153,6 +153,7 @@ namespace Microsoft.Azure.ServiceBus.Core
 
             this.ServiceBusConnection = serviceBusConnection ?? throw new ArgumentNullException(nameof(serviceBusConnection));
             this.Path = entityPath;
+            this.TransferDestinationPath = transferDestinationPath;
             this.EntityType = entityType;
 
             if (cbsTokenProvider != null)
@@ -192,6 +193,11 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// Gets the entity path of the MessageSender.
         /// </summary>
         public override string Path { get; }
+
+        /// <summary>
+        /// Gets the transfer destination path (send-via) of the MessageSender.
+        /// </summary>
+        public string TransferDestinationPath { get; }
 
         /// <summary>
         /// Duration after which individual operations will timeout.

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -541,6 +541,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         public override string Path { get; }
         public override System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin> RegisteredPlugins { get; }
         public override Microsoft.Azure.ServiceBus.ServiceBusConnection ServiceBusConnection { get; }
+        public string TransferDestinationPath { get; }
         public System.Threading.Tasks.Task CancelScheduledMessageAsync(long sequenceNumber) { }
         protected override System.Threading.Tasks.Task OnClosingAsync() { }
         public override void RegisterPlugin(Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin serviceBusPlugin) { }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/TransactionTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/TransactionTests.cs
@@ -240,6 +240,10 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                     ts.Dispose();
                 }
 
+                // Adding delay since transaction Commit/Rollback is an asynchronous operation.
+                // Operating on the same message should not be done.
+                await Task.Delay(TimeSpan.FromSeconds(2));
+
                 using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
                 {
                     await receiver.CompleteAsync(deferredMessage.SystemProperties.LockToken);
@@ -285,6 +289,11 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                         async () => await sender.SendAsync(message2));
                     ts.Complete();
                 }
+
+                // Adding delay since transaction Commit/Rollback is an asynchronous operation.
+                // Operating on the same message should not be done.
+                await Task.Delay(TimeSpan.FromSeconds(2));
+
                 transaction.Rollback();
 
                 // Two complete operations to different partitions.
@@ -305,6 +314,10 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                         async () => await receiver.CompleteAsync(receivedMessage2.SystemProperties.LockToken));
                     ts.Complete();
                 }
+
+                // Adding delay since transaction Commit/Rollback is an asynchronous operation.
+                // Operating on the same message should not be done.
+                await Task.Delay(TimeSpan.FromSeconds(2));
 
                 transaction.Rollback();
 

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/TransactionTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/TransactionTests.cs
@@ -290,11 +290,11 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                     ts.Complete();
                 }
 
+                transaction.Rollback();
+                
                 // Adding delay since transaction Commit/Rollback is an asynchronous operation.
                 // Operating on the same message should not be done.
                 await Task.Delay(TimeSpan.FromSeconds(2));
-
-                transaction.Rollback();
 
                 // Two complete operations to different partitions.
                 await sender.SendAsync(message1);
@@ -315,11 +315,11 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                     ts.Complete();
                 }
 
+                transaction.Rollback();
+
                 // Adding delay since transaction Commit/Rollback is an asynchronous operation.
                 // Operating on the same message should not be done.
                 await Task.Delay(TimeSpan.FromSeconds(2));
-
-                transaction.Rollback();
 
                 await receiver.CompleteAsync(receivedMessage1.SystemProperties.LockToken);
                 await receiver.CompleteAsync(receivedMessage2.SystemProperties.LockToken);

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/TransactionTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/TransactionTests.cs
@@ -77,6 +77,10 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                     ts.Dispose();
                 }
 
+                // Adding delay since transaction Commit/Rollback is an asynchronous operation.
+                // Operating on the same message should not be done.
+                await Task.Delay(TimeSpan.FromSeconds(2));
+
                 var receivedMessage = await receiver.ReceiveAsync(ReceiveTimeout);
                 Assert.Null(receivedMessage);
             }
@@ -148,6 +152,10 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                     ts.Dispose();
                 }
 
+                // Adding delay since transaction Commit/Rollback is an asynchronous operation.
+                // Operating on the same message should not be done.
+                await Task.Delay(TimeSpan.FromSeconds(2));
+
                 await receiver.CompleteAsync(receivedMessage.SystemProperties.LockToken);
             }
             finally
@@ -197,6 +205,8 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                     ts.Complete();
                 }
 
+                // Adding delay since transaction Commit/Rollback is an asynchronous operation.
+                // Operating on the same message should not be done.
                 await Task.Delay(TimeSpan.FromSeconds(2));
 
                 await Assert.ThrowsAsync<SessionLockLostException>(async () => await receiver.CompleteAsync(receivedMessage.SystemProperties.LockToken));
@@ -249,6 +259,10 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                     await receiver.CompleteAsync(deferredMessage.SystemProperties.LockToken);
                     ts.Complete();
                 }
+
+                // Adding delay since transaction Commit/Rollback is an asynchronous operation.
+                // Operating on the same message should not be done.
+                await Task.Delay(TimeSpan.FromSeconds(2));
 
                 await Assert.ThrowsAsync<MessageLockLostException>(async () => await receiver.CompleteAsync(deferredMessage.SystemProperties.LockToken));
             }
@@ -362,6 +376,10 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                     ts.Complete();
                 }
 
+                // Adding delay since transaction Commit/Rollback is an asynchronous operation.
+                // Operating on the same message should not be done.
+                await Task.Delay(TimeSpan.FromSeconds(2));
+
                 // Assert that complete did succeed
                 await Assert.ThrowsAsync<MessageLockLostException>(async () => await receiver.CompleteAsync(receivedMessage.SystemProperties.LockToken));
 
@@ -405,6 +423,10 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                     await sender.SendAsync(message2).ConfigureAwait(false);
                     ts.Dispose();
                 }
+
+                // Adding delay since transaction Commit/Rollback is an asynchronous operation.
+                // Operating on the same message should not be done.
+                await Task.Delay(TimeSpan.FromSeconds(2));
 
                 // Following should succeed without exceptions
                 await receiver.CompleteAsync(receivedMessage.SystemProperties.LockToken);


### PR DESCRIPTION
## Description

`Path` and `Connection` are already available. `TransferDestinationPath` is not.
W/o it, passing message senders around requires to also pass around transfer destination path, which is redundant considering that info can be made availabe as a read-only property.

## Legal


This following list is used to make sure that common guidelines for a pull request are followed.

- **Read the [contribution guidelines](./CONTRIBUTING.md).** 
- Make title of the pull request clear and informative. 
- Link to appropriate [issue](https://github.com/Azure/azure-service-bus-dotnet/issues).
- Include test coverage for the changes.
