### PR TITLE
Changing topicName param to topicPath in CreateRuleAsync, fixing variable typo in CreateRuleAsync

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Management/ManagementClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/Management/ManagementClient.cs
@@ -630,7 +630,7 @@ namespace Microsoft.Azure.ServiceBus.Management
         /// <summary>
         /// Adds a new rule to the subscription under given topic.
         /// </summary>
-        /// <param name="topicName">The topic name relative to the service namespace base address.</param>
+        /// <param name="topicPath">The topic name relative to the service namespace base address.</param>
         /// <param name="subscriptionName">The name of the subscription.</param>
         /// <param name="ruleDescription">A <see cref="RuleDescription"/> object describing the attributes with which the messages are matched and acted upon.</param>
         /// <param name="cancellationToken"></param>
@@ -642,16 +642,16 @@ namespace Microsoft.Azure.ServiceBus.Management
         /// <exception cref="ServerBusyException">The server is busy. You should wait before you retry the operation.</exception>
         /// <exception cref="ServiceBusException">An internal error or unexpected exception occurs.</exception>
         /// <returns><see cref="RuleDescription"/> of the recently created rule.</returns>
-        public virtual async Task<RuleDescription> CreateRuleAsync(string topicName, string subscriptionName, RuleDescription ruleDescription, CancellationToken cancellationToken = default)
+        public virtual async Task<RuleDescription> CreateRuleAsync(string topicPath, string subscriptionName, RuleDescription ruleDescription, CancellationToken cancellationToken = default)
         {
-            EntityNameHelper.CheckValidTopicName(topicName);
-            EntityNameHelper.CheckValidSubscriptionName(topicName);
+            EntityNameHelper.CheckValidTopicName(topicPath);
+            EntityNameHelper.CheckValidSubscriptionName(topicPath);
             ruleDescription = ruleDescription ?? throw new ArgumentNullException(nameof(ruleDescription));
 
             var atomRequest = ruleDescription.Serialize().ToString();
 
             var content = await PutEntity(
-                EntityNameHelper.FormatRulePath(topicName, subscriptionName, ruleDescription.Name),
+                EntityNameHelper.FormatRulePath(topicPath, subscriptionName, ruleDescription.Name),
                 atomRequest,
                 false,
                 null, 

--- a/src/Microsoft.Azure.ServiceBus/Management/ManagementClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/Management/ManagementClient.cs
@@ -645,7 +645,7 @@ namespace Microsoft.Azure.ServiceBus.Management
         public virtual async Task<RuleDescription> CreateRuleAsync(string topicPath, string subscriptionName, RuleDescription ruleDescription, CancellationToken cancellationToken = default)
         {
             EntityNameHelper.CheckValidTopicName(topicPath);
-            EntityNameHelper.CheckValidSubscriptionName(topicPath);
+            EntityNameHelper.CheckValidSubscriptionName(subscriptionName);
             ruleDescription = ruleDescription ?? throw new ArgumentNullException(nameof(ruleDescription));
 
             var atomRequest = ruleDescription.Serialize().ToString();

--- a/src/Microsoft.Azure.ServiceBus/Management/ManagementClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/Management/ManagementClient.cs
@@ -634,7 +634,7 @@ namespace Microsoft.Azure.ServiceBus.Management
         /// <summary>
         /// Adds a new rule to the subscription under given topic.
         /// </summary>
-        /// <param name="topicPath">The topic name relative to the service namespace base address.</param>
+        /// <param name="topicPath">The topic path relative to the service namespace base address.</param>
         /// <param name="subscriptionName">The name of the subscription.</param>
         /// <param name="ruleDescription">A <see cref="RuleDescription"/> object describing the attributes with which the messages are matched and acted upon.</param>
         /// <param name="cancellationToken"></param>

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -3,7 +3,7 @@
 [assembly: System.Runtime.InteropServices.GuidAttribute("a042adf0-ef65-4f87-b634-322a409f3d61")]
 namespace Microsoft.Azure.ServiceBus
 {
-
+    
     public abstract class ClientEntity : Microsoft.Azure.ServiceBus.IClientEntity
     {
         protected ClientEntity(string clientTypeName, string postfix, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy) { }
@@ -476,7 +476,7 @@ namespace Microsoft.Azure.ServiceBus
 }
 namespace Microsoft.Azure.ServiceBus.Core
 {
-
+    
     public interface IMessageReceiver : Microsoft.Azure.ServiceBus.Core.IReceiverClient, Microsoft.Azure.ServiceBus.IClientEntity
     {
         long LastPeekedSequenceNumber { get; }
@@ -591,7 +591,7 @@ namespace Microsoft.Azure.ServiceBus.Core
 }
 namespace Microsoft.Azure.ServiceBus.Diagnostics
 {
-
+    
     public class static MessageExtensions
     {
         public static System.Diagnostics.Activity ExtractActivity(this Microsoft.Azure.ServiceBus.Message message, string activityName = null) { }
@@ -599,9 +599,9 @@ namespace Microsoft.Azure.ServiceBus.Diagnostics
 }
 namespace Microsoft.Azure.ServiceBus.InteropExtensions
 {
-
+    
     public class static DataContractBinarySerializer<T>
-
+    
     {
         public static readonly System.Runtime.Serialization.XmlObjectSerializer Instance;
     }
@@ -612,7 +612,7 @@ namespace Microsoft.Azure.ServiceBus.InteropExtensions
 }
 namespace Microsoft.Azure.ServiceBus.Management
 {
-
+    
     public enum AccessRights
     {
         Manage = 0,
@@ -811,7 +811,7 @@ namespace Microsoft.Azure.ServiceBus.Management
 }
 namespace Microsoft.Azure.ServiceBus.Primitives
 {
-
+    
     public class AzureActiveDirectoryTokenProvider : Microsoft.Azure.ServiceBus.Primitives.TokenProvider
     {
         public override System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.Primitives.SecurityToken> GetTokenAsync(string appliesTo, System.TimeSpan timeout) { }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -3,7 +3,7 @@
 [assembly: System.Runtime.InteropServices.GuidAttribute("a042adf0-ef65-4f87-b634-322a409f3d61")]
 namespace Microsoft.Azure.ServiceBus
 {
-    
+
     public abstract class ClientEntity : Microsoft.Azure.ServiceBus.IClientEntity
     {
         protected ClientEntity(string clientTypeName, string postfix, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy) { }
@@ -476,7 +476,7 @@ namespace Microsoft.Azure.ServiceBus
 }
 namespace Microsoft.Azure.ServiceBus.Core
 {
-    
+
     public interface IMessageReceiver : Microsoft.Azure.ServiceBus.Core.IReceiverClient, Microsoft.Azure.ServiceBus.IClientEntity
     {
         long LastPeekedSequenceNumber { get; }
@@ -591,7 +591,7 @@ namespace Microsoft.Azure.ServiceBus.Core
 }
 namespace Microsoft.Azure.ServiceBus.Diagnostics
 {
-    
+
     public class static MessageExtensions
     {
         public static System.Diagnostics.Activity ExtractActivity(this Microsoft.Azure.ServiceBus.Message message, string activityName = null) { }
@@ -599,9 +599,9 @@ namespace Microsoft.Azure.ServiceBus.Diagnostics
 }
 namespace Microsoft.Azure.ServiceBus.InteropExtensions
 {
-    
+
     public class static DataContractBinarySerializer<T>
-    
+
     {
         public static readonly System.Runtime.Serialization.XmlObjectSerializer Instance;
     }
@@ -612,7 +612,7 @@ namespace Microsoft.Azure.ServiceBus.InteropExtensions
 }
 namespace Microsoft.Azure.ServiceBus.Management
 {
-    
+
     public enum AccessRights
     {
         Manage = 0,
@@ -657,7 +657,7 @@ namespace Microsoft.Azure.ServiceBus.Management
         public System.Threading.Tasks.Task CloseAsync() { }
         public virtual System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.Management.QueueDescription> CreateQueueAsync(string queuePath, System.Threading.CancellationToken cancellationToken = null) { }
         public virtual System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.Management.QueueDescription> CreateQueueAsync(Microsoft.Azure.ServiceBus.Management.QueueDescription queueDescription, System.Threading.CancellationToken cancellationToken = null) { }
-        public virtual System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.RuleDescription> CreateRuleAsync(string topicName, string subscriptionName, Microsoft.Azure.ServiceBus.RuleDescription ruleDescription, System.Threading.CancellationToken cancellationToken = null) { }
+        public virtual System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.RuleDescription> CreateRuleAsync(string topicPath, string subscriptionName, Microsoft.Azure.ServiceBus.RuleDescription ruleDescription, System.Threading.CancellationToken cancellationToken = null) { }
         public virtual System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.Management.SubscriptionDescription> CreateSubscriptionAsync(string topicPath, string subscriptionName, System.Threading.CancellationToken cancellationToken = null) { }
         public virtual System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.Management.SubscriptionDescription> CreateSubscriptionAsync(Microsoft.Azure.ServiceBus.Management.SubscriptionDescription subscriptionDescription, System.Threading.CancellationToken cancellationToken = null) { }
         public virtual System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.Management.SubscriptionDescription> CreateSubscriptionAsync(Microsoft.Azure.ServiceBus.Management.SubscriptionDescription subscriptionDescription, Microsoft.Azure.ServiceBus.RuleDescription defaultRule, System.Threading.CancellationToken cancellationToken = null) { }
@@ -811,7 +811,7 @@ namespace Microsoft.Azure.ServiceBus.Management
 }
 namespace Microsoft.Azure.ServiceBus.Primitives
 {
-    
+
     public class AzureActiveDirectoryTokenProvider : Microsoft.Azure.ServiceBus.Primitives.TokenProvider
     {
         public override System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.Primitives.SecurityToken> GetTokenAsync(string appliesTo, System.TimeSpan timeout) { }


### PR DESCRIPTION
topicPath is used elsewhere in other methods, this was the only one using topicName.

Also while looking at the code I discovered a typo where `EntityNameHelper.CheckValidSubscriptionName(topicName);` should have been `EntityNameHelper.CheckValidSubscriptionName(subscriptionName);` .