### PR TITLE
Allow clients to report if they own or share the underlying connection string (Part 2)

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/IClientEntity.cs
+++ b/src/Microsoft.Azure.ServiceBus/IClientEntity.cs
@@ -45,6 +45,11 @@ namespace Microsoft.Azure.ServiceBus
         ServiceBusConnection ServiceBusConnection { get; }
 
         /// <summary>
+        /// Returns true if connection is owned and false if connection is shared.
+        /// </summary>
+        bool OwnsConnection { get; }
+
+        /// <summary>
         /// Gets a list of currently registered plugins for this client.
         /// </summary>
         IList<ServiceBusPlugin> RegisteredPlugins { get; }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -93,6 +93,7 @@ namespace Microsoft.Azure.ServiceBus
         string ClientId { get; }
         bool IsClosedOrClosing { get; }
         System.TimeSpan OperationTimeout { get; set; }
+        bool OwnsConnection { get; }
         string Path { get; }
         System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin> RegisteredPlugins { get; }
         Microsoft.Azure.ServiceBus.ServiceBusConnection ServiceBusConnection { get; }


### PR DESCRIPTION
Follow up for PR #485 which fixed issue #482 

- Extract `OwnsConnection` into `IClientEntity` contract