### PR TITLE
[WIP] Specific optional SessionId option to listen to with SessionHandler

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/MessageSession.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageSession.cs
@@ -63,11 +63,6 @@ namespace Microsoft.Azure.ServiceBus
             return ServiceBusDiagnosticSource.IsEnabled() ? this.OnRenewSessionLockInstrumentedAsync() : this.OnRenewSessionLockAsync();
         }
 
-        protected override void OnMessageHandler(MessageHandlerOptions registerHandlerOptions, Func<Message, CancellationToken, Task> callback)
-        {
-            throw new InvalidOperationException($"{nameof(RegisterMessageHandler)} is not supported for Sessions.");
-        }
-
         protected override Task<DateTime> OnRenewLockAsync(string lockToken)
         {
             throw new InvalidOperationException($"{nameof(RenewLockAsync)} is not supported for Session. Use {nameof(RenewSessionLockAsync)} to renew sessions instead");

--- a/src/Microsoft.Azure.ServiceBus/SessionHandlerOptions.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionHandlerOptions.cs
@@ -88,7 +88,8 @@ namespace Microsoft.Azure.ServiceBus
         /// <value>true if the autocomplete option of the session handler is enabled; otherwise, false.</value>
         public bool AutoComplete { get; set; }
 
-         /// <summary>Gets or sets the optional session ID.</summary>
+         /// <summary>Gets or sets a single session ID. This option is optional.
+         /// Note that the handler will only listen to this single session ID for its entire lifetime.</summary>
         public string SessionId { get; set; }
 
         internal bool AutoRenewLock => this.MaxAutoRenewDuration > TimeSpan.Zero;

--- a/src/Microsoft.Azure.ServiceBus/SessionHandlerOptions.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionHandlerOptions.cs
@@ -88,8 +88,8 @@ namespace Microsoft.Azure.ServiceBus
         /// <value>true if the autocomplete option of the session handler is enabled; otherwise, false.</value>
         public bool AutoComplete { get; set; }
 
-         /// <summary>Gets or sets a single session ID. This option is optional.
-         /// Note that the handler will only listen to this single session ID for its entire lifetime.</summary>
+         /// <summary>Gets or sets a single session ID. This option is optional.</summary>
+         /// <remark>Note that the handler will only listen to this single session ID for its entire lifetime.</remark>
         public string SessionId { get; set; }
 
         internal bool AutoRenewLock => this.MaxAutoRenewDuration > TimeSpan.Zero;

--- a/src/Microsoft.Azure.ServiceBus/SessionHandlerOptions.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionHandlerOptions.cs
@@ -83,10 +83,13 @@ namespace Microsoft.Azure.ServiceBus
                 this.MaxConcurrentAcceptSessionCalls = Math.Min(value, 2 * Environment.ProcessorCount);
             }
         }
-
+        
         /// <summary>Gets or sets whether the autocomplete option of the session handler is enabled.</summary>
         /// <value>true if the autocomplete option of the session handler is enabled; otherwise, false.</value>
         public bool AutoComplete { get; set; }
+
+        /// <summary>Gets or sets the optional session ID</summary>
+        public string SessionId { get; set; }
 
         internal bool AutoRenewLock => this.MaxAutoRenewDuration > TimeSpan.Zero;
 

--- a/src/Microsoft.Azure.ServiceBus/SessionHandlerOptions.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionHandlerOptions.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.ServiceBus
         /// <value>true if the autocomplete option of the session handler is enabled; otherwise, false.</value>
         public bool AutoComplete { get; set; }
 
-        /// <summary>Gets or sets the optional session ID</summary>
+         /// <summary>Gets or sets the optional session ID.</summary>
         public string SessionId { get; set; }
 
         internal bool AutoRenewLock => this.MaxAutoRenewDuration > TimeSpan.Zero;

--- a/src/Microsoft.Azure.ServiceBus/SessionHandlerOptions.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionHandlerOptions.cs
@@ -88,10 +88,6 @@ namespace Microsoft.Azure.ServiceBus
         /// <value>true if the autocomplete option of the session handler is enabled; otherwise, false.</value>
         public bool AutoComplete { get; set; }
 
-         /// <summary>Gets or sets a single session ID. This option is optional.</summary>
-         /// <remark>Note that the handler will only listen to this single session ID for its entire lifetime.</remark>
-        public string SessionId { get; set; }
-
         internal bool AutoRenewLock => this.MaxAutoRenewDuration > TimeSpan.Zero;
 
         internal int MaxConcurrentAcceptSessionCalls { get; set; }

--- a/src/Microsoft.Azure.ServiceBus/SessionReceivePump.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionReceivePump.cs
@@ -122,7 +122,13 @@ namespace Microsoft.Azure.ServiceBus
                     concurrentSessionSemaphoreAcquired = true;
 
                     await this.maxPendingAcceptSessionsSemaphoreSlim.WaitAsync(this.pumpCancellationToken).ConfigureAwait(false);
-                    var session = await this.client.AcceptMessageSessionAsync().ConfigureAwait(false);
+
+                    IMessageSession session;
+                    if(string.IsNullOrEmpty(sessionHandlerOptions.SessionId))
+                        session = await this.client.AcceptMessageSessionAsync().ConfigureAwait(false);
+                    else
+                        session = await this.client.AcceptMessageSessionAsync(sessionHandlerOptions.SessionId).ConfigureAwait(false);
+
                     if (session == null)
                     {
                         await Task.Delay(Constants.NoMessageBackoffTimeSpan, this.pumpCancellationToken).ConfigureAwait(false);

--- a/src/Microsoft.Azure.ServiceBus/SessionReceivePump.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionReceivePump.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.ServiceBus
 
                     await this.maxPendingAcceptSessionsSemaphoreSlim.WaitAsync(this.pumpCancellationToken).ConfigureAwait(false);
 
-                    var session = await this.client.AcceptMessageSessionAsync(this.sessionHandlerOptions.SessionId).ConfigureAwait(false);
+                    var session = await this.client.AcceptMessageSessionAsync().ConfigureAwait(false);
 
                     if (session == null)
                     {

--- a/src/Microsoft.Azure.ServiceBus/SessionReceivePump.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionReceivePump.cs
@@ -123,11 +123,7 @@ namespace Microsoft.Azure.ServiceBus
 
                     await this.maxPendingAcceptSessionsSemaphoreSlim.WaitAsync(this.pumpCancellationToken).ConfigureAwait(false);
 
-                    IMessageSession session;
-                    if(string.IsNullOrEmpty(sessionHandlerOptions.SessionId))
-                        session = await this.client.AcceptMessageSessionAsync().ConfigureAwait(false);
-                    else
-                        session = await this.client.AcceptMessageSessionAsync(sessionHandlerOptions.SessionId).ConfigureAwait(false);
+                    var session = await this.client.AcceptMessageSessionAsync(sessionHandlerOptions.SessionId).ConfigureAwait(false);
 
                     if (session == null)
                     {

--- a/src/Microsoft.Azure.ServiceBus/SessionReceivePump.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionReceivePump.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.ServiceBus
 
                     await this.maxPendingAcceptSessionsSemaphoreSlim.WaitAsync(this.pumpCancellationToken).ConfigureAwait(false);
 
-                    var session = await this.client.AcceptMessageSessionAsync(sessionHandlerOptions.SessionId).ConfigureAwait(false);
+                    var session = await this.client.AcceptMessageSessionAsync(this.sessionHandlerOptions.SessionId).ConfigureAwait(false);
 
                     if (session == null)
                     {

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -384,6 +384,7 @@ namespace Microsoft.Azure.ServiceBus
         public System.TimeSpan MaxAutoRenewDuration { get; set; }
         public int MaxConcurrentSessions { get; set; }
         public System.TimeSpan MessageWaitTimeout { get; set; }
+        public string SessionId { get; set; }
     }
     public sealed class SessionLockLostException : Microsoft.Azure.ServiceBus.ServiceBusException
     {


### PR DESCRIPTION
This PR provides another setting on the ```SessionHandlerOptions``` class so you can specify a single SessionId when registering a SessionHandler.

Couldn't find the CONTRIBUTING.md file. Please link so I can check that out.

I've made this change based on [this](https://github.com/Azure/azure-service-bus/issues/131) issue.

I'll have to look into the test coverage for the changes.

# Extended general description
So basically what I needed was a handler that handles 1 specific session id. 

I made an application that does a request for data by sending a message to a specific topic.
The response will be sent with the ```ReplyToSessionId``` value from the original message into another queue (Response queue).

So the application that needs to receive the message just has to listen to messages in the response queue with its SessionId. Registering a session handler on a Queue client doesn't allow me to filter on a specific SessionId.

Thinking that it would be a waste of resources to just create an if statement in the message handler I found out it was easy to implement it into the project.

# Providing functionality with this PR
The best way to show what is possible with this PR is by code. 
First the current way of solving the problem:
```c#
 const string SessionId = "B1A405E2-C354-4F00-8E9E-8D71BA5C30B3";
var queueClient = new QueueClient(ConnectionString, QueueName);

queueClient.RegisterSessionHandler((session, message, arg3) =>
{
    if (!session.SessionId.Equals(SessionId, StringComparison.OrdinalIgnoreCase))
        return Task.CompletedTask;

    // process data here

    return Task.CompletedTask;
}, new SessionHandlerOptions(args =>
{
    // handle error here
    return Task.CompletedTask;
}));
```

New way of solving the problem:
```c#
const string SessionId = "B1A405E2-C354-4F00-8E9E-8D71BA5C30B3";
var queueClient = new QueueClient(ConnectionString, QueueName);

queueClient.RegisterSessionHandler((session, message, arg3) =>
{
    // process data here

    return Task.CompletedTask;
}, new SessionHandlerOptions(args =>
{
    // handle error here
    return Task.CompletedTask;
})
{
    SessionId = SessionId
});
```

