### PR TITLE
Updated with the correct message property name for EnqueuedSequenceNumber

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
@@ -306,7 +306,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
                             sbMessage.SystemProperties.SequenceNumber = (long)pair.Value;
                             break;
                         case EnqueueSequenceNumberName:
-                            sbMessage.SystemProperties.EnqueuedSequenceNumber = long.Parse((string)pair.Value);
+                            sbMessage.SystemProperties.EnqueuedSequenceNumber = (long)pair.Value;
                             break;
                         case LockedUntilName:
                             sbMessage.SystemProperties.LockedUntilUtc = (DateTime)pair.Value;

--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpMessageConverter.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
         const string EnqueuedTimeUtcName = "x-opt-enqueued-time";
         const string ScheduledEnqueueTimeUtcName = "x-opt-scheduled-enqueue-time";
         const string SequenceNumberName = "x-opt-sequence-number";
-        const string OffsetName = "x-opt-offset";
+        const string EnqueueSequenceNumberName = "x-opt-enqueue-sequence-number";
         const string LockedUntilName = "x-opt-locked-until";
         const string PublisherName = "x-opt-publisher";
         const string PartitionKeyName = "x-opt-partition-key";
@@ -305,7 +305,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
                         case SequenceNumberName:
                             sbMessage.SystemProperties.SequenceNumber = (long)pair.Value;
                             break;
-                        case OffsetName:
+                        case EnqueueSequenceNumberName:
                             sbMessage.SystemProperties.EnqueuedSequenceNumber = long.Parse((string)pair.Value);
                             break;
                         case LockedUntilName:


### PR DESCRIPTION
Fixes #484 
While converting from AMQP message to Service Bus message, anything message property that is not understood by the client is converted to `UserProperty`. 
There was a wrong conversion used for `EnqueuedSequenceNumber` and hence it was being pushed to `UserProperty` instead.
