### PR TITLE
Mute NuGet licenseUrl warning to unblock contributors using Rider IDE

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
+++ b/src/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.csproj
@@ -23,7 +23,7 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>CS1591;CS1573</NoWarn>
+    <NoWarn>CS1591;CS1573;NU5125</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Having GeneratePackageOnBuild=true causes the following error:

> /usr/local/share/dotnet/sdk/2.2.105/Sdks/NuGet.Build.Tasks.Pack/buildCrossTargeting/NuGet.Build.Tasks.Pack.targets(202,5): Error  : The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead.

This should be a simple warning but since `TreatWarningsAsErrors` is set to true in Directory.Build.props it becomes an error.

Since we don't need to generate a package on build during development anyway, we set GeneratePackageOnBuild=true when building the project with the build.ps1 script only.

**Update**: this was a symptom of [NU5125](https://github.com/NuGet/Home/issues/7509). Muting it for now.