### PR TITLE
[Service Bus Client] ReadMe Content Updates (for archive)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,49 +4,18 @@
 
 # Microsoft Azure Service Bus Client for .NET
 
+Azure Service Bus allows you to build applications that take advantage of asynchronous messaging patterns using a highly-reliable service to broker messages between producers and consumers. Azure Service Bus provides flexible, brokered messaging between client and server, along with structured first-in, first-out (FIFO) messaging, and publish/subscribe capabilities with complex routing.
 
-|Build/Package|Status|
-|------|-------------|
-|master|[![Build status](https://ci.appveyor.com/api/projects/status/o4kaqt06h62d0ugp/branch/master?svg=true)](https://ci.appveyor.com/project/vinaysurya/azure-service-bus-dotnet/branch/master) [![codecov](https://codecov.io/gh/Azure/azure-service-bus-dotnet/branch/master/graph/badge.svg)](https://codecov.io/gh/Azure/azure-service-bus-dotnet)|
-|dev|[![Build status](https://ci.appveyor.com/api/projects/status/o4kaqt06h62d0ugp/branch/dev?svg=true)](https://ci.appveyor.com/project/vinaysurya/azure-service-bus-dotnet/branch/dev) [![codecov](https://codecov.io/gh/Azure/azure-service-bus-dotnet/branch/dev/graph/badge.svg)](https://codecov.io/gh/Azure/azure-service-bus-dotnet)|
-|Microsoft.Azure.ServiceBus|[![NuGet Version and Downloads count](https://buildstats.info/nuget/Microsoft.Azure.ServiceBus?includePreReleases=true)](https://www.nuget.org/packages/Microsoft.Azure.ServiceBus/)|
-
-This is the next generation Service Bus .NET client library that focuses on queues & topics. If you are looking for Event Hubs and Relay clients, follow the below links:
-* [Event Hubs](https://github.com/azure/azure-event-hubs-dotnet)
+This is the next generation Service Bus .NET client library focused on queues and topics. If you are looking for Event Hubs and Relay clients, please see:
+* [Event Hubs](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/eventhub/Microsoft.Azure.EventHub)
 * [Relay](https://github.com/azure/azure-relay-dotnet)
 
-Azure Service Bus is an asynchronous messaging cloud platform that enables you to send messages between decoupled systems. Microsoft offers this feature as a service, which means that you do not need to host any of your own hardware in order to use it.
 
-Refer to the [online documentation](https://azure.microsoft.com/services/service-bus/) to learn more about Service Bus.
+## We've moved!
 
-This library is built using .NET Standard 1.3. For more information on what platforms are supported see [.NET Platforms Support](https://docs.microsoft.com/en-us/dotnet/articles/standard/library#net-platforms-support).
+The Microsoft Azure Service Bus Client for .NET has joined the unified Azure Developer Platform and can now be found in the [Azure SDK for .NET](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/servicebus/Microsoft.Azure.ServiceBus) repository.  To view the latest source, participate in the development process, report issues, or engage with the community, please visit our new home.
 
-## How to provide feedback
+This repository has been archived and is intended to provide historical reference and context for the Microsoft Azure Service Bus Client for .NET 
+  
+[Source code](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/servicebus/Microsoft.Azure.ServiceBus) | [Package (NuGet)](https://www.nuget.org/packages/Microsoft.Azure.ServiceBus/) | [API reference documentation](https://docs.microsoft.com/en-us/dotnet/api/overview/azure/service-bus?view=azure-dotnet) | [Product documentation](https://docs.microsoft.com/en-us/azure/service-bus-messaging/)
 
-See our [Contribution Guidelines](./.github/CONTRIBUTING.md).
-
-## How to get support
-
-See our [Support Guidelines](./.github/SUPPORT.md)
-
-## FAQ
-
-### Where can I find examples that use this library?
-
-[https://github.com/Azure/azure-service-bus/tree/master/samples](https://github.com/Azure/azure-service-bus/tree/master/samples)
-
-### How do I run the unit tests? 
-
-In order to run the unit tests, you will need to do the following:
-
-1. Deploy the Azure Resource Manager template located at [/build/azuredeploy.json](/build/azuredeploy.json) by clicking the following button:
-
-    <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-service-bus-dotnet%2Fmaster%2Fbuild%2Fazuredeploy.json" target="_blank">
-        <img src="http://azuredeploy.net/deploybutton.png"/>
-    </a>
-
-    *Running the above template will provision a standard Service Bus namespace along with the required entities to successfully run the unit tests.*
-
-1. Add an Environment Variable named `azure-service-bus-dotnet/connectionstring` and set the value as the connection string of the newly created namespace. **Please note that if you are using Visual Studio, you must restart Visual Studio in order to use new Environment Variables.**
-
-Once you have completed the above, you can run `dotnet test` from the `/test/Microsoft.Azure.ServiceBus.UnitTests` directory.


### PR DESCRIPTION
# Summary

Updated copy to reflect the new location for the Service Bus client library and status of this repository as transitioning to a historical archive.

The contents have been massaged to more closely match the format and voice used for the Service Bus client ReadMe in the central repository, in order to ease the cognitive burden for those navigating over.  An attempt was also made to keep the original introductory content and context.

# Known Issues

- The link for the Event Hubs library is not yet valid, as the initial migration to the central repository is in-process.   _(see: [pull request](https://github.com/Azure/azure-sdk-for-net/pull/5862))_

# Goals 

- Update the ReadMe for the stand-alone Service Bus client repository to reflect the migration to the Azure Developer Platform central repository.

- Provide context for visitors of the repository to understand what the Service Bus client library is, where to find its active development, and to understand the new purpose of the stand-alone repository.

# Non-Goals

- Archive the stand-alone repository;  this will occur as a separate work stream.

# Last Upstream Rebase

Tuesday, April 23, 2019 4:40pm (EDT)

# Related and Follow-Up Issues

- [[Service Bus] Update ReadMe in Standalone Repository](https://github.com/Azure/azure-sdk-for-net/issues/5717) (#5717)
- [Update Repo Structure for ServiceBus](https://github.com/Azure/azure-sdk-for-net/pull/5857) (#5857)
- [[Service Bus Client] Migrate Recent Updates](https://github.com/Azure/azure-sdk-for-net/pull/5915) ( #5915)
- [[Service Bus] .NET Client Library Adoption](https://github.com/Azure/azure-sdk-for-net/pull/5329) (#5329)