### PR TITLE
Do not retry when there's an ambient transaction

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/RetryExponential.cs
+++ b/src/Microsoft.Azure.ServiceBus/RetryExponential.cs
@@ -8,7 +8,8 @@ namespace Microsoft.Azure.ServiceBus
 
     /// <summary>
     /// RetryPolicy implementation where the delay between retries will grow in a staggered exponential manner.
-    /// RetryIntervals will be computed using a retryFactor which is a function of deltaBackOff (MaximumBackoff - MinimumBackoff) and MaximumRetryCount
+    /// RetryIntervals will be computed using a retryFactor which is a function of deltaBackOff (MaximumBackoff - MinimumBackoff) and MaximumRetryCount.
+    /// <remarks>RetryPolicy will not be applied when an ambient transaction is found.</remarks>
     /// </summary>
     public sealed class RetryExponential : RetryPolicy
     {

--- a/src/Microsoft.Azure.ServiceBus/RetryPolicy.cs
+++ b/src/Microsoft.Azure.ServiceBus/RetryPolicy.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.ServiceBus
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using System.Transactions;
     using Primitives;
 
     /// <summary>
@@ -124,9 +125,9 @@ namespace Microsoft.Azure.ServiceBus
 
         internal bool ShouldRetry(TimeSpan remainingTime, int currentRetryCount, Exception lastException, out TimeSpan retryInterval)
         {
-            if (lastException == null)
+            // There is no exception information or there's there's an ambient transaction - should not retry
+            if (lastException == null || Transaction.Current != null)
             {
-                // there are no exceptions.
                 retryInterval = TimeSpan.Zero;
                 return false;
             }

--- a/src/Microsoft.Azure.ServiceBus/RetryPolicy.cs
+++ b/src/Microsoft.Azure.ServiceBus/RetryPolicy.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.ServiceBus
     /// <summary>
     /// Represents an abstraction for retrying messaging operations. Users should not
     /// implement this class, and instead should use one of the provided implementations.
+    /// <remarks>RetryPolicy will not be applied when an ambient transaction is found.</remarks>
     /// </summary>
     public abstract class RetryPolicy
     {

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/RetryPolicyTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/RetryPolicyTests.cs
@@ -1,0 +1,59 @@
+﻿namespace Microsoft.Azure.ServiceBus.UnitTests
+{
+    using System;
+    using System.Threading.Tasks;
+    using System.Transactions;
+    using Xunit;
+
+    public class RetryPolicyTests
+    {
+        [Fact]
+        [DisplayTestMethodName]
+        public async Task Should_retry_when_throttled_and_no_ambient_transaction_is_detected()
+        {
+            var retryPolicy = RetryPolicy.Default;
+
+            var numberOfExecutions = 0;
+
+            await retryPolicy.RunOperation(() =>
+            {
+                if (numberOfExecutions > 1)
+                {
+                    return Task.CompletedTask;
+                }
+
+                numberOfExecutions++;
+
+                throw new ServerBusyException("Rico KABOOM!");
+            }, TimeSpan.FromSeconds(30));
+
+            Assert.Equal(2, numberOfExecutions);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        public async Task Should_not_retry_when_throttled_and_ambient_transaction_is_detected()
+        {
+            var retryPolicy = RetryPolicy.Default;
+            var numberOfExecutions = 0;
+
+            using (var tx = new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+            {
+                await Assert.ThrowsAsync<ServerBusyException>(() =>
+                    retryPolicy.RunOperation(() =>
+                    {
+                        if (numberOfExecutions > 1)
+                        {
+                            return Task.CompletedTask;
+                        }
+
+                        numberOfExecutions++;
+
+                        throw new ServerBusyException("Rico KABOOM!");
+                    }, TimeSpan.FromSeconds(30)));
+            }
+
+            Assert.Equal(1, numberOfExecutions);
+        }
+    }
+}

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/SenderReceiverClientTestBase.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/SenderReceiverClientTestBase.cs
@@ -25,8 +25,8 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         internal async Task ReceiveDeleteTestCase(IMessageSender messageSender, IMessageReceiver messageReceiver, int messageCount)
         {
             await TestUtility.SendMessagesAsync(messageSender, messageCount);
-            var receivedMessages = await TestUtility.ReceiveMessagesAsync(messageReceiver, messageCount);
-            Assert.True(messageCount == receivedMessages.Count);
+            var receivedMessages = await TestUtility.ReceiveMessagesAsync(messageReceiver, messageCount, TimeSpan.FromSeconds(10));
+            Assert.Equal(receivedMessages.Count, messageCount);
         }
 
         internal async Task PeekLockWithAbandonTestCase(IMessageSender messageSender, IMessageReceiver messageReceiver, int messageCount)

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/TestConstants.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/TestConstants.cs
@@ -3,9 +3,12 @@
 
 namespace Microsoft.Azure.ServiceBus.UnitTests
 {
+    using System;
+
     static class TestConstants
     {
         internal const int MaxAttemptsCount = 5;
+        internal readonly static TimeSpan WaitTimeBetweenAttempts = TimeSpan.FromSeconds(1);
 
         internal const string ConnectionStringEnvironmentVariable = "azure-service-bus-dotnet/connectionstring";
 


### PR DESCRIPTION
Fixes #615 

Fix is following [recommendation](https://github.com/Azure/azure-service-bus-dotnet/issues/615#issuecomment-446329787) made on the issue:
> The RetryPolicy should understand whether the operation is within a transaction scope or not. If it is, it should never retry. And this should be documented properly.

## TODO
- [x] Implement change to skip retries when an ambient transaction is detected
- [x] Document this behavior (XMLdocs, anywhere else?)
- [x] Verify with tests
- [ ] Release as a hotfix 3.2.1