### PR TITLE
Enable the use of a proxy when running in .NET Core

### DIFF
--- a/src/Microsoft.Azure.ServiceBus/Amqp/AmqpConnectionHelper.cs
+++ b/src/Microsoft.Azure.ServiceBus/Amqp/AmqpConnectionHelper.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Azure.ServiceBus.Amqp
 {
     using System;
+    using System.Net;
     using Microsoft.Azure.Amqp;
     using Microsoft.Azure.Amqp.Sasl;
     using Microsoft.Azure.Amqp.Transport;
@@ -101,7 +102,8 @@ namespace Microsoft.Azure.ServiceBus.Amqp
         public static TransportSettings CreateWebSocketTransportSettings(
             string networkHost,
             string hostName,
-            int port)
+            int port,
+            IWebProxy proxy)
         {
             var uriBuilder = new UriBuilder(
                 WebSocketConstants.WebSocketSecureScheme,
@@ -112,7 +114,8 @@ namespace Microsoft.Azure.ServiceBus.Amqp
             {
                 Uri = uriBuilder.Uri,
                 ReceiveBufferSize = AmqpConstants.TransportBufferSize,
-                SendBufferSize = AmqpConstants.TransportBufferSize
+                SendBufferSize = AmqpConstants.TransportBufferSize,
+                Proxy = proxy
             };
 
             TransportSettings tpSettings = webSocketTransportSettings;

--- a/src/Microsoft.Azure.ServiceBus/ServiceBusConnection.cs
+++ b/src/Microsoft.Azure.ServiceBus/ServiceBusConnection.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Azure.ServiceBus
 {
     using System;
+    using System.Net;
     using System.Threading.Tasks;
     using Microsoft.Azure.Amqp;
     using Microsoft.Azure.Amqp.Framing;
@@ -309,7 +310,8 @@ namespace Microsoft.Azure.ServiceBus
                 return AmqpConnectionHelper.CreateWebSocketTransportSettings(
                     networkHost: networkHost,
                     hostName: hostName,
-                    port: port);
+                    port: port,
+                    proxy: WebRequest.DefaultWebProxy);
             }
 
             return AmqpConnectionHelper.CreateTcpTransportSettings(


### PR DESCRIPTION
I believe this fixes #436 

It has been been tested running in .NET Framework 4.7.2 and .NET Core 2.1 on Windows. It is assumed that the proxy is only used in transportMode=AmqpWebSockets.