### PR TITLE
Add support for configuring OperationTimeout in the connection string

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Management/ManagementClient.cs
+++ b/src/Microsoft.Azure.ServiceBus/Management/ManagementClient.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Azure.ServiceBus.Management
         private HttpClient httpClient;
         private readonly string endpointFQDN;
         private readonly ITokenProvider tokenProvider;
-        private readonly TimeSpan operationTimeout;
         private readonly int port;
         private readonly string clientId;
 
@@ -48,14 +47,13 @@ namespace Microsoft.Azure.ServiceBus.Management
         /// <param name="tokenProvider">Token provider which will generate security tokens for authorization.</param>
         public ManagementClient(ServiceBusConnectionStringBuilder connectionStringBuilder, ITokenProvider tokenProvider = default)
         {
-            this.httpClient = new HttpClient();
+            this.httpClient = new HttpClient { Timeout = connectionStringBuilder.OperationTimeout };
             this.endpointFQDN = connectionStringBuilder.Endpoint;
             this.tokenProvider = tokenProvider ?? CreateTokenProvider(connectionStringBuilder);
-            this.operationTimeout = Constants.DefaultOperationTimeout;
             this.port = GetPort(connectionStringBuilder.Endpoint);
             this.clientId = nameof(ManagementClient) + Guid.NewGuid().ToString("N").Substring(0, 6);
 
-            MessagingEventSource.Log.ManagementClientCreated(this.clientId, this.operationTimeout.TotalSeconds, this.tokenProvider.ToString());
+            MessagingEventSource.Log.ManagementClientCreated(this.clientId, this.httpClient.Timeout.TotalSeconds, this.tokenProvider.ToString());
         }
 
         public static HttpRequestMessage CloneRequest(HttpRequestMessage req)

--- a/src/Microsoft.Azure.ServiceBus/ServiceBusConnection.cs
+++ b/src/Microsoft.Azure.ServiceBus/ServiceBusConnection.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.ServiceBus
         /// <param name="operationTimeout">Duration after which individual operations will timeout.</param>
         /// <param name="retryPolicy">Retry policy for operations. Defaults to <see cref="RetryPolicy.Default"/></param>
         /// <remarks>It is the responsibility of the user to close the connection after use through <see cref="CloseAsync"/></remarks>
-        [Obsolete("Please use the constructor with (string namespaceConnectionString, RetryPolicy retryPolicy) arguments and define the operationTimeout in the connection string.")]
+        [Obsolete("This constructor is obsolete. Use ServiceBusConnection(string namespaceConnectionString, RetryPolicy retryPolicy) constructor instead, providing operationTimeout in the connection string.")]
         public ServiceBusConnection(string namespaceConnectionString, TimeSpan operationTimeout, RetryPolicy retryPolicy = null)
             : this(retryPolicy)
         {
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.ServiceBus
             }
 
             this.InitializeConnection(serviceBusConnectionStringBuilder);
-            // operationTimeout argument wins over OperationTimeout defined in the connection string since it's explicitly specified in the constructor
+            // operationTimeout argument explicitly provided by caller should take precedence over OperationTimeout found in the connection string.
             this.OperationTimeout = operationTimeout;
         }
 

--- a/src/Microsoft.Azure.ServiceBus/ServiceBusConnection.cs
+++ b/src/Microsoft.Azure.ServiceBus/ServiceBusConnection.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.ServiceBus
         /// <param name="namespaceConnectionString">Namespace connection string</param>
         /// <remarks>It is the responsibility of the user to close the connection after use through <see cref="CloseAsync"/></remarks>
         public ServiceBusConnection(string namespaceConnectionString)
-            : this(namespaceConnectionString, Constants.DefaultOperationTimeout, RetryPolicy.Default)
+            : this(namespaceConnectionString, RetryPolicy.Default)
         {
         }
 
@@ -45,11 +45,10 @@ namespace Microsoft.Azure.ServiceBus
         /// Creates a new connection to service bus.
         /// </summary>
         /// <param name="namespaceConnectionString">Namespace connection string.</param>
-        /// <param name="operationTimeout">Duration after which individual operations will timeout.</param>
         /// <param name="retryPolicy">Retry policy for operations. Defaults to <see cref="RetryPolicy.Default"/></param>
         /// <remarks>It is the responsibility of the user to close the connection after use through <see cref="CloseAsync"/></remarks>
-        public ServiceBusConnection(string namespaceConnectionString, TimeSpan operationTimeout, RetryPolicy retryPolicy = null)
-            : this(operationTimeout, retryPolicy)
+        public ServiceBusConnection(string namespaceConnectionString, RetryPolicy retryPolicy = null)
+            : this(retryPolicy)
         {
             if (string.IsNullOrWhiteSpace(namespaceConnectionString))
             {
@@ -68,11 +67,38 @@ namespace Microsoft.Azure.ServiceBus
         /// <summary>
         /// Creates a new connection to service bus.
         /// </summary>
+        /// <param name="namespaceConnectionString">Namespace connection string.</param>
+        /// <param name="operationTimeout">Duration after which individual operations will timeout.</param>
+        /// <param name="retryPolicy">Retry policy for operations. Defaults to <see cref="RetryPolicy.Default"/></param>
+        /// <remarks>It is the responsibility of the user to close the connection after use through <see cref="CloseAsync"/></remarks>
+        [Obsolete("Please use the constructor with (string namespaceConnectionString, RetryPolicy retryPolicy) arguments and define the operationTimeout in the connection string.")]
+        public ServiceBusConnection(string namespaceConnectionString, TimeSpan operationTimeout, RetryPolicy retryPolicy = null)
+            : this(retryPolicy)
+        {
+            if (string.IsNullOrWhiteSpace(namespaceConnectionString))
+            {
+                throw Fx.Exception.ArgumentNullOrWhiteSpace(nameof(namespaceConnectionString));
+            }
+
+            var serviceBusConnectionStringBuilder = new ServiceBusConnectionStringBuilder(namespaceConnectionString);
+            if (!string.IsNullOrWhiteSpace(serviceBusConnectionStringBuilder.EntityPath))
+            {
+                throw Fx.Exception.Argument(nameof(namespaceConnectionString), "NamespaceConnectionString should not contain EntityPath.");
+            }
+
+            this.InitializeConnection(serviceBusConnectionStringBuilder);
+            // operationTimeout argument wins over OperationTimeout defined in the connection string since it's explicitly specified in the constructor
+            this.OperationTimeout = operationTimeout;
+        }
+
+        /// <summary>
+        /// Creates a new connection to service bus.
+        /// </summary>
         /// <param name="endpoint">Fully qualified domain name for Service Bus. Most likely, {yournamespace}.servicebus.windows.net</param>
         /// <param name="transportType">Transport type.</param>
         /// <param name="retryPolicy">Retry policy for operations. Defaults to <see cref="RetryPolicy.Default"/></param>
         public ServiceBusConnection(string endpoint, TransportType transportType, RetryPolicy retryPolicy = null)
-            : this(Constants.DefaultOperationTimeout, retryPolicy)
+            : this(retryPolicy)
         {
             if (string.IsNullOrWhiteSpace(endpoint))
             {
@@ -88,9 +114,8 @@ namespace Microsoft.Azure.ServiceBus
             this.InitializeConnection(serviceBusConnectionStringBuilder);
         }
 
-        internal ServiceBusConnection(TimeSpan operationTimeout, RetryPolicy retryPolicy = null)
+        internal ServiceBusConnection(RetryPolicy retryPolicy = null)
         {
-            this.OperationTimeout = operationTimeout;
             this.RetryPolicy = retryPolicy ?? RetryPolicy.Default;
             this.syncLock = new object();
         }
@@ -193,6 +218,7 @@ namespace Microsoft.Azure.ServiceBus
                 this.TokenProvider = new SharedAccessSignatureTokenProvider(builder.SasKeyName, builder.SasKey);
             }
 
+            this.OperationTimeout = builder.OperationTimeout;
             this.TransportType = builder.TransportType;
             this.ConnectionManager = new FaultTolerantAmqpObject<AmqpConnection>(this.CreateConnectionAsync, CloseConnection);
             this.TransactionController = new FaultTolerantAmqpObject<Controller>(this.CreateControllerAsync, CloseController);

--- a/src/Microsoft.Azure.ServiceBus/ServiceBusConnectionStringBuilder.cs
+++ b/src/Microsoft.Azure.ServiceBus/ServiceBusConnectionStringBuilder.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Azure.ServiceBus
         const string EntityPathConfigName = "EntityPath";
         const string TransportTypeConfigName = "TransportType";
 
+        const string OperationTimeoutConfigName = "OperationTimeout";
+
         string entityPath, sasKeyName, sasKey, sasToken, endpoint;
 
         /// <summary>
@@ -212,6 +214,12 @@ namespace Microsoft.Azure.ServiceBus
         /// </summary>
         public TransportType TransportType { get; set; }
 
+        /// <summary>
+        /// Duration after which individual operations will timeout.
+        /// </summary>
+        /// <remarks>Defaults to 1 minute.</remarks>
+        public TimeSpan OperationTimeout { get; set; } = Constants.DefaultOperationTimeout;
+
         internal Dictionary<string, string> ConnectionStringProperties = new Dictionary<string, string>(StringComparer.CurrentCultureIgnoreCase);
 
         /// <summary>
@@ -244,6 +252,11 @@ namespace Microsoft.Azure.ServiceBus
             if (this.TransportType != TransportType.Amqp)
             {
                 connectionStringBuilder.Append($"{TransportTypeConfigName}{KeyValueSeparator}{this.TransportType}");
+            }
+
+            if (this.OperationTimeout != Constants.DefaultOperationTimeout)
+            {
+                connectionStringBuilder.Append($"{OperationTimeoutConfigName}{KeyValueSeparator}{this.OperationTimeout}");
             }
 
             return connectionStringBuilder.ToString().Trim(';');
@@ -317,6 +330,17 @@ namespace Microsoft.Azure.ServiceBus
                     if (Enum.TryParse(value, true, out TransportType transportType))
                     {
                         this.TransportType = transportType;
+                    }
+                }
+                else if (key.Equals(OperationTimeoutConfigName, StringComparison.OrdinalIgnoreCase))
+                {
+                    try
+                    {
+                        this.OperationTimeout = TimeSpan.Parse(value);
+                    }
+                    catch (Exception exception)
+                    {
+                        throw new FormatException($"Failed to parse {OperationTimeoutConfigName} ({value}).", exception);
                     }
                 }
                 else

--- a/src/Microsoft.Azure.ServiceBus/ServiceBusConnectionStringBuilder.cs
+++ b/src/Microsoft.Azure.ServiceBus/ServiceBusConnectionStringBuilder.cs
@@ -251,12 +251,12 @@ namespace Microsoft.Azure.ServiceBus
 
             if (this.TransportType != TransportType.Amqp)
             {
-                connectionStringBuilder.Append($"{TransportTypeConfigName}{KeyValueSeparator}{this.TransportType}");
+                connectionStringBuilder.Append($"{TransportTypeConfigName}{KeyValueSeparator}{this.TransportType}{KeyValuePairDelimiter}");
             }
 
             if (this.OperationTimeout != Constants.DefaultOperationTimeout)
             {
-                connectionStringBuilder.Append($"{OperationTimeoutConfigName}{KeyValueSeparator}{this.OperationTimeout}");
+                connectionStringBuilder.Append($"{OperationTimeoutConfigName}{KeyValueSeparator}{this.OperationTimeout}{KeyValuePairDelimiter}");
             }
 
             return connectionStringBuilder.ToString().Trim(';');

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -309,6 +309,9 @@ namespace Microsoft.Azure.ServiceBus
     {
         public ServiceBusConnection(Microsoft.Azure.ServiceBus.ServiceBusConnectionStringBuilder connectionStringBuilder) { }
         public ServiceBusConnection(string namespaceConnectionString) { }
+        public ServiceBusConnection(string namespaceConnectionString, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null) { }
+        [System.ObsoleteAttribute("Please use the constructor with (string namespaceConnectionString, RetryPolicy re" +
+            "tryPolicy) arguments and define the operationTimeout in the connection string.")]
         public ServiceBusConnection(string namespaceConnectionString, System.TimeSpan operationTimeout, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null) { }
         public ServiceBusConnection(string endpoint, Microsoft.Azure.ServiceBus.TransportType transportType, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null) { }
         public System.Uri Endpoint { get; set; }
@@ -329,6 +332,7 @@ namespace Microsoft.Azure.ServiceBus
         public ServiceBusConnectionStringBuilder(string endpoint, string entityPath, string sharedAccessSignature, Microsoft.Azure.ServiceBus.TransportType transportType) { }
         public string Endpoint { get; set; }
         public string EntityPath { get; set; }
+        public System.TimeSpan OperationTimeout { get; set; }
         public string SasKey { get; set; }
         public string SasKeyName { get; set; }
         public string SasToken { get; set; }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -310,8 +310,9 @@ namespace Microsoft.Azure.ServiceBus
         public ServiceBusConnection(Microsoft.Azure.ServiceBus.ServiceBusConnectionStringBuilder connectionStringBuilder) { }
         public ServiceBusConnection(string namespaceConnectionString) { }
         public ServiceBusConnection(string namespaceConnectionString, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null) { }
-        [System.ObsoleteAttribute("Please use the constructor with (string namespaceConnectionString, RetryPolicy re" +
-            "tryPolicy) arguments and define the operationTimeout in the connection string.")]
+        [System.ObsoleteAttribute("This constructor is obsolete. Use ServiceBusConnection(string namespaceConnection" +
+            "String, RetryPolicy retryPolicy) constructor instead, providing operationTimeout" +
+            " in the connection string.")]
         public ServiceBusConnection(string namespaceConnectionString, System.TimeSpan operationTimeout, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null) { }
         public ServiceBusConnection(string endpoint, Microsoft.Azure.ServiceBus.TransportType transportType, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null) { }
         public System.Uri Endpoint { get; set; }

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/ServiceBusConnectionStringBuilderTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/ServiceBusConnectionStringBuilderTests.cs
@@ -75,6 +75,13 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
 
             csBuilder.EntityPath = "myQ";
             Assert.Equal("Endpoint=amqps://contoso.servicebus.windows.net;EntityPath=myQ", csBuilder.ToString());
+
+            csBuilder.EntityPath = "";
+            csBuilder.TransportType = TransportType.AmqpWebSockets;
+            Assert.Equal("Endpoint=amqps://contoso.servicebus.windows.net;TransportType=AmqpWebSockets", csBuilder.ToString());
+
+            csBuilder.OperationTimeout = TimeSpan.FromSeconds(42);
+            Assert.Equal("Endpoint=amqps://contoso.servicebus.windows.net;TransportType=AmqpWebSockets;OperationTimeout=00:00:42", csBuilder.ToString());
         }
 
         [Fact]

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/ServiceBusConnectionStringBuilderTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/ServiceBusConnectionStringBuilderTests.cs
@@ -127,6 +127,28 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         }
 
         [Fact]
+        void ConnectionStringBuilderShouldParseOperationTimeout()
+        {
+            var csBuilder = new ServiceBusConnectionStringBuilder("Endpoint=sb://contoso.servicebus.windows.net;SharedAccessKeyName=keyname;SharedAccessKey=key;OperationTimeout=11:22:33");
+            Assert.Equal(TimeSpan.FromHours(11).Add(TimeSpan.FromMinutes(22)).Add(TimeSpan.FromSeconds(33)), csBuilder.OperationTimeout);
+        }
+
+        [Fact]
+        void ConnectionStringBuilderOperationTimeoutShouldDefaultToOneMinute()
+        {
+            var csBuilder = new ServiceBusConnectionStringBuilder("Endpoint=sb://contoso.servicebus.windows.net;SharedAccessKeyName=keyname;SharedAccessKey=key");
+            Assert.Equal(Constants.DefaultOperationTimeout, csBuilder.OperationTimeout);
+        }
+
+        [Fact]
+        void ConnectionStringBuilderShouldThrowForInvalidOperationTimeout()
+        {
+            var exception = Assert.Throws<FormatException>(() => new ServiceBusConnectionStringBuilder("Endpoint=sb://contoso.servicebus.windows.net;SharedAccessKeyName=keyname;SharedAccessKey=key;OperationTimeout=x"));
+            Assert.Contains("OperationTimeout", exception.Message);
+            Assert.Contains("(x)", exception.Message);
+        }
+
+        [Fact]
         void ConnectionStringBuilderShouldParseToken()
         {
             var token = "SharedAccessSignature sr=https%3a%2f%2fmynamespace.servicebus.windows.net%2fvendor-&sig=somesignature&se=64953734126&skn=PolicyName";

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/ServiceBusConnectionStringBuilderTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/ServiceBusConnectionStringBuilderTests.cs
@@ -134,10 +134,17 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         }
 
         [Fact]
-        void ConnectionStringBuilderShouldParseOperationTimeout()
+        void ConnectionStringBuilderShouldParseOperationTimeoutAsInteger()
         {
-            var csBuilder = new ServiceBusConnectionStringBuilder("Endpoint=sb://contoso.servicebus.windows.net;SharedAccessKeyName=keyname;SharedAccessKey=key;OperationTimeout=11:22:33");
-            Assert.Equal(TimeSpan.FromHours(11).Add(TimeSpan.FromMinutes(22)).Add(TimeSpan.FromSeconds(33)), csBuilder.OperationTimeout);
+            var csBuilder = new ServiceBusConnectionStringBuilder("Endpoint=sb://contoso.servicebus.windows.net;SharedAccessKeyName=keyname;SharedAccessKey=key;OperationTimeout=120");
+            Assert.Equal(TimeSpan.FromMinutes(2), csBuilder.OperationTimeout);
+        }
+
+        [Fact]
+        void ConnectionStringBuilderShouldParseOperationTimeoutAsTimeSpan()
+        {
+            var csBuilder = new ServiceBusConnectionStringBuilder("Endpoint=sb://contoso.servicebus.windows.net;SharedAccessKeyName=keyname;SharedAccessKey=key;OperationTimeout=00:12:34");
+            Assert.Equal(TimeSpan.FromMinutes(12).Add(TimeSpan.FromSeconds(34)), csBuilder.OperationTimeout);
         }
 
         [Fact]
@@ -150,7 +157,8 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         [Fact]
         void ConnectionStringBuilderShouldThrowForInvalidOperationTimeout()
         {
-            var exception = Assert.Throws<FormatException>(() => new ServiceBusConnectionStringBuilder("Endpoint=sb://contoso.servicebus.windows.net;SharedAccessKeyName=keyname;SharedAccessKey=key;OperationTimeout=x"));
+            var exception = Assert.Throws<ArgumentException>(() => new ServiceBusConnectionStringBuilder("Endpoint=sb://contoso.servicebus.windows.net;SharedAccessKeyName=keyname;SharedAccessKey=key;OperationTimeout=x"));
+            Assert.Equal("connectionString", exception.ParamName);
             Assert.Contains("OperationTimeout", exception.Message);
             Assert.Contains("(x)", exception.Message);
         }


### PR DESCRIPTION
Like in [Microsoft.ServiceBus.Messaging (.NET Framework)][1], it's now possible to configure the `OperationTimeout` in the connection string.

The `ServiceBusConnection` class constructors are adapted to read the `OperationTimeout` from the connection string and the constructor explicitly having a `TimeSpan operationTimeout` argument is obsoleted with this message:
> Please use the constructor with (string namespaceConnectionString, RetryPolicy retryPolicy) arguments and define the operationTimeout in the connection string.

Also, use the operation timeout defined in the connection string for the ManagementClient and **actually** use the operation timeout as a timeout for the `HttpClient` responsible for the management operations instead of storing the `Constants.DefaultOperationTimeout` in a private field which is never used.

[1]: https://docs.microsoft.com/en-us/dotnet/api/microsoft.servicebus.servicebusconnectionstringbuilder.operationtimeout
