### PR TITLE
Return zero for message Size when body is null

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Message.cs
+++ b/src/Microsoft.Azure.ServiceBus/Message.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Azure.ServiceBus
         /// <summary>
         /// Gets the total size of the message body in bytes.
         /// </summary>
-        public long Size => Body.Length;
+        public long Size => this.Body != null ? this.Body.Length : 0;
 
         /// <summary>
         /// Gets the "user properties" bag, which can be used for custom message metadata.


### PR DESCRIPTION
Fixes #648 

The old client did not throw for an empty message. The new client shouldn't either.