### PR TITLE
Separate Issue Template into bug report and feature request (#507)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,13 @@
+---
+name: Bug report
+about: Report a bug to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+
 ## Actual Behavior
 1. 
 2. 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+
+A clear and concise description of what the problem is. E.g. “I’m always frustrated when [...]”
+
+**Describe the solution you’d like**
+
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you’ve considered**
+
+A clear and concise description of any alternative solutions or features you’ve considered.
+
+**Additional context**
+
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Fixes #507.

Separates the current ISSUE_TEMPLATE into separate Bug Report and Feature Request templates. The Bug Report template is based on the existing issue template. The new Feature Request template is a tweak of GitHub’s default Feature Request template.

I see in the Contributing Guidelines that “All files have the Microsoft copyright header”, but this probably doesn't apply to the GitHub meta files, does it? The existing issue template doesn't have one.