### PR TITLE
[SPIKE] Switch MessageHandlers to use ValueTask

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Core/IReceiverClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/IReceiverClient.cs
@@ -45,23 +45,23 @@ namespace Microsoft.Azure.ServiceBus.Core
 
         /// <summary>
         /// Receive messages continuously from the entity. Registers a message handler and begins a new thread to receive messages.
-        /// This handler(<see cref="Func{Message, CancellationToken, Task}"/>) is awaited on every time a new message is received by the receiver.
+        /// This handler(<see cref="Func{Message, CancellationToken, ValueTask}"/>) is awaited on every time a new message is received by the receiver.
         /// </summary>
-        /// <param name="handler">A <see cref="Func{Message, CancellationToken, Task}"/> that processes messages.</param>
+        /// <param name="handler">A <see cref="Func{Message, CancellationToken, ValueTask}"/> that processes messages.</param>
         /// <param name="exceptionReceivedHandler">A <see cref="Func{T1, TResult}"/> that is invoked during exceptions.
         /// <see cref="ExceptionReceivedEventArgs"/> contains contextual information regarding the exception.</param>
         /// <remarks>Enable prefetch to speed up the receive rate.
-        /// Use <see cref="RegisterMessageHandler(Func{Message,CancellationToken,Task}, MessageHandlerOptions)"/> to configure the settings of the pump.</remarks>
-        void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler);
+        /// Use <see cref="RegisterMessageHandler(Func{Message,CancellationToken,ValueTask}, MessageHandlerOptions)"/> to configure the settings of the pump.</remarks>
+        void RegisterMessageHandler(Func<Message, CancellationToken, ValueTask> handler, Func<ExceptionReceivedEventArgs, ValueTask> exceptionReceivedHandler);
 
         /// <summary>
         /// Receive messages continuously from the entity. Registers a message handler and begins a new thread to receive messages.
-        /// This handler(<see cref="Func{Message, CancellationToken, Task}"/>) is awaited on every time a new message is received by the receiver.
+        /// This handler(<see cref="Func{Message, CancellationToken, ValueTask}"/>) is awaited on every time a new message is received by the receiver.
         /// </summary>
-        /// <param name="handler">A <see cref="Func{Message, CancellationToken, Task}"/> that processes messages.</param>
+        /// <param name="handler">A <see cref="Func{Message, CancellationToken, ValueTask}"/> that processes messages.</param>
         /// <param name="messageHandlerOptions">The <see cref="MessageHandlerOptions"/> options used to configure the settings of the pump.</param>
         /// <remarks>Enable prefetch to speed up the receive rate.</remarks>
-        void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, MessageHandlerOptions messageHandlerOptions);
+        void RegisterMessageHandler(Func<Message, CancellationToken, ValueTask> handler, MessageHandlerOptions messageHandlerOptions);
 
         /// <summary>
         /// Completes a <see cref="Message"/> using its lock token. This will delete the message from the queue.

--- a/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
+++ b/src/Microsoft.Azure.ServiceBus/Core/MessageReceiver.cs
@@ -224,7 +224,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// replenished in the background as space becomes available.If there are no messages available for delivery, the receive operation will drain the
         /// buffer and then wait or block as expected.
         /// </para>
-        /// <para>Prefetch also works equivalently with the <see cref="RegisterMessageHandler(Func{Message,CancellationToken,Task}, Func{ExceptionReceivedEventArgs, Task})"/> APIs.</para>
+        /// <para>Prefetch also works equivalently with the <see cref="RegisterMessageHandler(Func{Message,CancellationToken,ValueTask}, Func{ExceptionReceivedEventArgs, ValueTask})"/> APIs.</para>
         /// <para>Updates to this value take effect on the next receive call to the service.</para>
         /// </remarks>
         public int PrefetchCount
@@ -877,11 +877,11 @@ namespace Microsoft.Azure.ServiceBus.Core
 
         /// <summary>
         /// Receive messages continuously from the entity. Registers a message handler and begins a new thread to receive messages.
-        /// This handler(<see cref="Func{Message, CancellationToken, Task}"/>) is awaited on every time a new message is received by the receiver.
+        /// This handler(<see cref="Func{Message, CancellationToken, ValueTask}"/>) is awaited on every time a new message is received by the receiver.
         /// </summary>
         /// <param name="handler">A <see cref="Func{T1, T2, TResult}"/> that processes messages.</param>
         /// <param name="exceptionReceivedHandler">A <see cref="Func{T1, TResult}"/> that is used to notify exceptions.</param>
-        public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler)
+        public void RegisterMessageHandler(Func<Message, CancellationToken, ValueTask> handler, Func<ExceptionReceivedEventArgs, ValueTask> exceptionReceivedHandler)
         {
             this.RegisterMessageHandler(handler, new MessageHandlerOptions(exceptionReceivedHandler));
         }
@@ -890,10 +890,10 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// Receive messages continuously from the entity. Registers a message handler and begins a new thread to receive messages.
         /// This handler(<see cref="Func{Message, CancellationToken, Task}"/>) is awaited on every time a new message is received by the receiver.
         /// </summary>
-        /// <param name="handler">A <see cref="Func{Message, CancellationToken, Task}"/> that processes messages.</param>
+        /// <param name="handler">A <see cref="Func{Message, CancellationToken, ValueTask}"/> that processes messages.</param>
         /// <param name="messageHandlerOptions">The <see cref="MessageHandlerOptions"/> options used to configure the settings of the pump.</param>
         /// <remarks>Enable prefetch to speed up the receive rate.</remarks>
-        public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, MessageHandlerOptions messageHandlerOptions)
+        public void RegisterMessageHandler(Func<Message, CancellationToken, ValueTask> handler, MessageHandlerOptions messageHandlerOptions)
         {
             this.ThrowIfClosed();
             this.OnMessageHandler(messageHandlerOptions, handler);
@@ -1266,7 +1266,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// <summary> </summary>
         protected virtual void OnMessageHandler(
             MessageHandlerOptions registerHandlerOptions,
-            Func<Message, CancellationToken, Task> callback)
+            Func<Message, CancellationToken, ValueTask> callback)
         {
             MessagingEventSource.Log.RegisterOnMessageHandlerStart(this.ClientId, registerHandlerOptions);
 

--- a/src/Microsoft.Azure.ServiceBus/IQueueClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/IQueueClient.cs
@@ -58,24 +58,24 @@ namespace Microsoft.Azure.ServiceBus
 
         /// <summary>
         /// Receive session messages continuously from the queue. Registers a message handler and begins a new thread to receive session-messages.
-        /// This handler(<see cref="Func{IMessageSession, Message, CancellationToken, Task}"/>) is awaited on every time a new message is received by the queue client.
+        /// This handler(<see cref="Func{IMessageSession, Message, CancellationToken, ValueTask}"/>) is awaited on every time a new message is received by the queue client.
         /// </summary>
-        /// <param name="handler">A <see cref="Func{IMessageSession, Message, CancellationToken, Task}"/> that processes messages.
+        /// <param name="handler">A <see cref="Func{IMessageSession, Message, CancellationToken, ValueTask}"/> that processes messages.
         /// <see cref="IMessageSession"/> contains the session information, and must be used to perform Complete/Abandon/Deadletter or other such operations on the <see cref="Message"/></param>
         /// <param name="exceptionReceivedHandler">A <see cref="Func{T1, TResult}"/> that is invoked during exceptions.
         /// <see cref="ExceptionReceivedEventArgs"/> contains contextual information regarding the exception.</param>
         /// <remarks>Enable prefetch to speed up the receive rate.
-        /// Use <see cref="RegisterSessionHandler(Func{IMessageSession,Message,CancellationToken,Task}, SessionHandlerOptions)"/> to configure the settings of the pump.</remarks>
-        void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, Task> handler, Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler);
+        /// Use <see cref="RegisterSessionHandler(Func{IMessageSession,Message,CancellationToken,ValueTask}, SessionHandlerOptions)"/> to configure the settings of the pump.</remarks>
+        void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, ValueTask> handler, Func<ExceptionReceivedEventArgs, ValueTask> exceptionReceivedHandler);
 
         /// <summary>
         /// Receive session messages continuously from the queue. Registers a message handler and begins a new thread to receive session-messages.
         /// This handler(<see cref="Func{IMessageSession, Message, CancellationToken, Task}"/>) is awaited on every time a new message is received by the queue client.
         /// </summary>
-        /// <param name="handler">A <see cref="Func{IMessageSession, Message, CancellationToken, Task}"/> that processes messages.
+        /// <param name="handler">A <see cref="Func{IMessageSession, Message, CancellationToken, ValueTask}"/> that processes messages.
         /// <see cref="IMessageSession"/> contains the session information, and must be used to perform Complete/Abandon/Deadletter or other such operations on the <see cref="Message"/></param>
         /// <param name="sessionHandlerOptions">Options used to configure the settings of the session pump.</param>
         /// <remarks>Enable prefetch to speed up the receive rate. </remarks>
-        void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, Task> handler, SessionHandlerOptions sessionHandlerOptions);
+        void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, ValueTask> handler, SessionHandlerOptions sessionHandlerOptions);
     }
 }

--- a/src/Microsoft.Azure.ServiceBus/ISubscriptionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/ISubscriptionClient.cs
@@ -97,22 +97,22 @@ namespace Microsoft.Azure.ServiceBus
         /// Receive session messages continuously from the subscription. Registers a message handler and begins a new thread to receive session-messages.
         /// This handler(<see cref="Func{T1,T2,T3,TResult}"/>) is awaited on every time a new message is received by the subscription client.
         /// </summary>
-        /// <param name="handler">A <see cref="Func{IMessageSession, Message, CancellationToken, Task}"/> that processes messages.
+        /// <param name="handler">A <see cref="Func{IMessageSession, Message, CancellationToken, ValueTask}"/> that processes messages.
         /// <see cref="IMessageSession"/> contains the session information, and must be used to perform Complete/Abandon/Deadletter or other such operations on the <see cref="Message"/></param>
         /// <param name="exceptionReceivedHandler">A <see cref="Func{T1, TResult}"/> that is invoked during exceptions.
         /// <see cref="ExceptionReceivedEventArgs"/> contains contextual information regarding the exception.</param>
         /// <remarks>Enable prefetch to speed up the receive rate.
-        /// Use <see cref="RegisterSessionHandler(Func{IMessageSession,Message,CancellationToken,Task}, SessionHandlerOptions)"/> to configure the settings of the pump.</remarks>
-        void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, Task> handler, Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler);
+        /// Use <see cref="RegisterSessionHandler(Func{IMessageSession,Message,CancellationToken,ValueTask}, SessionHandlerOptions)"/> to configure the settings of the pump.</remarks>
+        void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, ValueTask> handler, Func<ExceptionReceivedEventArgs, ValueTask> exceptionReceivedHandler);
 
         /// <summary>
         /// Receive session messages continuously from the subscription. Registers a message handler and begins a new thread to receive session-messages.
-        /// This handler(<see cref="Func{IMessageSession, Message, CancellationToken, Task}"/>) is awaited on every time a new message is received by the subscription client.
+        /// This handler(<see cref="Func{IMessageSession, Message, CancellationToken, ValueTask}"/>) is awaited on every time a new message is received by the subscription client.
         /// </summary>
-        /// <param name="handler">A <see cref="Func{IMessageSession, Message, CancellationToken, Task}"/> that processes messages.
+        /// <param name="handler">A <see cref="Func{IMessageSession, Message, CancellationToken, ValueTask}"/> that processes messages.
         /// <see cref="IMessageSession"/> contains the session information, and must be used to perform Complete/Abandon/Deadletter or other such operations on the <see cref="Message"/></param>
         /// <param name="sessionHandlerOptions">Options used to configure the settings of the session pump.</param>
         /// <remarks>Enable prefetch to speed up the receive rate. </remarks>
-        void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, Task> handler, SessionHandlerOptions sessionHandlerOptions);
+        void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, ValueTask> handler, SessionHandlerOptions sessionHandlerOptions);
     }
 }

--- a/src/Microsoft.Azure.ServiceBus/MessageHandlerOptions.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageHandlerOptions.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Azure.ServiceBus
     using Primitives;
 
     /// <summary>Provides options associated with message pump processing using
-    /// <see cref="QueueClient.RegisterMessageHandler(Func{Message, CancellationToken, Task}, MessageHandlerOptions)" /> and
-    /// <see cref="SubscriptionClient.RegisterMessageHandler(Func{Message, CancellationToken, Task}, MessageHandlerOptions)" />.</summary>
+    /// <see cref="QueueClient.RegisterMessageHandler(Func{Message, CancellationToken, ValueTask}, MessageHandlerOptions)" /> and
+    /// <see cref="SubscriptionClient.RegisterMessageHandler(Func{Message, CancellationToken, ValueTask}, MessageHandlerOptions)" />.</summary>
     public sealed class MessageHandlerOptions
     {
         int maxConcurrentCalls;
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.ServiceBus
         /// </summary>
         /// <param name="exceptionReceivedHandler">A <see cref="Func{T1, TResult}"/> that is invoked during exceptions.
         /// <see cref="ExceptionReceivedEventArgs"/> contains contextual information regarding the exception.</param>
-        public MessageHandlerOptions(Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler)
+        public MessageHandlerOptions(Func<ExceptionReceivedEventArgs, ValueTask> exceptionReceivedHandler)
         {
             this.MaxConcurrentCalls = 1;
             this.AutoComplete = true;
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.ServiceBus
 
         /// <summary>Occurs when an exception is received. Enables you to be notified of any errors encountered by the message pump.
         /// When errors are received calls will automatically be retried, so this is informational. </summary>
-        public Func<ExceptionReceivedEventArgs, Task> ExceptionReceivedHandler { get; }
+        public Func<ExceptionReceivedEventArgs, ValueTask> ExceptionReceivedHandler { get; }
 
         /// <summary>Gets or sets the maximum number of concurrent calls to the callback the message pump should initiate.</summary>
         /// <value>The maximum number of concurrent calls to the callback.</value>

--- a/src/Microsoft.Azure.ServiceBus/MessageReceivePump.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageReceivePump.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.ServiceBus
 
     sealed class MessageReceivePump
     {
-        readonly Func<Message, CancellationToken, Task> onMessageCallback;
+        readonly Func<Message, CancellationToken, ValueTask> onMessageCallback;
         readonly string endpoint;
         readonly MessageHandlerOptions registerHandlerOptions;
         readonly IMessageReceiver messageReceiver;
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.ServiceBus
 
         public MessageReceivePump(IMessageReceiver messageReceiver,
             MessageHandlerOptions registerHandlerOptions,
-            Func<Message, CancellationToken, Task> callback,
+            Func<Message, CancellationToken, ValueTask> callback,
             Uri endpoint,
             CancellationToken pumpCancellationToken)
         {
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.ServiceBus
                     if (!(exception is ObjectDisposedException && this.pumpCancellationToken.IsCancellationRequested))
                     {
                         MessagingEventSource.Log.MessageReceivePumpTaskException(this.messageReceiver.ClientId, string.Empty, exception);
-                        await this.RaiseExceptionReceived(exception, ExceptionReceivedEventArgsAction.Receive).ConfigureAwait(false); 
+                        await this.RaiseExceptionReceived(exception, ExceptionReceivedEventArgsAction.Receive).ConfigureAwait(false);
                     }
                 }
                 finally

--- a/src/Microsoft.Azure.ServiceBus/MessageSession.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageSession.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.ServiceBus
             return ServiceBusDiagnosticSource.IsEnabled() ? this.OnRenewSessionLockInstrumentedAsync() : this.OnRenewSessionLockAsync();
         }
 
-        protected override void OnMessageHandler(MessageHandlerOptions registerHandlerOptions, Func<Message, CancellationToken, Task> callback)
+        protected override void OnMessageHandler(MessageHandlerOptions registerHandlerOptions, Func<Message, CancellationToken, ValueTask> callback)
         {
             throw new InvalidOperationException($"{nameof(RegisterMessageHandler)} is not supported for Sessions.");
         }

--- a/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
+++ b/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="[5.2.2, 6.0.0)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/src/Microsoft.Azure.ServiceBus/QueueClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/QueueClient.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.ServiceBus
             {
                 throw Fx.Exception.ArgumentNullOrWhiteSpace(connectionString);
             }
-            
+
             this.OwnsConnection = true;
         }
 
@@ -328,7 +328,7 @@ namespace Microsoft.Azure.ServiceBus
                 return this.sessionPumpHost;
             }
         }
-        
+
         ICbsTokenProvider CbsTokenProvider { get; }
 
         /// <summary>
@@ -420,14 +420,14 @@ namespace Microsoft.Azure.ServiceBus
 
         /// <summary>
         /// Receive messages continuously from the entity. Registers a message handler and begins a new thread to receive messages.
-        /// This handler(<see cref="Func{Message, CancellationToken, Task}"/>) is awaited on every time a new message is received by the receiver.
+        /// This handler(<see cref="Func{Message, CancellationToken, ValueTask}"/>) is awaited on every time a new message is received by the receiver.
         /// </summary>
-        /// <param name="handler">A <see cref="Func{Message, CancellationToken, Task}"/> that processes messages.</param>
+        /// <param name="handler">A <see cref="Func{Message, CancellationToken, ValueTask}"/> that processes messages.</param>
         /// <param name="exceptionReceivedHandler">A <see cref="Func{T1, TResult}"/> that is invoked during exceptions.
         /// <see cref="ExceptionReceivedEventArgs"/> contains contextual information regarding the exception.</param>
         /// <remarks>Enable prefetch to speed up the receive rate.
-        /// Use <see cref="RegisterMessageHandler(Func{Message,CancellationToken,Task}, MessageHandlerOptions)"/> to configure the settings of the pump.</remarks>
-        public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler)
+        /// Use <see cref="RegisterMessageHandler(Func{Message,CancellationToken,ValueTask}, MessageHandlerOptions)"/> to configure the settings of the pump.</remarks>
+        public void RegisterMessageHandler(Func<Message, CancellationToken, ValueTask> handler, Func<ExceptionReceivedEventArgs, ValueTask> exceptionReceivedHandler)
         {
             this.RegisterMessageHandler(handler, new MessageHandlerOptions(exceptionReceivedHandler));
         }
@@ -439,7 +439,7 @@ namespace Microsoft.Azure.ServiceBus
         /// <param name="handler">A <see cref="Func{Message, CancellationToken, Task}"/> that processes messages.</param>
         /// <param name="messageHandlerOptions">The <see cref="MessageHandlerOptions"/> options used to configure the settings of the pump.</param>
         /// <remarks>Enable prefetch to speed up the receive rate.</remarks>
-        public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, MessageHandlerOptions messageHandlerOptions)
+        public void RegisterMessageHandler(Func<Message, CancellationToken, ValueTask> handler, MessageHandlerOptions messageHandlerOptions)
         {
             this.ThrowIfClosed();
             this.InnerReceiver.RegisterMessageHandler(handler, messageHandlerOptions);
@@ -454,8 +454,8 @@ namespace Microsoft.Azure.ServiceBus
         /// <param name="exceptionReceivedHandler">A <see cref="Func{T1, TResult}"/> that is invoked during exceptions.
         /// <see cref="ExceptionReceivedEventArgs"/> contains contextual information regarding the exception.</param>
         /// <remarks>Enable prefetch to speed up the receive rate.
-        /// Use <see cref="RegisterSessionHandler(Func{IMessageSession,Message,CancellationToken,Task}, SessionHandlerOptions)"/> to configure the settings of the pump.</remarks>
-        public void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, Task> handler, Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler)
+        /// Use <see cref="RegisterSessionHandler(Func{IMessageSession,Message,CancellationToken,ValueTask}, SessionHandlerOptions)"/> to configure the settings of the pump.</remarks>
+        public void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, ValueTask> handler, Func<ExceptionReceivedEventArgs, ValueTask> exceptionReceivedHandler)
         {
             var sessionHandlerOptions = new SessionHandlerOptions(exceptionReceivedHandler);
             this.RegisterSessionHandler(handler, sessionHandlerOptions);
@@ -469,7 +469,7 @@ namespace Microsoft.Azure.ServiceBus
         /// <see cref="IMessageSession"/> contains the session information, and must be used to perform Complete/Abandon/Deadletter or other such operations on the <see cref="Message"/></param>
         /// <param name="sessionHandlerOptions">Options used to configure the settings of the session pump.</param>
         /// <remarks>Enable prefetch to speed up the receive rate. </remarks>
-        public void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, Task> handler, SessionHandlerOptions sessionHandlerOptions)
+        public void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, ValueTask> handler, SessionHandlerOptions sessionHandlerOptions)
         {
             this.ThrowIfClosed();
             this.SessionPumpHost.OnSessionHandler(handler, sessionHandlerOptions);

--- a/src/Microsoft.Azure.ServiceBus/SessionHandlerOptions.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionHandlerOptions.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Azure.ServiceBus
     using Primitives;
 
     /// <summary>Provides options associated with session pump processing using
-    /// <see cref="QueueClient.RegisterSessionHandler(Func{IMessageSession, Message, CancellationToken, Task}, SessionHandlerOptions)" /> and
-    /// <see cref="SubscriptionClient.RegisterSessionHandler(Func{IMessageSession, Message, CancellationToken, Task}, SessionHandlerOptions)" />.</summary>
+    /// <see cref="QueueClient.RegisterSessionHandler(Func{IMessageSession, Message, CancellationToken, ValueTask}, SessionHandlerOptions)" /> and
+    /// <see cref="SubscriptionClient.RegisterSessionHandler(Func{IMessageSession, Message, CancellationToken, ValueTask}, SessionHandlerOptions)" />.</summary>
     public sealed class SessionHandlerOptions
     {
         int maxConcurrentSessions;
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.ServiceBus
         /// </summary>
         /// <param name="exceptionReceivedHandler">A <see cref="Func{T1, TResult}"/> that is invoked during exceptions.
         /// <see cref="ExceptionReceivedEventArgs"/> contains contextual information regarding the exception.</param>
-        public SessionHandlerOptions(Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler)
+        public SessionHandlerOptions(Func<ExceptionReceivedEventArgs, ValueTask> exceptionReceivedHandler)
         {
             // These are default values
             this.AutoComplete = true;
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.ServiceBus
 
         /// <summary>Occurs when an exception is received. Enables you to be notified of any errors encountered by the session pump.
         /// When errors are received calls will automatically be retried, so this is informational. </summary>
-        public Func<ExceptionReceivedEventArgs, Task> ExceptionReceivedHandler { get; }
+        public Func<ExceptionReceivedEventArgs, ValueTask> ExceptionReceivedHandler { get; }
 
         /// <summary>Gets or sets the duration for which the session lock will be renewed automatically.</summary>
         /// <value>The duration for which the session renew its state.</value>

--- a/src/Microsoft.Azure.ServiceBus/SessionPumpHost.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionPumpHost.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.ServiceBus
         }
 
         public void OnSessionHandler(
-            Func<IMessageSession, Message, CancellationToken, Task> callback,
+            Func<IMessageSession, Message, CancellationToken, ValueTask> callback,
             SessionHandlerOptions sessionHandlerOptions)
         {
             MessagingEventSource.Log.RegisterOnSessionHandlerStart(this.ClientId, sessionHandlerOptions);

--- a/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/SubscriptionClient.cs
@@ -393,14 +393,14 @@ namespace Microsoft.Azure.ServiceBus
 
         /// <summary>
         /// Receive messages continuously from the entity. Registers a message handler and begins a new thread to receive messages.
-        /// This handler(<see cref="Func{Message, CancellationToken, Task}"/>) is awaited on every time a new message is received by the receiver.
+        /// This handler(<see cref="Func{Message, CancellationToken, ValueTask}"/>) is awaited on every time a new message is received by the receiver.
         /// </summary>
-        /// <param name="handler">A <see cref="Func{Message, CancellationToken, Task}"/> that processes messages.</param>
+        /// <param name="handler">A <see cref="Func{Message, CancellationToken, ValueTask}"/> that processes messages.</param>
         /// <param name="exceptionReceivedHandler">A <see cref="Func{T1, TResult}"/> that is invoked during exceptions.
         /// <see cref="ExceptionReceivedEventArgs"/> contains contextual information regarding the exception.</param>
         /// <remarks>Enable prefetch to speed up the receive rate.
-        /// Use <see cref="RegisterMessageHandler(Func{Message,CancellationToken,Task}, MessageHandlerOptions)"/> to configure the settings of the pump.</remarks>
-        public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler)
+        /// Use <see cref="RegisterMessageHandler(Func{Message,CancellationToken,ValueTask}, MessageHandlerOptions)"/> to configure the settings of the pump.</remarks>
+        public void RegisterMessageHandler(Func<Message, CancellationToken, ValueTask> handler, Func<ExceptionReceivedEventArgs, ValueTask> exceptionReceivedHandler)
         {
             this.ThrowIfClosed();
             this.InnerSubscriptionClient.InnerReceiver.RegisterMessageHandler(handler, exceptionReceivedHandler);
@@ -410,10 +410,10 @@ namespace Microsoft.Azure.ServiceBus
         /// Receive messages continuously from the entity. Registers a message handler and begins a new thread to receive messages.
         /// This handler(<see cref="Func{Message, CancellationToken, Task}"/>) is awaited on every time a new message is received by the receiver.
         /// </summary>
-        /// <param name="handler">A <see cref="Func{Message, CancellationToken, Task}"/> that processes messages.</param>
+        /// <param name="handler">A <see cref="Func{Message, CancellationToken, ValueTask}"/> that processes messages.</param>
         /// <param name="messageHandlerOptions">The <see cref="MessageHandlerOptions"/> options used to configure the settings of the pump.</param>
         /// <remarks>Enable prefetch to speed up the receive rate.</remarks>
-        public void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, MessageHandlerOptions messageHandlerOptions)
+        public void RegisterMessageHandler(Func<Message, CancellationToken, ValueTask> handler, MessageHandlerOptions messageHandlerOptions)
         {
             this.ThrowIfClosed();
             this.InnerSubscriptionClient.InnerReceiver.RegisterMessageHandler(handler, messageHandlerOptions);
@@ -421,15 +421,15 @@ namespace Microsoft.Azure.ServiceBus
 
         /// <summary>
         /// Receive session messages continuously from the queue. Registers a message handler and begins a new thread to receive session-messages.
-        /// This handler(<see cref="Func{IMessageSession, Message, CancellationToken, Task}"/>) is awaited on every time a new message is received by the subscription client.
+        /// This handler(<see cref="Func{IMessageSession, Message, CancellationToken, ValueTask}"/>) is awaited on every time a new message is received by the subscription client.
         /// </summary>
-        /// <param name="handler">A <see cref="Func{IMessageSession, Message, CancellationToken, Task}"/> that processes messages.
+        /// <param name="handler">A <see cref="Func{IMessageSession, Message, CancellationToken, ValueTask}"/> that processes messages.
         /// <see cref="IMessageSession"/> contains the session information, and must be used to perform Complete/Abandon/Deadletter or other such operations on the <see cref="Message"/></param>
         /// <param name="exceptionReceivedHandler">A <see cref="Func{T1, TResult}"/> that is invoked during exceptions.
         /// <see cref="ExceptionReceivedEventArgs"/> contains contextual information regarding the exception.</param>
         /// <remarks>  Enable prefetch to speed up the receive rate.
-        /// Use <see cref="RegisterSessionHandler(Func{IMessageSession,Message,CancellationToken,Task}, SessionHandlerOptions)"/> to configure the settings of the pump.</remarks>
-        public void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, Task> handler, Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler)
+        /// Use <see cref="RegisterSessionHandler(Func{IMessageSession,Message,CancellationToken,ValueTask}, SessionHandlerOptions)"/> to configure the settings of the pump.</remarks>
+        public void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, ValueTask> handler, Func<ExceptionReceivedEventArgs, ValueTask> exceptionReceivedHandler)
         {
             var sessionHandlerOptions = new SessionHandlerOptions(exceptionReceivedHandler);
             this.RegisterSessionHandler(handler, sessionHandlerOptions);
@@ -437,13 +437,13 @@ namespace Microsoft.Azure.ServiceBus
 
         /// <summary>
         /// Receive session messages continuously from the queue. Registers a message handler and begins a new thread to receive session-messages.
-        /// This handler(<see cref="Func{IMessageSession, Message, CancellationToken, Task}"/>) is awaited on every time a new message is received by the subscription client.
+        /// This handler(<see cref="Func{IMessageSession, Message, CancellationToken, ValueTask}"/>) is awaited on every time a new message is received by the subscription client.
         /// </summary>
-        /// <param name="handler">A <see cref="Func{IMessageSession, Message, CancellationToken, Task}"/> that processes messages.
+        /// <param name="handler">A <see cref="Func{IMessageSession, Message, CancellationToken, ValueTask}"/> that processes messages.
         /// <see cref="IMessageSession"/> contains the session information, and must be used to perform Complete/Abandon/Deadletter or other such operations on the <see cref="Message"/></param>
         /// <param name="sessionHandlerOptions">Options used to configure the settings of the session pump.</param>
         /// <remarks>Enable prefetch to speed up the receive rate. </remarks>
-        public void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, Task> handler, SessionHandlerOptions sessionHandlerOptions)
+        public void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, ValueTask> handler, SessionHandlerOptions sessionHandlerOptions)
         {
             this.ThrowIfClosed();
             this.SessionPumpHost.OnSessionHandler(handler, sessionHandlerOptions);

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -108,8 +108,8 @@ namespace Microsoft.Azure.ServiceBus
     public interface IQueueClient : Microsoft.Azure.ServiceBus.Core.IReceiverClient, Microsoft.Azure.ServiceBus.Core.ISenderClient, Microsoft.Azure.ServiceBus.IClientEntity
     {
         string QueueName { get; }
-        void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler);
-        void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, Microsoft.Azure.ServiceBus.SessionHandlerOptions sessionHandlerOptions);
+        void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> handler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.ValueTask> exceptionReceivedHandler);
+        void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> handler, Microsoft.Azure.ServiceBus.SessionHandlerOptions sessionHandlerOptions);
     }
     public interface ISessionClient : Microsoft.Azure.ServiceBus.IClientEntity
     {
@@ -126,8 +126,8 @@ namespace Microsoft.Azure.ServiceBus
         System.Threading.Tasks.Task AddRuleAsync(string ruleName, Microsoft.Azure.ServiceBus.Filter filter);
         System.Threading.Tasks.Task AddRuleAsync(Microsoft.Azure.ServiceBus.RuleDescription description);
         System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Azure.ServiceBus.RuleDescription>> GetRulesAsync();
-        void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler);
-        void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, Microsoft.Azure.ServiceBus.SessionHandlerOptions sessionHandlerOptions);
+        void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> handler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.ValueTask> exceptionReceivedHandler);
+        void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> handler, Microsoft.Azure.ServiceBus.SessionHandlerOptions sessionHandlerOptions);
         System.Threading.Tasks.Task RemoveRuleAsync(string ruleName);
     }
     public interface ITopicClient : Microsoft.Azure.ServiceBus.Core.ISenderClient, Microsoft.Azure.ServiceBus.IClientEntity
@@ -175,9 +175,9 @@ namespace Microsoft.Azure.ServiceBus
     }
     public sealed class MessageHandlerOptions
     {
-        public MessageHandlerOptions(System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler) { }
+        public MessageHandlerOptions(System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.ValueTask> exceptionReceivedHandler) { }
         public bool AutoComplete { get; set; }
-        public System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> ExceptionReceivedHandler { get; }
+        public System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.ValueTask> ExceptionReceivedHandler { get; }
         public System.TimeSpan MaxAutoRenewDuration { get; set; }
         public int MaxConcurrentCalls { get; set; }
     }
@@ -230,11 +230,11 @@ namespace Microsoft.Azure.ServiceBus
         public System.Threading.Tasks.Task DeadLetterAsync(string lockToken, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null) { }
         public System.Threading.Tasks.Task DeadLetterAsync(string lockToken, string deadLetterReason, string deadLetterErrorDescription = null) { }
         protected override System.Threading.Tasks.Task OnClosingAsync() { }
-        public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler) { }
-        public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, Microsoft.Azure.ServiceBus.MessageHandlerOptions messageHandlerOptions) { }
+        public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> handler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.ValueTask> exceptionReceivedHandler) { }
+        public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> handler, Microsoft.Azure.ServiceBus.MessageHandlerOptions messageHandlerOptions) { }
         public override void RegisterPlugin(Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin serviceBusPlugin) { }
-        public void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler) { }
-        public void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, Microsoft.Azure.ServiceBus.SessionHandlerOptions sessionHandlerOptions) { }
+        public void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> handler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.ValueTask> exceptionReceivedHandler) { }
+        public void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> handler, Microsoft.Azure.ServiceBus.SessionHandlerOptions sessionHandlerOptions) { }
         public System.Threading.Tasks.Task<long> ScheduleMessageAsync(Microsoft.Azure.ServiceBus.Message message, System.DateTimeOffset scheduleEnqueueTimeUtc) { }
         public System.Threading.Tasks.Task SendAsync(Microsoft.Azure.ServiceBus.Message message) { }
         public System.Threading.Tasks.Task SendAsync(System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Message> messageList) { }
@@ -373,9 +373,9 @@ namespace Microsoft.Azure.ServiceBus
     }
     public sealed class SessionHandlerOptions
     {
-        public SessionHandlerOptions(System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler) { }
+        public SessionHandlerOptions(System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.ValueTask> exceptionReceivedHandler) { }
         public bool AutoComplete { get; set; }
-        public System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> ExceptionReceivedHandler { get; }
+        public System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.ValueTask> ExceptionReceivedHandler { get; }
         public System.TimeSpan MaxAutoRenewDuration { get; set; }
         public int MaxConcurrentSessions { get; set; }
         public System.TimeSpan MessageWaitTimeout { get; set; }
@@ -428,11 +428,11 @@ namespace Microsoft.Azure.ServiceBus
         public System.Threading.Tasks.Task DeadLetterAsync(string lockToken, string deadLetterReason, string deadLetterErrorDescription = null) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Azure.ServiceBus.RuleDescription>> GetRulesAsync() { }
         protected override System.Threading.Tasks.Task OnClosingAsync() { }
-        public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler) { }
-        public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, Microsoft.Azure.ServiceBus.MessageHandlerOptions messageHandlerOptions) { }
+        public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> handler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.ValueTask> exceptionReceivedHandler) { }
+        public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> handler, Microsoft.Azure.ServiceBus.MessageHandlerOptions messageHandlerOptions) { }
         public override void RegisterPlugin(Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin serviceBusPlugin) { }
-        public void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler) { }
-        public void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, Microsoft.Azure.ServiceBus.SessionHandlerOptions sessionHandlerOptions) { }
+        public void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> handler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.ValueTask> exceptionReceivedHandler) { }
+        public void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> handler, Microsoft.Azure.ServiceBus.SessionHandlerOptions sessionHandlerOptions) { }
         public System.Threading.Tasks.Task RemoveRuleAsync(string ruleName) { }
         public override void UnregisterPlugin(string serviceBusPluginName) { }
     }
@@ -504,8 +504,8 @@ namespace Microsoft.Azure.ServiceBus.Core
         System.Threading.Tasks.Task CompleteAsync(string lockToken);
         System.Threading.Tasks.Task DeadLetterAsync(string lockToken, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null);
         System.Threading.Tasks.Task DeadLetterAsync(string lockToken, string deadLetterReason, string deadLetterErrorDescription = null);
-        void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler);
-        void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, Microsoft.Azure.ServiceBus.MessageHandlerOptions messageHandlerOptions);
+        void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> handler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.ValueTask> exceptionReceivedHandler);
+        void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> handler, Microsoft.Azure.ServiceBus.MessageHandlerOptions messageHandlerOptions);
     }
     public interface ISenderClient : Microsoft.Azure.ServiceBus.IClientEntity
     {
@@ -538,7 +538,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         protected virtual System.Threading.Tasks.Task OnCompleteAsync(System.Collections.Generic.IEnumerable<string> lockTokens) { }
         protected virtual System.Threading.Tasks.Task OnDeadLetterAsync(string lockToken, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null, string deadLetterReason = null, string deadLetterErrorDescription = null) { }
         protected virtual System.Threading.Tasks.Task OnDeferAsync(string lockToken, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null) { }
-        protected virtual void OnMessageHandler(Microsoft.Azure.ServiceBus.MessageHandlerOptions registerHandlerOptions, System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> callback) { }
+        protected virtual void OnMessageHandler(Microsoft.Azure.ServiceBus.MessageHandlerOptions registerHandlerOptions, System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> callback) { }
         protected virtual System.Threading.Tasks.Task<System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Message>> OnPeekAsync(long fromSequenceNumber, int messageCount = 1) { }
         protected virtual System.Threading.Tasks.Task<System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Message>> OnReceiveAsync(int maxMessageCount, System.TimeSpan serverWaitTime) { }
         protected virtual System.Threading.Tasks.Task<System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Message>> OnReceiveDeferredMessageAsync(long[] sequenceNumbers) { }
@@ -553,8 +553,8 @@ namespace Microsoft.Azure.ServiceBus.Core
         public System.Threading.Tasks.Task<System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Message>> ReceiveAsync(int maxMessageCount, System.TimeSpan operationTimeout) { }
         public System.Threading.Tasks.Task<Microsoft.Azure.ServiceBus.Message> ReceiveDeferredMessageAsync(long sequenceNumber) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Message>> ReceiveDeferredMessageAsync(System.Collections.Generic.IEnumerable<long> sequenceNumbers) { }
-        public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler) { }
-        public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, Microsoft.Azure.ServiceBus.MessageHandlerOptions messageHandlerOptions) { }
+        public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> handler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.ValueTask> exceptionReceivedHandler) { }
+        public void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> handler, Microsoft.Azure.ServiceBus.MessageHandlerOptions messageHandlerOptions) { }
         public override void RegisterPlugin(Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin serviceBusPlugin) { }
         public System.Threading.Tasks.Task RenewLockAsync(Microsoft.Azure.ServiceBus.Message message) { }
         public System.Threading.Tasks.Task<System.DateTime> RenewLockAsync(string lockToken) { }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/QueueClientDiagnosticsTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/QueueClientDiagnosticsTests.cs
@@ -31,9 +31,9 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
             this.queueClient.RegisterMessageHandler((msg, ct) => {
                     processActivity = Activity.Current;
                     processingDone.Set();
-                    return Task.CompletedTask;
+                    return default;
                 },
-                exArgs => Task.CompletedTask);
+                exArgs => default);
 
             processingDone.WaitOne(TimeSpan.FromSeconds(maxWaitSec));
             Assert.True(this.events.IsEmpty);
@@ -58,9 +58,9 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
                 {
                     processActivity = Activity.Current;
                     processingDone.Set();
-                    return Task.CompletedTask;
+                    return default;
                 },
-                exArgs => Task.CompletedTask);
+                exArgs => default);
 
             processingDone.WaitOne(TimeSpan.FromSeconds(maxWaitSec));
 
@@ -90,12 +90,12 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
                 {
                     processActivity = Activity.Current;
                     processingDone.Set();
-                    return Task.CompletedTask;
+                    return default;
                 },
                 exArgs =>
                 {
                     exceptionCalled = true;
-                    return Task.CompletedTask;
+                    return default;
                 });
 
             processingDone.WaitOne(TimeSpan.FromSeconds(maxWaitSec));
@@ -159,12 +159,12 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
                     }
 
                     processingDone.Set();
-                    return Task.CompletedTask;
+                    return default;
                 },
                 exArgs =>
                 {
                     exceptionCalled = true;
-                    return Task.CompletedTask;
+                    return default;
                 });
             processingDone.WaitOne(TimeSpan.FromSeconds(maxWaitSec));
             Assert.True(exceptionCalled);
@@ -454,9 +454,9 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
             this.queueClient.RegisterMessageHandler((msg, ct) =>
                 {
                     processingDone.Set();
-                    return Task.CompletedTask;
+                    return default;
                 },
-                exArgs => Task.CompletedTask);
+                exArgs => default);
             processingDone.WaitOne(TimeSpan.FromSeconds(maxWaitSec));
 
             Assert.True(this.events.TryDequeue(out var sendStop));

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/SessionDiagnosticsTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Diagnostics/SessionDiagnosticsTests.cs
@@ -144,9 +144,9 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
             this.queueClient.RegisterSessionHandler((session, msg, ct) =>
                 {
                     processingDone.Set();
-                    return Task.CompletedTask;
+                    return default;
                 },
-                exArgs => Task.CompletedTask);
+                exArgs => default);
 
             processingDone.WaitOne(TimeSpan.FromSeconds(maxWaitSec));
 
@@ -212,7 +212,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
             this.AssertCommonPayloadProperties(payload);
 
             var sessionId = this.GetPropertyValueFromAnonymousTypeInstance<string>(payload, "SessionId");
-            
+
             Assert.NotNull(activity);
             Assert.Null(activity.Parent);
             Assert.Equal(sessionId, activity.Tags.Single(t => t.Key == "SessionId").Value);
@@ -236,7 +236,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Diagnostics
             this.AssertCommonPayloadProperties(payload);
 
             var sessionId = this.GetPropertyValueFromAnonymousTypeInstance<string>(payload, "SessionId");
-            
+
             Assert.NotNull(activity);
             Assert.Null(activity.Parent);
             Assert.Equal(sessionId, activity.Tags.Single(t => t.Key == "SessionId").Value);

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/OnMessageQueueTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/OnMessageQueueTests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                     {
                         exceptionReceivedHandlerCalled = true;
                     }
-                    return Task.CompletedTask;
+                    return default;
                 });
 
             try

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/OnSessionQueueTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/OnSessionQueueTests.cs
@@ -111,14 +111,14 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 {
                     exceptionReceivedHandlerCalled = true;
                 }
-                return Task.CompletedTask;
+                return default;
             })
             { MaxConcurrentSessions = 1 };
 
             queueClient.RegisterSessionHandler(
                (session, message, token) =>
                {
-                   return Task.CompletedTask;
+                   return default;
                },
                sessionHandlerOptions);
 
@@ -172,10 +172,10 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             }
         }
 
-        Task ExceptionReceivedHandler(ExceptionReceivedEventArgs eventArgs)
+        ValueTask ExceptionReceivedHandler(ExceptionReceivedEventArgs eventArgs)
         {
             TestUtility.Log($"Exception Received: ClientId: {eventArgs.ExceptionReceivedContext.ClientId}, EntityPath: {eventArgs.ExceptionReceivedContext.EntityPath}, Exception: {eventArgs.Exception.Message}");
-            return Task.CompletedTask;
+            return default;
         }
     }
 }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/OnSessionTopicSubscriptionTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/OnSessionTopicSubscriptionTests.cs
@@ -57,12 +57,12 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 {
                     exceptionReceivedHandlerCalled = true;
                 }
-                return Task.CompletedTask;
+                return default;
             })
             { MaxConcurrentSessions = 1 };
 
             subscriptionClient.RegisterSessionHandler(
-               (session, message, token) => Task.CompletedTask,
+               (session, message, token) => default,
                sessionHandlerOptions);
 
             try
@@ -130,10 +130,10 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             }
         }
 
-        Task ExceptionReceivedHandler(ExceptionReceivedEventArgs eventArgs)
+        ValueTask ExceptionReceivedHandler(ExceptionReceivedEventArgs eventArgs)
         {
             TestUtility.Log($"Exception Received: ClientId: {eventArgs.ExceptionReceivedContext.ClientId}, EntityPath: {eventArgs.ExceptionReceivedContext.EntityPath}, Exception: {eventArgs.Exception.Message}");
-            return Task.CompletedTask;
+            return default;
         }
     }
 }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/PluginTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/PluginTests.cs
@@ -185,9 +185,8 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                         Assert.Equal(sendMessage.Body, message.Body);
 
                         messageReceived = true;
-                        return Task.CompletedTask;
-                    },
-                    exceptionArgs => Task.CompletedTask);
+                        return default;
+                    }, args => default);
 
                 for (var i = 0; i < 20; i++)
                 {

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/SenderReceiverClientTestBase.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/SenderReceiverClientTestBase.cs
@@ -308,10 +308,10 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             Assert.True(count == 1);
         }
 
-        Task ExceptionReceivedHandler(ExceptionReceivedEventArgs eventArgs)
+        ValueTask ExceptionReceivedHandler(ExceptionReceivedEventArgs eventArgs)
         {
             TestUtility.Log($"Exception Received: ClientId: {eventArgs.ExceptionReceivedContext.ClientId}, EntityPath: {eventArgs.ExceptionReceivedContext.EntityPath}, Exception: {eventArgs.Exception.Message}");
-            return Task.CompletedTask;
+            return default;
         }
     }
 }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/TestSessionHandler.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/TestSessionHandler.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             await TestUtility.SendSessionMessagesAsync(this.sender, NumberOfSessions, MessagesPerSession);
         }
 
-        public async Task OnSessionHandler(IMessageSession session, Message message, CancellationToken token)
+        public async ValueTask OnSessionHandler(IMessageSession session, Message message, CancellationToken token)
         {
             Assert.NotNull(session);
             Assert.NotNull(message);
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 else
                 {
                     this.sessionMessageMap[session.SessionId]++;
-                } 
+                }
             }
         }
 

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/WebSocketsEnd2EndTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/WebSocketsEnd2EndTests.cs
@@ -25,12 +25,12 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 queueClient.RegisterMessageHandler((message, token) =>
                     {
                         taskCompletionSource.SetResult(message);
-                        return Task.CompletedTask;
+                        return default;
                     },
                     exceptionReceivedArgs =>
                     {
                         taskCompletionSource.SetException(exceptionReceivedArgs.Exception);
-                        return Task.CompletedTask;
+                        return default;
                     });
                 await queueClient.SendAsync(new Message(contentAsBytes));
 


### PR DESCRIPTION
Experimental PR for issue #609 to see if switching MessageHandlers (message pumps) to `ValueTask` yields any performance benefits.

According to `ValueTask` [documentation](https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.valuetask-1?view=netcore-2.1#remarks)

> the default choice for any asynchronous method should be to return a `Task` or `Task<TResult>`. **Only if performance analysis proves it worthwhile should a `ValueTask<TResult>` be used instead of a `Task<TResult>`**. 