### PR TITLE
Making Queue/Topic/Subscription descriptions forward compatible (#563) + Minor bugs

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Filters/XmlObjectConvertor.cs
+++ b/src/Microsoft.Azure.ServiceBus/Filters/XmlObjectConvertor.cs
@@ -13,6 +13,11 @@ namespace Microsoft.Azure.ServiceBus.Filters
         internal static object ParseValueObject(XElement element)
         {
             var prefix = element.GetPrefixOfNamespace(XNamespace.Get(ManagementClientConstants.XmlSchemaNs));
+            if (string.IsNullOrWhiteSpace(prefix))
+            {
+                return element.Value;
+            }
+
             var type = element.Attribute(XName.Get("type", ManagementClientConstants.XmlSchemaInstanceNs)).Value;
             switch (type.Substring(prefix.Length + 1))
             {

--- a/src/Microsoft.Azure.ServiceBus/Management/AuthorizationRules.cs
+++ b/src/Microsoft.Azure.ServiceBus/Management/AuthorizationRules.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.ServiceBus.Management
 
         public bool Equals(AuthorizationRules other)
         {
-            if (other == null || this.Count != other.Count)
+            if (ReferenceEquals(other, null) || this.Count != other.Count)
             {
                 return false;
             }

--- a/src/Microsoft.Azure.ServiceBus/Management/ManagementClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/Management/ManagementClient.cs
@@ -899,7 +899,7 @@ namespace Microsoft.Azure.ServiceBus.Management
                 return null;
             }
 
-            var exceptionMessage = await response.Content?.ReadAsStringAsync();
+            var exceptionMessage = await (response.Content?.ReadAsStringAsync() ?? Task.FromResult(string.Empty));
             exceptionMessage = ParseDetailIfAvailable(exceptionMessage) ?? response.ReasonPhrase;
 
             if (response.StatusCode == HttpStatusCode.Unauthorized)

--- a/src/Microsoft.Azure.ServiceBus/Management/ManagementClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/Management/ManagementClient.cs
@@ -247,6 +247,8 @@ namespace Microsoft.Azure.ServiceBus.Management
         /// <exception cref="UnauthorizedAccessException">No sufficient permission to perform this operation. You should check to ensure that your <see cref="ManagementClient"/> has the correct <see cref="TokenProvider"/> credentials to perform this operation.</exception>
         /// <exception cref="ServerBusyException">The server is busy. You should wait before you retry the operation.</exception>
         /// <exception cref="ServiceBusException">An internal error or an unexpected exception occured.</exception>
+        /// <remarks>Note - Only following data types are deserialized in Filters and Action parameters - string,int,long,bool,double,DateTime.
+        /// Other data types would return its string value.</remarks>
         public virtual async Task<RuleDescription> GetRuleAsync(string topicPath, string subscriptionName, string ruleName, CancellationToken cancellationToken = default)
         {
             EntityNameHelper.CheckValidTopicName(topicPath);
@@ -436,7 +438,9 @@ namespace Microsoft.Azure.ServiceBus.Management
         /// <exception cref="ServerBusyException">The server is busy. You should wait before you retry the operation.</exception>
         /// <exception cref="ServiceBusException">An internal error or an unexpected exception occured.</exception>
         /// <remarks>You can simulate pages of list of entities by manipulating <paramref name="count"/> and <paramref name="skip"/>.
-        /// skip(0)+count(100) gives first 100 entities. skip(100)+count(100) gives the next 100 entities.</remarks>
+        /// skip(0)+count(100) gives first 100 entities. skip(100)+count(100) gives the next 100 entities.
+        /// Note - Only following data types are deserialized in Filters and Action parameters - string,int,long,bool,double,DateTime.
+        /// Other data types would return its string value.</remarks>
         public virtual async Task<IList<RuleDescription>> GetRulesAsync(string topicPath, string subscriptionName, int count = 100, int skip = 0, CancellationToken cancellationToken = default)
         {
             EntityNameHelper.CheckValidTopicName(topicPath);

--- a/src/Microsoft.Azure.ServiceBus/Management/QueueDescription.cs
+++ b/src/Microsoft.Azure.ServiceBus/Management/QueueDescription.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Azure.ServiceBus.Management
 {
     using System;
+    using System.Collections.Generic;
     using Microsoft.Azure.ServiceBus.Primitives;
 
     /// <summary>
@@ -282,6 +283,12 @@ namespace Microsoft.Azure.ServiceBus.Management
                 this.userMetadata = value;
             }
         }
+
+        /// <summary>
+        /// List of properties that were retrieved using GetQueue but is not understood by this version of client is stored here.
+        /// These will be sent back to the service as-is when UpdateQueue is called on this QueueDescription.
+        /// </summary>
+        internal List<object> UnknownProperties { get; set; }
 
         public override int GetHashCode()
         {

--- a/src/Microsoft.Azure.ServiceBus/Management/QueueDescription.cs
+++ b/src/Microsoft.Azure.ServiceBus/Management/QueueDescription.cs
@@ -294,14 +294,10 @@ namespace Microsoft.Azure.ServiceBus.Management
             return this.Equals(other);
         }
 
-        public bool Equals(QueueDescription other)
+        public bool Equals(QueueDescription otherDescription)
         {
-            if (other == null)
-            {
-                return false;
-            }
-
-            if (this.Path.Equals(other.Path, StringComparison.OrdinalIgnoreCase)
+            if (otherDescription is QueueDescription other
+                && this.Path.Equals(other.Path, StringComparison.OrdinalIgnoreCase)
                 && this.AutoDeleteOnIdle.Equals(other.AutoDeleteOnIdle)
                 && this.DefaultMessageTimeToLive.Equals(other.DefaultMessageTimeToLive)
                 && (!this.RequiresDuplicateDetection || this.DuplicateDetectionHistoryTimeWindow.Equals(other.DuplicateDetectionHistoryTimeWindow))

--- a/src/Microsoft.Azure.ServiceBus/Management/SubscriptionDescription.cs
+++ b/src/Microsoft.Azure.ServiceBus/Management/SubscriptionDescription.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Azure.ServiceBus.Management
 {
     using System;
+    using System.Collections.Generic;
     using Microsoft.Azure.ServiceBus.Primitives;
 
     /// <summary>
@@ -247,6 +248,12 @@ namespace Microsoft.Azure.ServiceBus.Management
                 this.userMetadata = value;
             }
         }
+
+        /// <summary>
+        /// List of properties that were retrieved using GetSubscription but is not understood by this version of client is stored here.
+        /// These will be sent back to the service as-is when UpdateSubscription is called on this SubscriptionDescription.
+        /// </summary>
+        internal List<object> UnknownProperties { get; set; }
 
         internal RuleDescription DefaultRuleDescription { get; set; }
 

--- a/src/Microsoft.Azure.ServiceBus/Management/TopicDescription.cs
+++ b/src/Microsoft.Azure.ServiceBus/Management/TopicDescription.cs
@@ -200,7 +200,8 @@ namespace Microsoft.Azure.ServiceBus.Management
 
         public bool Equals(TopicDescription otherDescription)
         {
-            if (otherDescription is TopicDescription other && this.Path.Equals(other.Path, StringComparison.OrdinalIgnoreCase)
+            if (otherDescription is TopicDescription other 
+                && this.Path.Equals(other.Path, StringComparison.OrdinalIgnoreCase)
                 && this.AutoDeleteOnIdle.Equals(other.AutoDeleteOnIdle)
                 && this.DefaultMessageTimeToLive.Equals(other.DefaultMessageTimeToLive)
                 && (!this.RequiresDuplicateDetection || this.DuplicateDetectionHistoryTimeWindow.Equals(other.DuplicateDetectionHistoryTimeWindow))

--- a/src/Microsoft.Azure.ServiceBus/Management/TopicDescription.cs
+++ b/src/Microsoft.Azure.ServiceBus/Management/TopicDescription.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Azure.ServiceBus.Management
 {
     using System;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Represents the metadata description of the topic.
@@ -186,6 +187,12 @@ namespace Microsoft.Azure.ServiceBus.Management
                 this.userMetadata = value;
             }
         }
+
+        /// <summary>
+        /// List of properties that were retrieved using GetTopic but is not understood by this version of client is stored here.
+        /// These will be sent back to the service as-is when UpdateTopic is called on this TopicDescription.
+        /// </summary>
+        internal List<object> UnknownProperties { get; set; }
 
         public override int GetHashCode()
         {

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -721,7 +721,7 @@ namespace Microsoft.Azure.ServiceBus.Management
         public Microsoft.Azure.ServiceBus.Management.EntityStatus Status { get; set; }
         public string UserMetadata { get; set; }
         public override bool Equals(object obj) { }
-        public bool Equals(Microsoft.Azure.ServiceBus.Management.QueueDescription other) { }
+        public bool Equals(Microsoft.Azure.ServiceBus.Management.QueueDescription otherDescription) { }
         public override int GetHashCode() { }
     }
     public class QueueRuntimeInfo


### PR DESCRIPTION
Fixes-
#563 - Making Queue/Topic/Subscription descriptions forward compatible by storing all unknown properties in a list and relaying it back during Update.
#564 - Equals() should not use == to check for null
#562 - NRE when content = null.
NRE when GetRules() is invoked on rules containing custom data types.