### PR TITLE
Ensuring non amqp scheme URIs can also be used

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpConnectionHelper.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpConnectionHelper.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
             var tcpTransportSettings = new TcpTransportSettings
             {
                 Host = networkHost,
-                Port = port < 0 ? AmqpConstants.DefaultSecurePort : port,
+                Port = port < Constants.WellKnownPublicPortsLimit ? AmqpConstants.DefaultSecurePort : port,
                 ReceiveBufferSize = AmqpConstants.TransportBufferSize,
                 SendBufferSize = AmqpConstants.TransportBufferSize
             };
@@ -103,7 +103,11 @@ namespace Microsoft.Azure.ServiceBus.Amqp
             string hostName,
             int port)
         {
-            var uriBuilder = new UriBuilder(WebSocketConstants.WebSocketSecureScheme, networkHost, port < 0 ? WebSocketConstants.WebSocketSecurePort : port, WebSocketConstants.WebSocketDefaultPath);
+            var uriBuilder = new UriBuilder(
+                WebSocketConstants.WebSocketSecureScheme,
+                networkHost,
+                port < Constants.WellKnownPublicPortsLimit ? WebSocketConstants.WebSocketSecurePort : port,
+                WebSocketConstants.WebSocketDefaultPath);
             var webSocketTransportSettings = new WebSocketTransportSettings
             {
                 Uri = uriBuilder.Uri,

--- a/src/Microsoft.Azure.ServiceBus/Constants.cs
+++ b/src/Microsoft.Azure.ServiceBus/Constants.cs
@@ -45,5 +45,7 @@ namespace Microsoft.Azure.ServiceBus
 
         /// Represents 00:00:00 UTC Thursday 1, January 1970.
         public static readonly DateTime EpochTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+
+        public const int WellKnownPublicPortsLimit = 1023;
     }
 }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/ServiceBusConnectionStringBuilderTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/ServiceBusConnectionStringBuilderTests.cs
@@ -5,6 +5,8 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.ServiceBus.Core;
     using Xunit;
 
     public class ServiceBusConnectionStringBuilderTests
@@ -131,6 +133,23 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             var csBuilder = new ServiceBusConnectionStringBuilder("SharedAccessSignature=" + token+";Endpoint=sb://contoso.servicebus.windows.net");
             Assert.Equal("sb://contoso.servicebus.windows.net", csBuilder.Endpoint);
             Assert.Equal(token, csBuilder.SasToken);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        public async Task NonAmqpUriSchemesShouldWorkAsExpected()
+        {
+            var csb = new ServiceBusConnectionStringBuilder(TestUtility.NamespaceConnectionString);
+            csb.Endpoint = new UriBuilder(csb.Endpoint)
+            {
+                Scheme = Uri.UriSchemeHttps
+            }.Uri.ToString();
+            csb.EntityPath = TestConstants.NonPartitionedQueueName;
+
+            var receiver = new MessageReceiver(csb);
+            var msg = await receiver.ReceiveAsync(TimeSpan.FromSeconds(5));
+
+            await receiver.CloseAsync();
         }
     }
 }


### PR DESCRIPTION
Resolves #411 
Bug: If you provide a connection string which has a known URL scheme, then you end up with error as described in #411.
