### PR TITLE
Allow clients to report if they own or share the underlying connection string (Part 1)

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/ClientEntity.cs
+++ b/src/Microsoft.Azure.ServiceBus/ClientEntity.cs
@@ -55,6 +55,11 @@ namespace Microsoft.Azure.ServiceBus
         public abstract ServiceBusConnection ServiceBusConnection { get; }
 
         /// <summary>
+        /// Returns true if connection is owned and false if connection is shared.
+        /// </summary>
+        public bool OwnsConnection { get; internal set; }
+
+        /// <summary>
         /// Gets the name of the entity.
         /// </summary>
         public abstract string Path { get; }

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -48,7 +48,6 @@ namespace Microsoft.Azure.ServiceBus.Core
         readonly ConcurrentExpiringSet<Guid> requestResponseLockedMessages;
         readonly bool isSessionReceiver;
         readonly object messageReceivePumpSyncLock;
-        readonly bool ownsConnection;
         readonly ActiveClientLinkManager clientLinkManager;
         readonly ServiceBusDiagnosticSource diagnosticSource;
 
@@ -99,7 +98,7 @@ namespace Microsoft.Azure.ServiceBus.Core
                 throw Fx.Exception.ArgumentNullOrWhiteSpace(connectionString);
             }
             
-            this.ownsConnection = true;
+            this.OwnsConnection = true;
         }
 
         /// <summary>
@@ -124,7 +123,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             int prefetchCount = Constants.DefaultClientPrefetchCount)
             : this(entityPath, null, receiveMode, new ServiceBusConnection(endpoint, transportType, retryPolicy) {TokenProvider = tokenProvider}, null, retryPolicy, prefetchCount)
         {
-            this.ownsConnection = true;
+            this.OwnsConnection = true;
         }
 
         /// <summary>
@@ -145,7 +144,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             int prefetchCount = Constants.DefaultClientPrefetchCount)
             : this(entityPath, null, receiveMode, serviceBusConnection, null, retryPolicy, prefetchCount)
         {
-            this.ownsConnection = false;
+            this.OwnsConnection = false;
         }
 
         internal MessageReceiver(
@@ -1009,7 +1008,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             await this.ReceiveLinkManager.CloseAsync().ConfigureAwait(false);
             await this.RequestResponseLinkManager.CloseAsync().ConfigureAwait(false);
 
-            if (this.ownsConnection)
+            if (this.OwnsConnection)
             {
                 await this.ServiceBusConnection.CloseAsync().ConfigureAwait(false);
             }

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageSender.cs
@@ -37,7 +37,6 @@ namespace Microsoft.Azure.ServiceBus.Core
     public class MessageSender : ClientEntity, IMessageSender
     {
         int deliveryCount;
-        readonly bool ownsConnection;
         readonly ActiveClientLinkManager clientLinkManager;
         readonly ServiceBusDiagnosticSource diagnosticSource;
         readonly bool isViaSender;
@@ -74,7 +73,7 @@ namespace Microsoft.Azure.ServiceBus.Core
                 throw Fx.Exception.ArgumentNullOrWhiteSpace(connectionString);
             }
 
-            this.ownsConnection = true;
+            this.OwnsConnection = true;
         }
 
         /// <summary>
@@ -94,7 +93,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             RetryPolicy retryPolicy = null)
             : this(entityPath, null, null, new ServiceBusConnection(endpoint, transportType, retryPolicy) {TokenProvider = tokenProvider}, null, retryPolicy)
         {
-            this.ownsConnection = true;
+            this.OwnsConnection = true;
         }
 
         /// <summary>
@@ -109,7 +108,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             RetryPolicy retryPolicy = null)
             : this(entityPath, null, null, serviceBusConnection, null, retryPolicy)
         {
-            this.ownsConnection = false;
+            this.OwnsConnection = false;
         }
 
         /// <summary>
@@ -132,7 +131,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             RetryPolicy retryPolicy = null)
             :this(viaEntityPath, entityPath, null, serviceBusConnection, null, retryPolicy)
         {
-            this.ownsConnection = false;
+            this.OwnsConnection = false;
         }
 
         internal MessageSender(
@@ -444,7 +443,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             await this.SendLinkManager.CloseAsync().ConfigureAwait(false);
             await this.RequestResponseLinkManager.CloseAsync().ConfigureAwait(false);
 
-            if (this.ownsConnection)
+            if (this.OwnsConnection)
             {
                 await this.ServiceBusConnection.CloseAsync().ConfigureAwait(false);
             }

--- a/src/Microsoft.Azure.ServiceBus/QueueClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/QueueClient.cs
@@ -54,7 +54,6 @@ namespace Microsoft.Azure.ServiceBus
     /// It uses AMQP protocol for communicating with servicebus.</remarks>
     public class QueueClient : ClientEntity, IQueueClient
     {
-        readonly bool ownsConnection;
         readonly object syncLock;
 
         int prefetchCount;
@@ -91,7 +90,7 @@ namespace Microsoft.Azure.ServiceBus
                 throw Fx.Exception.ArgumentNullOrWhiteSpace(connectionString);
             }
             
-            this.ownsConnection = true;
+            this.OwnsConnection = true;
         }
 
         /// <summary>
@@ -113,7 +112,7 @@ namespace Microsoft.Azure.ServiceBus
             RetryPolicy retryPolicy = null)
             : this(new ServiceBusConnection(endpoint, transportType, retryPolicy) {TokenProvider = tokenProvider}, entityPath, receiveMode, retryPolicy)
         {
-            this.ownsConnection = true;
+            this.OwnsConnection = true;
         }
 
         /// <summary>
@@ -137,7 +136,7 @@ namespace Microsoft.Azure.ServiceBus
             this.syncLock = new object();
             this.QueueName = entityPath;
             this.ReceiveMode = receiveMode;
-            this.ownsConnection = false;
+            this.OwnsConnection = false;
             if (this.ServiceBusConnection.TokenProvider != null)
             {
                 this.CbsTokenProvider = new TokenProviderAdapter(this.ServiceBusConnection.TokenProvider, this.ServiceBusConnection.OperationTimeout);
@@ -535,7 +534,7 @@ namespace Microsoft.Azure.ServiceBus
                 await this.sessionClient.CloseAsync().ConfigureAwait(false);
             }
 
-            if (this.ownsConnection)
+            if (this.OwnsConnection)
             {
                 await this.ServiceBusConnection.CloseAsync().ConfigureAwait(false);
             }

--- a/src/Microsoft.Azure.ServiceBus/SessionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionClient.cs
@@ -45,7 +45,6 @@ namespace Microsoft.Azure.ServiceBus
     public sealed class SessionClient : ClientEntity, ISessionClient
     {
         const int DefaultPrefetchCount = 0;
-        readonly bool ownsConnection;
         readonly ServiceBusDiagnosticSource diagnosticSource;
 
         /// <summary>
@@ -97,7 +96,7 @@ namespace Microsoft.Azure.ServiceBus
                 throw Fx.Exception.ArgumentNullOrWhiteSpace(connectionString);
             }
 
-            this.ownsConnection = true;
+            this.OwnsConnection = true;
         }
 
         /// <summary>
@@ -130,7 +129,7 @@ namespace Microsoft.Azure.ServiceBus
                 retryPolicy,
                 null)
         {
-            this.ownsConnection = true;
+            this.OwnsConnection = true;
         }
 
         /// <summary>
@@ -158,7 +157,7 @@ namespace Microsoft.Azure.ServiceBus
                 retryPolicy,
                 null)
         {
-            this.ownsConnection = false;
+            this.OwnsConnection = false;
         }
 
         internal SessionClient(
@@ -397,7 +396,7 @@ namespace Microsoft.Azure.ServiceBus
 
         protected override async Task OnClosingAsync()
         {
-            if (this.ownsConnection)
+            if (this.OwnsConnection)
             {
                 await this.ServiceBusConnection.CloseAsync().ConfigureAwait(false);
             }

--- a/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
@@ -52,7 +52,6 @@ namespace Microsoft.Azure.ServiceBus
     {
         int prefetchCount;
         readonly object syncLock;
-        readonly bool ownsConnection;
         readonly ServiceBusDiagnosticSource diagnosticSource;
 
         IInnerSubscriptionClient innerSubscriptionClient;
@@ -86,7 +85,7 @@ namespace Microsoft.Azure.ServiceBus
                 throw Fx.Exception.ArgumentNullOrWhiteSpace(connectionString);
             }
 
-            this.ownsConnection = true;
+            this.OwnsConnection = true;
         }
 
         /// <summary>
@@ -110,7 +109,7 @@ namespace Microsoft.Azure.ServiceBus
             RetryPolicy retryPolicy = null)
             : this(new ServiceBusConnection(endpoint, transportType, retryPolicy) {TokenProvider = tokenProvider}, topicPath, subscriptionName, receiveMode, retryPolicy)
         {
-            this.ownsConnection = true;
+            this.OwnsConnection = true;
         }
 
         /// <summary>
@@ -142,7 +141,7 @@ namespace Microsoft.Azure.ServiceBus
             this.Path = EntityNameHelper.FormatSubscriptionPath(this.TopicPath, this.SubscriptionName);
             this.ReceiveMode = receiveMode;
             this.diagnosticSource = new ServiceBusDiagnosticSource(this.Path, serviceBusConnection.Endpoint);
-            this.ownsConnection = false;
+            this.OwnsConnection = false;
             if (this.ServiceBusConnection.TokenProvider != null)
             {
                 this.CbsTokenProvider = new TokenProviderAdapter(this.ServiceBusConnection.TokenProvider, this.ServiceBusConnection.OperationTimeout);
@@ -637,7 +636,7 @@ namespace Microsoft.Azure.ServiceBus
                 await this.sessionClient.CloseAsync().ConfigureAwait(false);
             }
 
-            if (this.ownsConnection)
+            if (this.OwnsConnection)
             {
                 await this.ServiceBusConnection.CloseAsync().ConfigureAwait(false);
             }

--- a/src/Microsoft.Azure.ServiceBus/TopicClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/TopicClient.cs
@@ -31,7 +31,6 @@ namespace Microsoft.Azure.ServiceBus
     /// <remarks>It uses AMQP protocol for communicating with servicebus.</remarks>
     public class TopicClient : ClientEntity, ITopicClient
     {
-        readonly bool ownsConnection;
         readonly object syncLock;
         MessageSender innerSender;
 
@@ -61,7 +60,7 @@ namespace Microsoft.Azure.ServiceBus
                 throw Fx.Exception.ArgumentNullOrWhiteSpace(connectionString);
             }
 
-            this.ownsConnection = true;
+            this.OwnsConnection = true;
         }
 
         /// <summary>
@@ -81,7 +80,7 @@ namespace Microsoft.Azure.ServiceBus
             RetryPolicy retryPolicy = null)
             : this(new ServiceBusConnection(endpoint, transportType, retryPolicy) {TokenProvider = tokenProvider}, entityPath, retryPolicy)
         {
-            this.ownsConnection = true;
+            this.OwnsConnection = true;
         }
 
         /// <summary>
@@ -102,7 +101,7 @@ namespace Microsoft.Azure.ServiceBus
             this.ServiceBusConnection = serviceBusConnection ?? throw new ArgumentNullException(nameof(serviceBusConnection));
             this.syncLock = new object();
             this.TopicName = entityPath;
-            this.ownsConnection = false;
+            this.OwnsConnection = false;
             if (this.ServiceBusConnection.TokenProvider != null)
             {
                 this.CbsTokenProvider = new TokenProviderAdapter(this.ServiceBusConnection.TokenProvider, this.ServiceBusConnection.OperationTimeout);
@@ -236,7 +235,7 @@ namespace Microsoft.Azure.ServiceBus
                 await this.innerSender.CloseAsync().ConfigureAwait(false);
             }
 
-            if (this.ownsConnection)
+            if (this.OwnsConnection)
             {
                 await this.ServiceBusConnection.CloseAsync().ConfigureAwait(false);
             }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.ServiceBus
         public string ClientId { get; }
         public bool IsClosedOrClosing { get; }
         public abstract System.TimeSpan OperationTimeout { get; set; }
+        public bool OwnsConnection { get; }
         public abstract string Path { get; }
         public abstract System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin> RegisteredPlugins { get; }
         public Microsoft.Azure.ServiceBus.RetryPolicy RetryPolicy { get; }


### PR DESCRIPTION
Fixes #482 

- Allow clients to report if they own or share the underlying connection string.
- Remove unnecessary `ownsConnection` field from all clients

This is part 1 out of 2 parts PRs. Follow up PR #486 will be completing this change in the next major release.