### PR TITLE
Bugfix #544 - Receiving deferred message from sessionful partitioned entity.

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -1141,6 +1141,10 @@ namespace Microsoft.Azure.ServiceBus.Core
                 }
                 amqpRequestMessage.Map[ManagementConstants.Properties.SequenceNumbers] = sequenceNumbers;
                 amqpRequestMessage.Map[ManagementConstants.Properties.ReceiverSettleMode] = (uint)(this.ReceiveMode == ReceiveMode.ReceiveAndDelete ? 0 : 1);
+                if (!string.IsNullOrWhiteSpace(this.SessionIdInternal))
+                {
+                    amqpRequestMessage.Map[ManagementConstants.Properties.SessionId] = this.SessionIdInternal;
+                }
 
                 var response = await this.ExecuteRequestResponseAsync(amqpRequestMessage).ConfigureAwait(false);
 

--- a/src/Microsoft.Azure.ServiceBus/TransportType.cs
+++ b/src/Microsoft.Azure.ServiceBus/TransportType.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.ServiceBus
         /// Uses AMQP over WebSockets
         /// </summary>
         /// <remarks>This runs on port 443 with wss URI scheme. This could be used in scenarios where traffic to port 5671 is blocked. 
-        /// To setup a proxy connection, please configure system default proxy. Proxy currently is supported only in net451+ and .netcore 2.1+ framework.</remarks>
+        /// To setup a proxy connection, please configure system default proxy. Proxy currently is supported only in  .NET 4.5.1 and higher or .NET Core 2.1 and higher.</remarks>
         AmqpWebSockets = 1
     }
 }

--- a/src/Microsoft.Azure.ServiceBus/TransportType.cs
+++ b/src/Microsoft.Azure.ServiceBus/TransportType.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.ServiceBus
         /// Uses AMQP over WebSockets
         /// </summary>
         /// <remarks>This runs on port 443 with wss URI scheme. This could be used in scenarios where traffic to port 5671 is blocked. 
-        /// To setup a proxy connection, please configure system default proxy. Proxy currently is supported only in net451+ framework.</remarks>
+        /// To setup a proxy connection, please configure system default proxy. Proxy currently is supported only in net451+ and .netcore 2.1+ framework.</remarks>
         AmqpWebSockets = 1
     }
 }


### PR DESCRIPTION
For a partitioned session queue, sessionId is required for receiving deferred messages. Passing the value now.
Fixes #544 