### PR TITLE
Fix equality check for QueueDescription

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Management/QueueDescription.cs
+++ b/src/Microsoft.Azure.ServiceBus/Management/QueueDescription.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Azure.ServiceBus.Management
         int maxDeliveryCount = 10;
         string forwardTo = null;
         string forwardDeadLetteredMessagesTo = null;
-        AuthorizationRules authorizationRules = null;
         string userMetadata = null;
 
         /// <summary>
@@ -185,17 +184,7 @@ namespace Microsoft.Azure.ServiceBus.Management
         /// <summary>
         /// The <see cref="AuthorizationRules"/> on the queue to control user access at entity level.
         /// </summary>
-        public AuthorizationRules AuthorizationRules
-        {
-            get
-            {
-                return this.authorizationRules ?? (this.authorizationRules = new AuthorizationRules());
-            }
-            internal set
-            {
-                this.authorizationRules = value;
-            }
-        }
+        public AuthorizationRules AuthorizationRules { get; internal set; } = new AuthorizationRules();
 
         /// <summary>
         /// The current status of the queue (Enabled / Disabled).
@@ -320,9 +309,9 @@ namespace Microsoft.Azure.ServiceBus.Management
                 && this.RequiresSession.Equals(other.RequiresSession)
                 && this.Status.Equals(other.Status)
                 && string.Equals(this.userMetadata, other.userMetadata, StringComparison.OrdinalIgnoreCase)
-                && (this.authorizationRules != null && other.authorizationRules != null
-                    || this.authorizationRules == null && other.authorizationRules == null)
-                && (this.authorizationRules == null || this.AuthorizationRules.Equals(other.AuthorizationRules)))
+                && (this.AuthorizationRules != null && other.AuthorizationRules != null
+                    || this.AuthorizationRules == null && other.AuthorizationRules == null)
+                && (this.AuthorizationRules == null || this.AuthorizationRules.Equals(other.AuthorizationRules)))
             {
                 return true;
             }

--- a/src/Microsoft.Azure.ServiceBus/Management/TopicDescription.cs
+++ b/src/Microsoft.Azure.ServiceBus/Management/TopicDescription.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Azure.ServiceBus.Management
         internal string path;
         TimeSpan defaultMessageTimeToLive = TimeSpan.MaxValue;
         TimeSpan autoDeleteOnIdle = TimeSpan.MaxValue;
-        AuthorizationRules authorizationRules = null;
         string userMetadata = null;
 
         /// <summary>
@@ -123,22 +122,7 @@ namespace Microsoft.Azure.ServiceBus.Management
         /// <summary>
         /// The <see cref="AuthorizationRules"/> on the topic to control user access at entity level.
         /// </summary>
-        public AuthorizationRules AuthorizationRules
-        {
-            get
-            {
-                if (this.authorizationRules == null)
-                {
-                    this.authorizationRules = new AuthorizationRules();
-                }
-
-                return this.authorizationRules;
-            }
-            internal set
-            {
-                this.authorizationRules = value;
-            }
-        }
+        public AuthorizationRules AuthorizationRules { get; internal set; } = new AuthorizationRules();
 
         /// <summary>
         /// The current status of the topic (Enabled / Disabled).
@@ -218,9 +202,9 @@ namespace Microsoft.Azure.ServiceBus.Management
                 && this.RequiresDuplicateDetection.Equals(other.RequiresDuplicateDetection)
                 && this.Status.Equals(other.Status)
                 && string.Equals(this.userMetadata, other.userMetadata, StringComparison.OrdinalIgnoreCase)
-                && (this.authorizationRules != null && other.authorizationRules != null
-                    || this.authorizationRules == null && other.authorizationRules == null)
-                && (this.authorizationRules == null || this.AuthorizationRules.Equals(other.AuthorizationRules)))
+                && (this.AuthorizationRules != null && other.AuthorizationRules != null
+                    || this.AuthorizationRules == null && other.AuthorizationRules == null)
+                && (this.AuthorizationRules == null || this.AuthorizationRules.Equals(other.AuthorizationRules)))
             {
                 return true;
             }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Management/ManagementClientTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Management/ManagementClientTests.cs
@@ -554,11 +554,28 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Management
         [DisplayTestMethodName]
         public async Task QueueDescriptionParsedFromResponseEqualityCheckTest()
         {
-            var queueDescription = new QueueDescription("a");
+            var name = Guid.NewGuid().ToString("D").Substring(0, 8);
+            var queueDescription = new QueueDescription(name);
             var createdQueueDescription = await client.CreateQueueAsync(queueDescription);
 
-            var identicalQueueDescription = new QueueDescription("a");
+            var identicalQueueDescription = new QueueDescription(name);
             Assert.Equal(identicalQueueDescription, createdQueueDescription);
+
+            await client.DeleteQueueAsync(name);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        public async Task TopicDescriptionParsedFromResponseEqualityCheckTest()
+        {
+            var name = Guid.NewGuid().ToString("D").Substring(0, 8);
+            var topicDescription = new TopicDescription(name);
+            var createdTopicDescription = await client.CreateTopicAsync(topicDescription);
+
+            var identicalTopicDescription = new TopicDescription(name);
+            Assert.Equal(identicalTopicDescription, createdTopicDescription);
+
+            await client.DeleteTopicAsync(name);
         }
 
         [Fact]

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/Management/ManagementClientTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/Management/ManagementClientTests.cs
@@ -552,6 +552,17 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Management
 
         [Fact]
         [DisplayTestMethodName]
+        public async Task QueueDescriptionParsedFromResponseEqualityCheckTest()
+        {
+            var queueDescription = new QueueDescription("a");
+            var createdQueueDescription = await client.CreateQueueAsync(queueDescription);
+
+            var identicalQueueDescription = new QueueDescription("a");
+            Assert.Equal(identicalQueueDescription, createdQueueDescription);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
         public async Task SqlFilterParamsTest()
         {
             var topicName = Guid.NewGuid().ToString("D").Substring(0, 8);


### PR DESCRIPTION
## Description

The equality check between a manually created created instance of the QueueDescription class and an instance parsed from the XML response by the ManagementClient will not be considered equal. This is an issue when doing operations like create a queue if it is non existing.

The issue is originated in the property AuthorizationRules that was setting the underlying field if it was null. When an instance is being parsed from an non-existing set of rules in the XML response this property is set to an empty AuthorizationRules instance.

I decided to remove the underlying variable for simplicity and set a default value (empty AuthorizationRules instace) to remove the state-changing-getter that just seems to complicate things.