### PR TITLE
[WIP] Add the option to modify properties when abandoning a message

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/MessageHandlerOptions.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageHandlerOptions.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+using Microsoft.Azure.ServiceBus.Core;
+
 namespace Microsoft.Azure.ServiceBus
 {
     using System;
@@ -25,18 +28,39 @@ namespace Microsoft.Azure.ServiceBus
         /// </summary>
         /// <param name="exceptionReceivedHandler">A <see cref="Func{T1, TResult}"/> that is invoked during exceptions.
         /// <see cref="ExceptionReceivedEventArgs"/> contains contextual information regarding the exception.</param>
-        public MessageHandlerOptions(Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler)
+        public MessageHandlerOptions(Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler) : this(exceptionReceivedHandler, null)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="MessageHandlerOptions" /> class.
+        /// Default Values:
+        ///     <see cref="MaxConcurrentCalls"/> = 1
+        ///     <see cref="AutoComplete"/> = true
+        ///     <see cref="ReceiveTimeOut"/> = 1 minute
+        ///     <see cref="MaxAutoRenewDuration"/> = 5 minutes
+        /// </summary>
+        /// <param name="exceptionReceivedHandler">A <see cref="Func{T1, TResult}"/> that is invoked during exceptions.
+        /// <see cref="ExceptionReceivedEventArgs"/> contains contextual information regarding the exception.</param>
+        /// <param name="propertiesToModifyOnExceptionHandler">An optional <see cref="Func{T1, TResult}"/> that is invoked before a message is abandoned because of an exception that happened within the message handler callback;
+        /// The returned dictionary is passed to <see cref="IReceiverClient.AbandonAsync"/>.
+        /// <see cref="ExceptionReceivedEventArgs"/> contains contextual information regarding the exception.</param>
+        public MessageHandlerOptions(Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler, Func<ExceptionReceivedEventArgs, Task<IDictionary<string, object>>> propertiesToModifyOnExceptionHandler)
         {
             this.MaxConcurrentCalls = 1;
             this.AutoComplete = true;
             this.ReceiveTimeOut = Constants.DefaultOperationTimeout;
             this.MaxAutoRenewDuration = Constants.ClientPumpRenewLockTimeout;
             this.ExceptionReceivedHandler = exceptionReceivedHandler ?? throw new ArgumentNullException(nameof(exceptionReceivedHandler));
+            this.PropertiesToModifyOnExceptionHandler = propertiesToModifyOnExceptionHandler;
         }
 
         /// <summary>Occurs when an exception is received. Enables you to be notified of any errors encountered by the message pump.
         /// When errors are received calls will automatically be retried, so this is informational. </summary>
         public Func<ExceptionReceivedEventArgs, Task> ExceptionReceivedHandler { get; }
+
+        /// <summary>Occurs when a message is about to be abandoned because of an exception that happened within the message handler callback;
+        /// The returned dictionary is passed to <see cref="IReceiverClient.AbandonAsync"/>.</summary>
+        public Func<ExceptionReceivedEventArgs, Task<IDictionary<string, object>>> PropertiesToModifyOnExceptionHandler { get; }
 
         /// <summary>Gets or sets the maximum number of concurrent calls to the callback the message pump should initiate.</summary>
         /// <value>The maximum number of concurrent calls to the callback.</value>

--- a/src/Microsoft.Azure.ServiceBus/MessageHandlerOptions.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageHandlerOptions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.ServiceBus
         /// <param name="propertiesToModifyOnExceptionHandler">An optional <see cref="Func{T1, TResult}"/> that is invoked before a message is abandoned because of an exception that happened within the message handler callback;
         /// The returned dictionary is passed to <see cref="IReceiverClient.AbandonAsync"/>.
         /// <see cref="ExceptionReceivedEventArgs"/> contains contextual information regarding the exception.</param>
-        public MessageHandlerOptions(Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler, Func<ExceptionReceivedEventArgs, Task<IDictionary<string, object>>> propertiesToModifyOnExceptionHandler)
+        public MessageHandlerOptions(Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler, Func<ExceptionReceivedEventArgs, IDictionary<string, object>> propertiesToModifyOnExceptionHandler)
         {
             this.MaxConcurrentCalls = 1;
             this.AutoComplete = true;
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.ServiceBus
 
         /// <summary>Occurs when a message is about to be abandoned because of an exception that happened within the message handler callback;
         /// The returned dictionary is passed to <see cref="IReceiverClient.AbandonAsync"/>.</summary>
-        public Func<ExceptionReceivedEventArgs, Task<IDictionary<string, object>>> PropertiesToModifyOnExceptionHandler { get; }
+        public Func<ExceptionReceivedEventArgs, IDictionary<string, object>> PropertiesToModifyOnExceptionHandler { get; }
 
         /// <summary>Gets or sets the maximum number of concurrent calls to the callback the message pump should initiate.</summary>
         /// <value>The maximum number of concurrent calls to the callback.</value>

--- a/src/Microsoft.Azure.ServiceBus/MessageReceivePump.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageReceivePump.cs
@@ -203,7 +203,14 @@ namespace Microsoft.Azure.ServiceBus
                     if (this.registerHandlerOptions.PropertiesToModifyOnExceptionHandler != null)
                     {
                         var eventArgs = new ExceptionReceivedEventArgs(callbackException, ExceptionReceivedEventArgsAction.UserCallback, this.endpoint, this.messageReceiver.Path, this.messageReceiver.ClientId);
-                        propertiesToModify = await this.registerHandlerOptions.PropertiesToModifyOnExceptionHandler(eventArgs).ConfigureAwait(false);
+                        try
+                        {
+                            propertiesToModify = await this.registerHandlerOptions.PropertiesToModifyOnExceptionHandler(eventArgs).ConfigureAwait(false);
+                        }
+                        catch (Exception exception)
+                        {
+                            MessagingEventSource.Log.MessageReceiverPumpUserCallbackException(this.messageReceiver.ClientId, message, exception);
+                        }
                     }
                     await this.messageReceiver.AbandonAsync(message.SystemProperties.LockToken, propertiesToModify).ConfigureAwait(false);
                 }

--- a/src/Microsoft.Azure.ServiceBus/MessageReceivePump.cs
+++ b/src/Microsoft.Azure.ServiceBus/MessageReceivePump.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Azure.ServiceBus
                         var eventArgs = new ExceptionReceivedEventArgs(callbackException, ExceptionReceivedEventArgsAction.UserCallback, this.endpoint, this.messageReceiver.Path, this.messageReceiver.ClientId);
                         try
                         {
-                            propertiesToModify = await this.registerHandlerOptions.PropertiesToModifyOnExceptionHandler(eventArgs).ConfigureAwait(false);
+                            propertiesToModify = this.registerHandlerOptions.PropertiesToModifyOnExceptionHandler(eventArgs);
                         }
                         catch (Exception exception)
                         {

--- a/src/Microsoft.Azure.ServiceBus/SessionHandlerOptions.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionHandlerOptions.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.ServiceBus
         /// <param name="propertiesToModifyOnExceptionHandler">An optional <see cref="Func{T1, TResult}"/> that is invoked before a message is abandoned because of an exception that happened within the session handler callback;
         /// The returned dictionary is passed to <see cref="IReceiverClient.AbandonAsync"/>.
         /// <see cref="ExceptionReceivedEventArgs"/> contains contextual information regarding the exception.</param>
-        public SessionHandlerOptions(Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler, Func<ExceptionReceivedEventArgs, Task<IDictionary<string, object>>> propertiesToModifyOnExceptionHandler)
+        public SessionHandlerOptions(Func<ExceptionReceivedEventArgs, Task> exceptionReceivedHandler, Func<ExceptionReceivedEventArgs, IDictionary<string, object>> propertiesToModifyOnExceptionHandler)
         {
             // These are default values
             this.AutoComplete = true;
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.ServiceBus
 
         /// <summary>Occurs when a message is about to be abandoned because of an exception that happened within the session handler callback;
         /// The returned dictionary is passed to <see cref="IReceiverClient.AbandonAsync"/>.</summary>
-        public Func<ExceptionReceivedEventArgs, Task<IDictionary<string, object>>> PropertiesToModifyOnExceptionHandler { get; }
+        public Func<ExceptionReceivedEventArgs, IDictionary<string, object>> PropertiesToModifyOnExceptionHandler { get; }
 
         /// <summary>Gets or sets the duration for which the session lock will be renewed automatically.</summary>
         /// <value>The duration for which the session renew its state.</value>

--- a/src/Microsoft.Azure.ServiceBus/SessionReceivePump.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionReceivePump.cs
@@ -108,7 +108,14 @@ namespace Microsoft.Azure.ServiceBus
                     if (this.sessionHandlerOptions.PropertiesToModifyOnExceptionHandler != null)
                     {
                         var eventArgs = new ExceptionReceivedEventArgs(callbackException, ExceptionReceivedEventArgsAction.UserCallback, this.endpoint, this.entityPath, this.clientId);
-                        propertiesToModify = await this.sessionHandlerOptions.PropertiesToModifyOnExceptionHandler(eventArgs).ConfigureAwait(false);
+                        try
+                        {
+                            propertiesToModify = await this.sessionHandlerOptions.PropertiesToModifyOnExceptionHandler(eventArgs).ConfigureAwait(false);
+                        }
+                        catch (Exception exception)
+                        {
+                            MessagingEventSource.Log.MessageReceiverPumpUserCallbackException(this.clientId, message, exception);
+                        }
                     }
                     await session.AbandonAsync(message.SystemProperties.LockToken, propertiesToModify).ConfigureAwait(false);
                 }

--- a/src/Microsoft.Azure.ServiceBus/SessionReceivePump.cs
+++ b/src/Microsoft.Azure.ServiceBus/SessionReceivePump.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.ServiceBus
                         var eventArgs = new ExceptionReceivedEventArgs(callbackException, ExceptionReceivedEventArgsAction.UserCallback, this.endpoint, this.entityPath, this.clientId);
                         try
                         {
-                            propertiesToModify = await this.sessionHandlerOptions.PropertiesToModifyOnExceptionHandler(eventArgs).ConfigureAwait(false);
+                            propertiesToModify = this.sessionHandlerOptions.PropertiesToModifyOnExceptionHandler(eventArgs);
                         }
                         catch (Exception exception)
                         {

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -179,10 +179,12 @@ namespace Microsoft.Azure.ServiceBus
     public sealed class MessageHandlerOptions
     {
         public MessageHandlerOptions(System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler) { }
+        public MessageHandlerOptions(System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task<System.Collections.Generic.IDictionary<string, object>>> propertiesToModifyOnExceptionHandler) { }
         public bool AutoComplete { get; set; }
         public System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> ExceptionReceivedHandler { get; }
         public System.TimeSpan MaxAutoRenewDuration { get; set; }
         public int MaxConcurrentCalls { get; set; }
+        public System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task<System.Collections.Generic.IDictionary<string, object>>> PropertiesToModifyOnExceptionHandler { get; }
     }
     public sealed class MessageLockLostException : Microsoft.Azure.ServiceBus.ServiceBusException
     {
@@ -379,11 +381,13 @@ namespace Microsoft.Azure.ServiceBus
     public sealed class SessionHandlerOptions
     {
         public SessionHandlerOptions(System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler) { }
+        public SessionHandlerOptions(System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task<System.Collections.Generic.IDictionary<string, object>>> propertiesToModifyOnExceptionHandler) { }
         public bool AutoComplete { get; set; }
         public System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> ExceptionReceivedHandler { get; }
         public System.TimeSpan MaxAutoRenewDuration { get; set; }
         public int MaxConcurrentSessions { get; set; }
         public System.TimeSpan MessageWaitTimeout { get; set; }
+        public System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task<System.Collections.Generic.IDictionary<string, object>>> PropertiesToModifyOnExceptionHandler { get; }
     }
     public sealed class SessionLockLostException : Microsoft.Azure.ServiceBus.ServiceBusException
     {

--- a/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/test/Microsoft.Azure.ServiceBus.UnitTests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -179,12 +179,12 @@ namespace Microsoft.Azure.ServiceBus
     public sealed class MessageHandlerOptions
     {
         public MessageHandlerOptions(System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler) { }
-        public MessageHandlerOptions(System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task<System.Collections.Generic.IDictionary<string, object>>> propertiesToModifyOnExceptionHandler) { }
+        public MessageHandlerOptions(System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Collections.Generic.IDictionary<string, object>> propertiesToModifyOnExceptionHandler) { }
         public bool AutoComplete { get; set; }
         public System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> ExceptionReceivedHandler { get; }
         public System.TimeSpan MaxAutoRenewDuration { get; set; }
         public int MaxConcurrentCalls { get; set; }
-        public System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task<System.Collections.Generic.IDictionary<string, object>>> PropertiesToModifyOnExceptionHandler { get; }
+        public System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Collections.Generic.IDictionary<string, object>> PropertiesToModifyOnExceptionHandler { get; }
     }
     public sealed class MessageLockLostException : Microsoft.Azure.ServiceBus.ServiceBusException
     {
@@ -381,13 +381,13 @@ namespace Microsoft.Azure.ServiceBus
     public sealed class SessionHandlerOptions
     {
         public SessionHandlerOptions(System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler) { }
-        public SessionHandlerOptions(System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task<System.Collections.Generic.IDictionary<string, object>>> propertiesToModifyOnExceptionHandler) { }
+        public SessionHandlerOptions(System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Collections.Generic.IDictionary<string, object>> propertiesToModifyOnExceptionHandler) { }
         public bool AutoComplete { get; set; }
         public System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> ExceptionReceivedHandler { get; }
         public System.TimeSpan MaxAutoRenewDuration { get; set; }
         public int MaxConcurrentSessions { get; set; }
         public System.TimeSpan MessageWaitTimeout { get; set; }
-        public System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task<System.Collections.Generic.IDictionary<string, object>>> PropertiesToModifyOnExceptionHandler { get; }
+        public System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Collections.Generic.IDictionary<string, object>> PropertiesToModifyOnExceptionHandler { get; }
     }
     public sealed class SessionLockLostException : Microsoft.Azure.ServiceBus.ServiceBusException
     {


### PR DESCRIPTION
This is useful to store exception details when abandoning a message and still keeping the convenience of registering a message or session handler with AutoComplete = true